### PR TITLE
Make lint and test job dependent on the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - run: cd packages/syntax-design-tokens && pnpm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
       - run: pnpm run lint
         env:
           NODE_OPTIONS: --max-old-space-size=8192
@@ -55,6 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - run: cd packages/syntax-design-tokens && pnpm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
       - run: pnpm run test
         env:
           NODE_OPTIONS: --max-old-space-size=8192


### PR DESCRIPTION
Fixes an issue with https://github.com/Cambly/syntax/pull/73 where we added a dependency on `@cambly/syntax-design-tokens/dist` without it being built