### PR TITLE
Internal: fix release part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-      - id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,21 @@ jobs:
         id: pnpm-install
         with:
           version: 7
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
https://github.com/Cambly/syntax/actions/runs/4367246277/jobs/7638308860

```
sh: 1: turbo: not found
 ELIFECYCLE  Command failed.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
    at m._setResult (/home/runner/work/_actions/changesets/action/v1/dist/index.js:136:7258)
    at m.CheckComplete (/home/runner/work/_actions/changesets/action/v1/dist/index.js:136:6686)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/changesets/action/v1/dist/index.js:136:57[23](https://github.com/Cambly/syntax/actions/runs/4367246277/jobs/7638308860#step:5:24))
    at ChildProcess.emit (node:events:5[27](https://github.com/Cambly/syntax/actions/runs/4367246277/jobs/7638308860#step:5:28):[28](https://github.com/Cambly/syntax/actions/runs/4367246277/jobs/7638308860#step:5:29))
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:[30](https://github.com/Cambly/syntax/actions/runs/4367246277/jobs/7638308860#step:5:31)2:5)
```