### PR TITLE
Typography & Heading: add components to Syntax

### DIFF
--- a/.changeset/spicy-eyes-fly.md
+++ b/.changeset/spicy-eyes-fly.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add Typography and Heading components

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
+  "css.lint.validProperties": ["composes"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/syntax-core/src/Avatar/Avatar.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.tsx
@@ -21,7 +21,10 @@ const Avatar = ({
   /**
    * Size of the avatar.
    *
-   * `sm`: 24px, `md`: 40px, `lg`: 72px, `xl`: 128px
+   * * `sm`: 24px
+   * * `md`: 40px
+   * * `lg`: 72px
+   * * `xl`: 128px
    *
    * @defaultValue `md`
    */

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -59,7 +59,9 @@ const Button = ({
   /**
    * The size of the button
    *
-   * `sm`: 32px, `md`: 40px, `lg`: 48px
+   * * `sm`: 32px
+   * * `md`: 40px
+   * * `lg`: 48px
    *
    * @defaultValue "md"
    */

--- a/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
@@ -41,7 +41,9 @@ const ButtonGroup = ({
   /**
    * The size of the button group
    *
-   * `sm`: 32px, `md`: 40px, `lg`: 48px
+   * * `sm`: 32px
+   * * `md`: 40px
+   * * `lg`: 48px
    *
    * @defaultValue "md"
    */

--- a/packages/syntax-core/src/Heading/Heading.stories.tsx
+++ b/packages/syntax-core/src/Heading/Heading.stories.tsx
@@ -20,6 +20,9 @@ export default {
       options: ["h1", "h2", "h3", "h4", "h5", "h6"],
       control: { type: "radio" },
     },
+    children: {
+      control: "text",
+    },
     color: {
       options: [
         "destructive-primary",
@@ -39,7 +42,9 @@ export default {
 } as Meta<typeof Heading>;
 
 export const Default: StoryObj<typeof Heading> = {
-  render: (args) => <Heading {...args}>Default heading</Heading>,
+  render: (args) => (
+    <Heading {...args}>{args.children ?? "Default heading"}</Heading>
+  ),
 };
 
 export const Sizes: StoryObj<typeof Heading> = {

--- a/packages/syntax-core/src/Heading/Heading.stories.tsx
+++ b/packages/syntax-core/src/Heading/Heading.stories.tsx
@@ -1,0 +1,86 @@
+import { StoryObj, Meta } from "@storybook/react";
+import Heading from "./Heading";
+
+export default {
+  title: "Heading",
+  component: Heading,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=4003-11352&t=t9iBh7rbKNhWCMrt-0",
+    },
+  },
+  argTypes: {
+    align: {
+      options: ["start", "center", "end", "forceLeft", "forceRight"],
+      control: { type: "radio" },
+      defaultValue: "start",
+    },
+    as: {
+      options: ["h1", "h2", "h3", "h4", "h5", "h6"],
+      control: { type: "radio" },
+    },
+    color: {
+      options: [
+        "destructive-primary",
+        "gray700",
+        "gray900",
+        "primary",
+        "white",
+      ],
+      control: { type: "radio" },
+    },
+    size: {
+      options: [500, 600, 700, 800],
+      control: { type: "radio" },
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof Heading>;
+
+export const Default: StoryObj<typeof Heading> = {
+  render: (args) => <Heading {...args}>Default heading</Heading>,
+};
+
+export const Sizes: StoryObj<typeof Heading> = {
+  render: (args) => (
+    <>
+      <Heading {...args} size={500}>
+        Size 500
+      </Heading>
+      <Heading {...args} size={600}>
+        Size 600
+      </Heading>
+      <Heading {...args} size={700}>
+        Size 700
+      </Heading>
+      <Heading {...args} size={800}>
+        Size 800
+      </Heading>
+    </>
+  ),
+};
+
+export const Colors: StoryObj<typeof Heading> = {
+  render: (args) => (
+    <>
+      <Heading {...args} color="destructive-primary">
+        Color destructive-primary
+      </Heading>
+      <Heading {...args} color="gray700">
+        Color gray700
+      </Heading>
+      <Heading {...args} color="gray900">
+        Color gray900 (default)
+      </Heading>
+      <Heading {...args} color="primary">
+        Color primary
+      </Heading>
+      <div style={{ backgroundColor: "#000" }}>
+        <Heading {...args} color="white">
+          Color white
+        </Heading>
+      </div>
+    </>
+  ),
+};

--- a/packages/syntax-core/src/Heading/Heading.test.tsx
+++ b/packages/syntax-core/src/Heading/Heading.test.tsx
@@ -1,0 +1,42 @@
+import { screen, render } from "@testing-library/react";
+import Heading from "./Heading";
+import { expect } from "vitest";
+
+describe("heading", () => {
+  it("renders successfully", () => {
+    const { baseElement } = render(<Heading>Test</Heading>);
+    expect(baseElement).toBeTruthy();
+    expect(screen.getByText("Test")).toBeInTheDocument();
+  });
+
+  it("sets the correct HTML tag", () => {
+    render(
+      <>
+        <Heading as="h1">Heading 1</Heading>
+        <Heading as="h2">Heading 2</Heading>
+        <Heading as="h3">Heading 3</Heading>
+        <Heading as="h4">Heading 4</Heading>
+        <Heading as="h5">Heading 5</Heading>
+        <Heading as="h6">Heading 6</Heading>
+      </>,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Heading 1",
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Heading 2",
+    );
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+      "Heading 3",
+    );
+    expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent(
+      "Heading 4",
+    );
+    expect(screen.getByRole("heading", { level: 5 })).toHaveTextContent(
+      "Heading 5",
+    );
+    expect(screen.getByRole("heading", { level: 6 })).toHaveTextContent(
+      "Heading 6",
+    );
+  });
+});

--- a/packages/syntax-core/src/Heading/Heading.tsx
+++ b/packages/syntax-core/src/Heading/Heading.tsx
@@ -1,0 +1,57 @@
+import { ReactElement, ReactNode } from "react";
+import { Color } from "../constants";
+import Typography from "../Typography/Typography";
+/**
+ * Heading enforces a consistent style & accessibility best practices for headings.
+ */
+const Heading = ({
+  align = "start",
+  as = "h1",
+  children,
+  color = "gray900",
+  size = 500,
+}: {
+  /**
+   * Aligns the text to the left, right, or center of the container.
+   * * `start` and `end` will align the text to the left or right of the container depending on the locale.
+   * * `forceLeft` and `forceRight` will align the text to the left or right of the container regardless of the locale (should be used sparingly).
+   *
+   * @defaultValue "start"
+   */
+  align?: "start" | "end" | "forceLeft" | "center" | "forceRight";
+  /**
+   * DOM element to render as.
+   *
+   * @defaultValue "h1"
+   */
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  /**
+   * The text to be rendered
+   */
+  children?: ReactNode;
+  /**
+   * The color of the text.
+   *
+   * @defaultValue "gray900"
+   */
+  color?: (typeof Color)[number];
+  /**
+   * Size of the text.
+   *
+   * * `500`: 20px
+   * * `600`: 28px
+   * * `700`: 40px
+   * * `800`: 64px
+   *
+   * @defaultValue 500
+   */
+  size?: 500 | 600 | 700 | 800;
+}): ReactElement => {
+  return (
+    <Typography align={align} as={as} color={color} size={size} weight="bold">
+      {children}
+    </Typography>
+  );
+};
+
+export default Heading;

--- a/packages/syntax-core/src/Heading/Heading.tsx
+++ b/packages/syntax-core/src/Heading/Heading.tsx
@@ -47,8 +47,9 @@ const Heading = ({
    */
   size?: 500 | 600 | 700 | 800;
 }): ReactElement => {
+  const weight = [700, 800].includes(size) ? "heavy" : "bold";
   return (
-    <Typography align={align} as={as} color={color} size={size} weight="bold">
+    <Typography align={align} as={as} color={color} size={size} weight={weight}>
       {children}
     </Typography>
   );

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -33,7 +33,9 @@ const IconButton = ({
   /**
    * The size of the button
    *
-   * `sm`: 32px, `md`: 40px, `lg`: 48px
+   * * `sm`: 32px
+   * * `md`: 40px
+   * * `lg`: 48px
    *
    * @defaultValue "md"
    */

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -67,6 +67,10 @@
   font-weight: 600;
 }
 
+.heavy {
+  font-weight: 860;
+}
+
 .underline {
   text-decoration: underline;
 }

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -1,0 +1,80 @@
+.typography {
+  font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  margin: 0;
+}
+
+/* Sizes */
+.size100 {
+  font-size: 12px;
+}
+
+.size200 {
+  font-size: 14px;
+}
+
+.size300 {
+  font-size: 16px;
+}
+
+.size500 {
+  font-size: 20px;
+}
+
+.size600 {
+  font-size: 28px;
+}
+
+.size700 {
+  font-size: 40px;
+}
+
+.size800 {
+  font-size: 64px;
+}
+
+/* Align */
+.center {
+  text-align: center;
+}
+
+.forceLeft {
+  text-align: left;
+}
+
+.forceRight {
+  text-align: right;
+}
+
+.start {
+  text-align: start;
+}
+
+.end {
+  text-align: end;
+}
+
+/* Boldness */
+.bold {
+  font-weight: 700;
+}
+
+.regular {
+  font-weight: 400;
+}
+
+.semiBold {
+  font-weight: 600;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.inline {
+  display: inline;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -1,0 +1,143 @@
+import { StoryObj, Meta } from "@storybook/react";
+import Typography from "./Typography";
+
+export default {
+  title: "Typography",
+  component: Typography,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=4003-11352&t=t9iBh7rbKNhWCMrt-0",
+    },
+  },
+  argTypes: {
+    align: {
+      options: ["start", "center", "end", "forceLeft", "forceRight"],
+      control: { type: "radio" },
+      defaultValue: "start",
+    },
+    as: {
+      options: ["div", "h1", "h2", "h3", "h4", "h5", "h6"],
+      control: { type: "radio" },
+    },
+    color: {
+      options: [
+        "destructive-primary",
+        "gray700",
+        "gray900",
+        "primary",
+        "white",
+      ],
+      control: { type: "radio" },
+    },
+    inline: {
+      control: "boolean",
+    },
+    size: {
+      options: [100, 200, 300, 500, 600, 700, 800],
+      control: { type: "radio" },
+    },
+    tooltip: {
+      control: "text",
+    },
+    transform: {
+      options: ["none", "uppercase"],
+      defaultValue: "none",
+    },
+    underline: {
+      control: "boolean",
+    },
+    weight: {
+      options: ["regular", "semiBold", "bold"],
+      control: { type: "radio" },
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof Typography>;
+
+export const Default: StoryObj<typeof Typography> = {
+  render: (args) => <Typography {...args}>Default text</Typography>,
+};
+
+export const Sizes: StoryObj<typeof Typography> = {
+  render: (args) => (
+    <>
+      <Typography {...args} size={100}>
+        Size 100
+      </Typography>
+      <Typography {...args} size={200}>
+        Size 200 (default)
+      </Typography>
+      <Typography {...args} size={300}>
+        Size 300
+      </Typography>
+      <Typography {...args} size={500} weight="bold">
+        Size 500 Bold
+      </Typography>
+      <Typography {...args} size={600} weight="bold">
+        Size 600 Bold
+      </Typography>
+      <Typography {...args} size={700} weight="bold">
+        Size 700 Bold
+      </Typography>
+      <Typography {...args} size={800} weight="bold">
+        Size 800 Bold
+      </Typography>
+    </>
+  ),
+};
+
+export const Colors: StoryObj<typeof Typography> = {
+  render: (args) => (
+    <>
+      <Typography {...args} color="destructive-primary">
+        Color destructive-primary
+      </Typography>
+      <Typography {...args} color="gray700">
+        Color gray700
+      </Typography>
+      <Typography {...args} color="gray900">
+        Color gray900 (default)
+      </Typography>
+      <Typography {...args} color="primary">
+        Color primary
+      </Typography>
+      <div style={{ backgroundColor: "#000" }}>
+        <Typography {...args} color="white">
+          Color white
+        </Typography>
+      </div>
+    </>
+  ),
+};
+
+export const Inline: StoryObj<typeof Typography> = {
+  render: (args) => (
+    <>
+      <Typography {...args}>Block (default)</Typography>
+      <Typography {...args}>Block</Typography>
+      <Typography {...args} inline>
+        Inline
+      </Typography>{" "}
+      <Typography {...args} inline>
+        Inline
+      </Typography>
+    </>
+  ),
+};
+
+export const Uppercase: StoryObj<typeof Typography> = {
+  render: (args) => (
+    <Typography {...args} transform="uppercase">
+      Uppercase
+    </Typography>
+  ),
+};
+
+export const Underline: StoryObj<typeof Typography> = {
+  render: (args) => (
+    <Typography {...args} underline>
+      Underlined
+    </Typography>
+  ),
+};

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -48,7 +48,7 @@ export default {
       control: "boolean",
     },
     weight: {
-      options: ["regular", "semiBold", "bold"],
+      options: ["regular", "semiBold", "bold", "heavy"],
       control: { type: "radio" },
     },
   },
@@ -77,11 +77,11 @@ export const Sizes: StoryObj<typeof Typography> = {
       <Typography {...args} size={600} weight="bold">
         Size 600 Bold
       </Typography>
-      <Typography {...args} size={700} weight="bold">
-        Size 700 Bold
+      <Typography {...args} size={700} weight="heavy">
+        Size 700 Heavy
       </Typography>
-      <Typography {...args} size={800} weight="bold">
-        Size 800 Bold
+      <Typography {...args} size={800} weight="heavy">
+        Size 800 Heavy
       </Typography>
     </>
   ),

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -30,6 +30,9 @@ export default {
       ],
       control: { type: "radio" },
     },
+    children: {
+      control: "text",
+    },
     inline: {
       control: "boolean",
     },
@@ -56,7 +59,9 @@ export default {
 } as Meta<typeof Typography>;
 
 export const Default: StoryObj<typeof Typography> = {
-  render: (args) => <Typography {...args}>Default text</Typography>,
+  render: (args) => (
+    <Typography {...args}>{args.children ?? "Default text"}</Typography>
+  ),
 };
 
 export const Sizes: StoryObj<typeof Typography> = {

--- a/packages/syntax-core/src/Typography/Typography.test.tsx
+++ b/packages/syntax-core/src/Typography/Typography.test.tsx
@@ -1,0 +1,42 @@
+import { screen, render } from "@testing-library/react";
+import Typography from "./Typography";
+import { expect } from "vitest";
+
+describe("typography", () => {
+  it("renders successfully", () => {
+    const { baseElement } = render(<Typography>Test</Typography>);
+    expect(baseElement).toBeTruthy();
+    expect(screen.getByText("Test")).toBeInTheDocument();
+  });
+
+  it("sets the correct HTML tag", () => {
+    render(
+      <>
+        <Typography as="h1">Heading 1</Typography>
+        <Typography as="h2">Heading 2</Typography>
+        <Typography as="h3">Heading 3</Typography>
+        <Typography as="h4">Heading 4</Typography>
+        <Typography as="h5">Heading 5</Typography>
+        <Typography as="h6">Heading 6</Typography>
+      </>,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Heading 1",
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Heading 2",
+    );
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+      "Heading 3",
+    );
+    expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent(
+      "Heading 4",
+    );
+    expect(screen.getByRole("heading", { level: 5 })).toHaveTextContent(
+      "Heading 5",
+    );
+    expect(screen.getByRole("heading", { level: 6 })).toHaveTextContent(
+      "Heading 6",
+    );
+  });
+});

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -101,7 +101,7 @@ const Typography = ({
    *
    * @defaultValue "regular"
    */
-  weight?: "regular" | "semiBold" | "bold";
+  weight?: "regular" | "semiBold" | "bold" | "heavy";
 }): ReactElement => {
   const Tag = as;
 

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -1,0 +1,127 @@
+import classNames from "classnames";
+import { ReactElement, ReactNode } from "react";
+import { Color } from "../constants";
+import styles from "./Typography.module.css";
+import colorStyles from "../colors/colors.module.css";
+
+function textColor(color: (typeof Color)[number]): string {
+  switch (color) {
+    case "gray700":
+      return colorStyles.gray700Color;
+    case "white":
+      return colorStyles.whiteColor;
+    case "inherit":
+      return colorStyles.inheritColor;
+    case "primary":
+      return colorStyles.primary700Color;
+    case "destructive-primary":
+      return colorStyles.destructive700Color;
+    default:
+      return colorStyles.gray900Color;
+  }
+}
+
+/**
+ * Typography is a component that renders text.
+ */
+const Typography = ({
+  align = "start",
+  as = "div",
+  children,
+  color = "gray900",
+  inline = false,
+  size = 200,
+  tooltip,
+  transform = "none",
+  underline = false,
+  weight = "regular",
+}: {
+  /**
+   * Aligns the text to the left, right, or center of the container.
+   * * `start` and `end` will align the text to the left or right of the container depending on the locale.
+   * * `forceLeft` and `forceRight` will align the text to the left or right of the container regardless of the locale (should be used sparingly).
+   *
+   * @defaultValue "start"
+   */
+  align?: "start" | "end" | "forceLeft" | "center" | "forceRight";
+  /**
+   * DOM element to render as.
+   *
+   * @defaultValue "div"
+   */
+  as?: "div" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  /**
+   * The text to be rendered
+   */
+  children?: ReactNode;
+  /**
+   * The color of the text.
+   *
+   * @defaultValue "primary"
+   */
+  color?: (typeof Color)[number];
+  /**
+   * Whether the text should flow inline with other elements.
+   *
+   * @defaultValue false
+   */
+  inline?: boolean;
+  /**
+   * Size of the text.
+   *
+   * * `100`: 12px
+   * * `200`: 14px
+   * * `300`: 16px
+   * * `500`: 20px
+   * * `600`: 28px
+   * * `700`: 40px
+   * * `800`: 64px
+   *
+   * @defaultValue 200
+   */
+  size?: 100 | 200 | 300 | 500 | 600 | 700 | 800;
+  /**
+   * The tooltip to be displayed when the user hovers the text
+   */
+  tooltip?: string;
+  /**
+   * Whether the text should be transformed to uppercase.
+   *
+   * @defaultValue "none"
+   */
+  transform?: "none" | "uppercase";
+  /**
+   * Whether the text has an underline.
+   *
+   * @defaultValue false
+   */
+  underline?: boolean;
+  /**
+   * Indicates the boldness of the text.
+   *
+   * @defaultValue "regular"
+   */
+  weight?: "regular" | "semiBold" | "bold";
+}): ReactElement => {
+  const Tag = as;
+
+  return (
+    <Tag
+      className={classNames(
+        styles.typography,
+        styles[align],
+        styles[weight],
+        textColor(color),
+        inline && styles.inline,
+        styles[`size${size}`],
+        transform === "uppercase" && styles.uppercase,
+        underline && styles.underline,
+      )}
+      title={tooltip}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+export default Typography;

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -57,7 +57,7 @@ const Typography = ({
   /**
    * The color of the text.
    *
-   * @defaultValue "primary"
+   * @defaultValue "gray900"
    */
   color?: (typeof Color)[number];
   /**

--- a/packages/syntax-core/src/colors/colors.module.css
+++ b/packages/syntax-core/src/colors/colors.module.css
@@ -7,12 +7,20 @@
   color: var(--color-base-destructive-700);
 }
 
+.gray700Color {
+  color: var(--color-base-gray-700);
+}
+
 .gray900Color {
   color: var(--color-base-gray-900);
 }
 
 .whiteColor {
   color: var(--color-base-white);
+}
+
+.inheritColor {
+  color: inherit;
 }
 
 /* Background Colors */


### PR DESCRIPTION
# Changes

* Adds `Typography` and `Heading` components to Syntax

# FAQ

## What is the `Heading` component for?

Heading enforces a consistent style & accessibility best practices for headings.

## `Typography` is quite different from what we do in `Cambly-Frontend`, why is that?

* Sizes now go from small (100) to big (800) - previously the smallest size was `body300` which didn't make a lot of sense
* We now see `Typography` is the root component for all text to be rendered on Cambly. It allows for custom components such as `Heading` and has more flexibility built-in.

# Screenshots

## Typography

![typography-overview](https://user-images.githubusercontent.com/127199/227607473-a15b4434-c169-4834-bb2f-1b51bc52430c.png)

## Heading

![heading-overview](https://user-images.githubusercontent.com/127199/227607497-0e409257-6339-48b2-8707-ea025a069358.png)
