### PR TITLE
Internal: upgrade TypeScript to v5 & fix issue with "composes" in TypeScript plugin

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -36,7 +36,7 @@
     "storybook": "^7.0.0-beta.62",
     "storybook-addon-designs": "7.0.0-beta.2",
     "storybook-dark-mode": "^2.1.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.0.3",
     "vite": "^4.1.4"
   }
 }

--- a/packages/syntax-core/package.json
+++ b/packages/syntax-core/package.json
@@ -32,8 +32,8 @@
     "postcss": "^8.4.21",
     "postcss-modules": "^6.0.0",
     "react": "^18.2.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "6.7.0",
+    "typescript": "5.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/syntax-tsconfig/package.json
+++ b/packages/syntax-tsconfig/package.json
@@ -7,6 +7,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript-plugin-css-modules": "4.2.2"
+    "typescript-plugin-css-modules": "5.0.0"
   }
 }

--- a/packages/syntax-utils/package.json
+++ b/packages/syntax-utils/package.json
@@ -23,8 +23,8 @@
     "bundle-require": "^4.0.1",
     "eslint": "^8.35.0",
     "react": "^18.2.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "6.7.0",
+    "typescript": "5.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
       storybook: ^7.0.0-beta.62
       storybook-addon-designs: 7.0.0-beta.2
       storybook-dark-mode: ^2.1.1
-      typescript: ^4.9.5
+      typescript: 5.0.3
       vite: ^4.1.4
     dependencies:
       '@cambly/syntax-core': link:../../packages/syntax-core
@@ -81,16 +81,16 @@ importers:
       '@storybook/addon-essentials': 7.0.0-beta.62_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-links': 7.0.0-beta.62_biqbaboplfbrettd7655fr4n2y
       '@storybook/addons': 7.0.0-beta.62_biqbaboplfbrettd7655fr4n2y
-      '@storybook/react': 7.0.0-beta.62_ygqkwb4gg3aean7xjfdauovyqq
-      '@storybook/react-vite': 7.0.0-beta.62_ndsstb2ob2rgr4m75wxvpqsrpi
+      '@storybook/react': 7.0.0-beta.62_uhtpkmw4islv4eik2krbyemjmy
+      '@storybook/react-vite': 7.0.0-beta.62_xil2vwcnalsckangcy2jpgys5a
       '@storybook/theming': 7.0.0-beta.62_biqbaboplfbrettd7655fr4n2y
       '@vitejs/plugin-react': 3.1.0_vite@4.1.4
-      react-docgen-typescript: 2.2.2_typescript@4.9.5
+      react-docgen-typescript: 2.2.2_typescript@5.0.3
       serve: 14.2.0
       storybook: 7.0.0-beta.62
       storybook-addon-designs: 7.0.0-beta.2_4vj6zlpzwqclstcooof5hn6nce
       storybook-dark-mode: 2.1.1_biqbaboplfbrettd7655fr4n2y
-      typescript: 4.9.5
+      typescript: 5.0.3
       vite: 4.1.4
 
   packages/eslint-config-syntax:
@@ -104,15 +104,15 @@ importers:
       eslint-plugin-testing-library: ^5.10.2
       eslint-plugin-vitest: ^0.0.54
     dependencies:
-      eslint-config-next: 13.2.4_ycpbpc6yetojsgtrx3mwntkhsu
+      eslint-config-next: 13.2.4_hm2lnsmqyh3w2437rbu5kd45la
       eslint-config-prettier: 8.7.0_eslint@8.35.0
       eslint-config-turbo: 1.8.8_eslint@8.35.0
       eslint-plugin-react: 7.32.1_eslint@8.35.0
     devDependencies:
       '@cambly/syntax-tsconfig': link:../syntax-tsconfig
-      '@typescript-eslint/eslint-plugin': 5.54.1_mlk7dnz565t663n4razh6a6v6i
-      eslint-plugin-testing-library: 5.10.2_ycpbpc6yetojsgtrx3mwntkhsu
-      eslint-plugin-vitest: 0.0.54_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/eslint-plugin': 5.54.1_65sy3ptfeu2nwstjmwf7b2d754
+      eslint-plugin-testing-library: 5.10.2_hm2lnsmqyh3w2437rbu5kd45la
+      eslint-plugin-vitest: 0.0.54_hm2lnsmqyh3w2437rbu5kd45la
 
   packages/syntax-core:
     specifiers:
@@ -126,8 +126,8 @@ importers:
       postcss: ^8.4.21
       postcss-modules: ^6.0.0
       react: ^18.2.0
-      tsup: ^6.6.3
-      typescript: ^4.9.5
+      tsup: 6.7.0
+      typescript: 5.0.3
     dependencies:
       '@cambly/syntax-design-tokens': link:../syntax-design-tokens
     devDependencies:
@@ -140,8 +140,8 @@ importers:
       postcss: 8.4.21
       postcss-modules: 6.0.0_postcss@8.4.21
       react: 18.2.0
-      tsup: 6.6.3_uujdqti2krmttzhqvubwnsmcci
-      typescript: 4.9.5
+      tsup: 6.7.0_5kvjel2vjuwdvsrdtvsoziwvpe
+      typescript: 5.0.3
 
   packages/syntax-design-tokens:
     specifiers:
@@ -153,9 +153,9 @@ importers:
 
   packages/syntax-tsconfig:
     specifiers:
-      typescript-plugin-css-modules: 4.2.2
+      typescript-plugin-css-modules: 5.0.0
     devDependencies:
-      typescript-plugin-css-modules: 4.2.2_typescript@4.9.5
+      typescript-plugin-css-modules: 5.0.0_typescript@5.0.3
 
   packages/syntax-utils:
     specifiers:
@@ -166,8 +166,8 @@ importers:
       bundle-require: ^4.0.1
       eslint: ^8.35.0
       react: ^18.2.0
-      tsup: ^6.6.3
-      typescript: ^4.9.5
+      tsup: 6.7.0
+      typescript: 5.0.3
     devDependencies:
       '@cambly/eslint-config-syntax': link:../eslint-config-syntax
       '@cambly/syntax-tsconfig': link:../syntax-tsconfig
@@ -176,8 +176,8 @@ importers:
       bundle-require: 4.0.1_esbuild@0.17.11
       eslint: 8.35.0
       react: 18.2.0
-      tsup: 6.6.3_typescript@4.9.5
-      typescript: 4.9.5
+      tsup: 6.7.0_typescript@5.0.3
+      typescript: 5.0.3
 
 packages:
 
@@ -2346,7 +2346,7 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@joshwooding/vite-plugin-react-docgen-typescript/0.2.1_vwvfc4ezh6jlf6pa67auy3eulu:
+  /@joshwooding/vite-plugin-react-docgen-typescript/0.2.1_yhyffzgvoxucxqljq5bs5sxkma:
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -2358,8 +2358,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2_glob@7.2.3
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2_typescript@4.9.5
-      typescript: 4.9.5
+      react-docgen-typescript: 2.2.2_typescript@5.0.3
+      typescript: 5.0.3
       vite: 4.1.4
     dev: true
 
@@ -3098,7 +3098,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite/7.0.0-beta.62_vwvfc4ezh6jlf6pa67auy3eulu:
+  /@storybook/builder-vite/7.0.0-beta.62_yhyffzgvoxucxqljq5bs5sxkma:
     resolution: {integrity: sha512-G4vl9/TkpgcJp1MNaDqvflfTWIeLHO5UD5hCs/2vT03CQYCvJheKIfQQfyMYY5JunDUX4j1aYi73xxZCBgBMeA==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -3135,7 +3135,7 @@ packages:
       magic-string: 0.27.0
       rollup: 3.18.0
       slash: 3.0.0
-      typescript: 4.9.5
+      typescript: 5.0.3
       vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -3528,7 +3528,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: true
 
-  /@storybook/react-vite/7.0.0-beta.62_ndsstb2ob2rgr4m75wxvpqsrpi:
+  /@storybook/react-vite/7.0.0-beta.62_xil2vwcnalsckangcy2jpgys5a:
     resolution: {integrity: sha512-TEhcODciEX0t8Q7EFhdEGXAQT/fhiYKnPtlPRdKsk4ZleRU9DQNf411zUu2FD7BowTYhyMRHjBh0DCavxJ/sKw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3536,10 +3536,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1_vwvfc4ezh6jlf6pa67auy3eulu
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1_yhyffzgvoxucxqljq5bs5sxkma
       '@rollup/pluginutils': 4.2.1
-      '@storybook/builder-vite': 7.0.0-beta.62_vwvfc4ezh6jlf6pa67auy3eulu
-      '@storybook/react': 7.0.0-beta.62_ygqkwb4gg3aean7xjfdauovyqq
+      '@storybook/builder-vite': 7.0.0-beta.62_yhyffzgvoxucxqljq5bs5sxkma
+      '@storybook/react': 7.0.0-beta.62_uhtpkmw4islv4eik2krbyemjmy
       '@vitejs/plugin-react': 3.1.0_vite@4.1.4
       ast-types: 0.14.2
       magic-string: 0.27.0
@@ -3555,7 +3555,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react/7.0.0-beta.62_ygqkwb4gg3aean7xjfdauovyqq:
+  /@storybook/react/7.0.0-beta.62_uhtpkmw4islv4eik2krbyemjmy:
     resolution: {integrity: sha512-JWRomk5ajaA9jhEeiYCM0lmDwWqrG9ctNmijaQTJ7o9USBchdqDqyAje9P8NBMyGybwi1ab1/Ql4GlMAam1Rog==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -3588,7 +3588,7 @@ packages:
       react-element-to-jsx-string: 15.0.0_biqbaboplfbrettd7655fr4n2y
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 4.9.5
+      typescript: 5.0.3
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4060,7 +4060,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.54.1_mlk7dnz565t663n4razh6a6v6i:
+  /@typescript-eslint/eslint-plugin/5.54.1_65sy3ptfeu2nwstjmwf7b2d754:
     resolution: {integrity: sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4071,10 +4071,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/parser': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       '@typescript-eslint/scope-manager': 5.54.1
-      '@typescript-eslint/type-utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
-      '@typescript-eslint/utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/type-utils': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
+      '@typescript-eslint/utils': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       debug: 4.3.4
       eslint: 8.35.0
       grapheme-splitter: 1.0.4
@@ -4082,13 +4082,13 @@ packages:
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.0.3
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.54.1_ycpbpc6yetojsgtrx3mwntkhsu:
+  /@typescript-eslint/parser/5.54.1_hm2lnsmqyh3w2437rbu5kd45la:
     resolution: {integrity: sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4100,10 +4100,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.54.1
       '@typescript-eslint/types': 5.54.1
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.3
       debug: 4.3.4
       eslint: 8.35.0
-      typescript: 4.9.5
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4114,7 +4114,7 @@ packages:
       '@typescript-eslint/types': 5.54.1
       '@typescript-eslint/visitor-keys': 5.54.1
 
-  /@typescript-eslint/type-utils/5.54.1_ycpbpc6yetojsgtrx3mwntkhsu:
+  /@typescript-eslint/type-utils/5.54.1_hm2lnsmqyh3w2437rbu5kd45la:
     resolution: {integrity: sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4124,12 +4124,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
-      '@typescript-eslint/utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.3
+      '@typescript-eslint/utils': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       debug: 4.3.4
       eslint: 8.35.0
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.0.3
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4138,7 +4138,7 @@ packages:
     resolution: {integrity: sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /@typescript-eslint/typescript-estree/5.54.1_typescript@4.9.5:
+  /@typescript-eslint/typescript-estree/5.54.1_typescript@5.0.3:
     resolution: {integrity: sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4153,12 +4153,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.0.3
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.54.1_ycpbpc6yetojsgtrx3mwntkhsu:
+  /@typescript-eslint/utils/5.54.1_hm2lnsmqyh3w2437rbu5kd45la:
     resolution: {integrity: sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4168,7 +4168,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.54.1
       '@typescript-eslint/types': 5.54.1
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.3
       eslint: 8.35.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.35.0
@@ -5912,7 +5912,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next/13.2.4_ycpbpc6yetojsgtrx3mwntkhsu:
+  /eslint-config-next/13.2.4_hm2lnsmqyh3w2437rbu5kd45la:
     resolution: {integrity: sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -5923,7 +5923,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.2.4
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/parser': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.3_yckic57kx266ph64dhq6ozvb54
@@ -5931,7 +5931,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1_eslint@8.35.0
       eslint-plugin-react: 7.32.1_eslint@8.35.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.35.0
-      typescript: 4.9.5
+      typescript: 5.0.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -6006,7 +6006,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/parser': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       debug: 3.2.7
       eslint: 8.35.0
       eslint-import-resolver-node: 0.3.7
@@ -6024,7 +6024,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/parser': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -6105,13 +6105,13 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: false
 
-  /eslint-plugin-testing-library/5.10.2_ycpbpc6yetojsgtrx3mwntkhsu:
+  /eslint-plugin-testing-library/5.10.2_hm2lnsmqyh3w2437rbu5kd45la:
     resolution: {integrity: sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/utils': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       eslint: 8.35.0
     transitivePeerDependencies:
       - supports-color
@@ -6126,13 +6126,13 @@ packages:
       eslint: 8.35.0
     dev: false
 
-  /eslint-plugin-vitest/0.0.54_ycpbpc6yetojsgtrx3mwntkhsu:
+  /eslint-plugin-vitest/0.0.54_hm2lnsmqyh3w2437rbu5kd45la:
     resolution: {integrity: sha512-6ZR52LJ2pNe3aVaWkDBR7Cg8FlpEe9XDWnvtHU0kbl01IgijPRL3tVSfjiBSfpYUF8kzC0W9XjhzHttElOsXiQ==}
     engines: {node: 14.x || >= 16}
     peerDependencies:
       eslint: '>=8.0.0'
     dependencies:
-      '@typescript-eslint/utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/utils': 5.54.1_hm2lnsmqyh3w2437rbu5kd45la
       eslint: 8.35.0
     transitivePeerDependencies:
       - supports-color
@@ -9084,12 +9084,12 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: true
 
-  /react-docgen-typescript/2.2.2_typescript@4.9.5:
+  /react-docgen-typescript/2.2.2_typescript@5.0.3:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.0.3
     dev: true
 
   /react-docgen/6.0.0-alpha.3:
@@ -10464,50 +10464,14 @@ packages:
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsup/6.6.3_typescript@4.9.5:
-    resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
+  /tsup/6.7.0_5kvjel2vjuwdvsrdtvsoziwvpe:
+    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
     peerDependencies:
       '@swc/core': ^1
       postcss: ^8.4.12
-      typescript: ^4.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1_esbuild@0.17.11
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.17.11
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4
-      resolve-from: 5.0.0
-      rollup: 3.18.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.29.0
-      tree-kill: 1.2.2
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
-  /tsup/6.6.3_uujdqti2krmttzhqvubwnsmcci:
-    resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: ^4.1.0
+      typescript: '>=4.1.0'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -10531,20 +10495,56 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.29.0
       tree-kill: 1.2.2
-      typescript: 4.9.5
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils/3.21.0_typescript@4.9.5:
+  /tsup/6.7.0_typescript@5.0.3:
+    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.1_esbuild@0.17.11
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.17.11
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 3.1.4
+      resolve-from: 5.0.0
+      rollup: 3.18.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.29.0
+      tree-kill: 1.2.2
+      typescript: 5.0.3
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /tsutils/3.21.0_typescript@5.0.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.0.3
 
   /tty-table/4.1.6:
     resolution: {integrity: sha512-kRj5CBzOrakV4VRRY5kUWbNYvo/FpOsz65DzI5op9P+cHov3+IqPbo1JE1ZnQGkHdZgNFDsrEjrfqqy/Ply9fw==}
@@ -10692,10 +10692,10 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript-plugin-css-modules/4.2.2_typescript@4.9.5:
-    resolution: {integrity: sha512-X5OYGkX96ENq2c7xFJO4tgtiMTlBkOMoRmVHQXH2H4CGFcVODKGieDqPU2B0IV0I+AyvKYDFdKh4ZKtKxAcAww==}
+  /typescript-plugin-css-modules/5.0.0_typescript@5.0.3:
+    resolution: {integrity: sha512-fWqguBTVLnV9Xto3maYByUt4rfJdmZ5Z66TQ6jOHpIiU/RPDf/DCCtJPNYyWLQflrbimSawag8zE6EmrkYmuZQ==}
     peerDependencies:
-      typescript: '>=3.9.0'
+      typescript: '>=4.0.0'
     dependencies:
       '@types/postcss-modules-local-by-default': 4.0.0
       '@types/postcss-modules-scope': 3.0.1
@@ -10705,6 +10705,7 @@ packages:
       lodash.camelcase: 4.3.0
       postcss: 8.4.21
       postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-modules-extract-imports: 3.0.0_postcss@8.4.21
       postcss-modules-local-by-default: 4.0.0_postcss@8.4.21
       postcss-modules-scope: 3.0.0_postcss@8.4.21
       reserved-words: 0.1.2
@@ -10712,15 +10713,15 @@ packages:
       source-map-js: 1.0.2
       stylus: 0.59.0
       tsconfig-paths: 4.1.2
-      typescript: 4.9.5
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.0.3:
+    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
+    engines: {node: '>=12.20'}
     hasBin: true
 
   /ufo/1.1.1:


### PR DESCRIPTION
# Context

@nathan-ong  and @emmanuelgamboa09 noticed that using `composes` broke the `typescript-plugin-css-modules` plugin.

# Changes

* Upgrade `typescript-plugin-css-modules` and TypeScript since that fixes the composes issue: https://github.com/mrmckeb/typescript-plugin-css-modules/issues/207

# Notes

* Also had to upgrade `tsup` which added TS v5 support at https://github.com/egoist/tsup/releases/tag/v6.7.0