### PR TITLE
Internal: update gray10, gray30 and gray80 colors

### DIFF
--- a/.changeset/wet-suits-confess.md
+++ b/.changeset/wet-suits-confess.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-design-tokens": minor
+---
+
+Updates gray10, gray30 and gray80 colors

--- a/packages/syntax-design-tokens/tokens/color/base.json
+++ b/packages/syntax-design-tokens/tokens/color/base.json
@@ -12,7 +12,7 @@
       },
       "gray": {
         "10": {
-          "value": "#cbcbcb50",
+          "value": "rgba(203, 203, 203, 0.5)",
           "comment": "Used as the default color for dividers and inner strokes"
         },
         "100": { "value": "#f7f7f7" },
@@ -21,7 +21,7 @@
           "comment": "Used for light mode backgrounds when showing card content on top"
         },
         "30": {
-          "value": "#00000050",
+          "value": "rgba(0, 0, 0, 0.3)",
           "comment": "For IconButton background when on top of an image"
         },
         "300": {
@@ -33,7 +33,7 @@
           "comment": "For secondary text in light mode"
         },
         "80": {
-          "value": "#00000080",
+          "value": "rgba(0, 0, 0, 0.8)",
           "comment": "Used as the background for modals"
         },
         "800": { "value": "#353535" },


### PR DESCRIPTION
Thanks to @somethiiing for spotting this issue - we previously specced `#cbcbcb50` assuming it would be `rgba(203, 203, 203, 0.5)` but instead it was `rgba(203, 203, 203, 0.3)`.

Main issue is that the alpha channel (last 2 characters of the hex) is not the same as the opacity percentage

![image](https://user-images.githubusercontent.com/127199/226756653-8c4d6522-0412-4d6b-b193-67decbcb12bf.png)
