### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,10 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=main
+      - author=camblybot
+      - check-success=Build
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
This change has been made by @christianvuerings from Mergify config editor.

Allows us to automatically merge PRs from `camblybot` if they pass the build