### PR TITLE
Button: fix disabled prop

### DIFF
--- a/.changeset/beige-donuts-allow.md
+++ b/.changeset/beige-donuts-allow.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Button: fix disabled prop

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -100,9 +100,9 @@ const Button = ({
 }): ReactElement => {
   const contextProps = useContext(ButtonGroupContext);
 
-  const size = contextProps?.size ?? sizeProp;
-  const disabled = contextProps?.disabled ?? disabledProp;
-  const fullWidth = contextProps?.fullWidth ?? fullWidthProp;
+  const size = contextProps?.size || sizeProp;
+  const disabled = contextProps?.disabled || disabledProp;
+  const fullWidth = contextProps?.fullWidth || fullWidthProp;
 
   return (
     <button


### PR DESCRIPTION
`contextProps?.disabled` will be `false` by default. And in that case, we would never fall back to the second part `disabledProp`