### PR TITLE
Box: no longer use composes in media queries

### DIFF
--- a/.changeset/hungry-hairs-wonder.md
+++ b/.changeset/hungry-hairs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Fix box mediaquery props

--- a/packages/syntax-core/src/Box/Box.module.css
+++ b/packages/syntax-core/src/Box/Box.module.css
@@ -30,46 +30,46 @@
 /* Align items (small and up) */
 @media (min-width: 480px) {
   .alignItemscenterSmall {
-    composes: alignItemscenter;
+    align-items: center;
   }
 
   .alignItemsstartSmall {
-    composes: alignItemsstart;
+    align-items: flex-start;
   }
 
   .alignItemsendSmall {
-    composes: alignItemsend;
+    align-items: flex-end;
   }
 
   .alignItemsstretchSmall {
-    composes: alignItemsstretch;
+    align-items: stretch;
   }
 
   .alignItemsbaselineSmall {
-    composes: alignItemsbaseline;
+    align-items: baseline;
   }
 }
 
 /* Align items (large and up) */
 @media (min-width: 960px) {
   .alignItemscenterLarge {
-    composes: alignItemscenter;
+    align-items: center;
   }
 
   .alignItemsstartLarge {
-    composes: alignItemsstart;
+    align-items: flex-start;
   }
 
   .alignItemsendLarge {
-    composes: alignItemsend;
+    align-items: flex-end;
   }
 
   .alignItemsstretchLarge {
-    composes: alignItemsstretch;
+    align-items: stretch;
   }
 
   .alignItemsbaselineLarge {
-    composes: alignItemsbaseline;
+    align-items: baseline;
   }
 }
 
@@ -132,6 +132,10 @@
   display: inline-block;
 }
 
+.none {
+  display: none;
+}
+
 .visuallyHidden {
   position: absolute;
   width: 1px;
@@ -147,38 +151,62 @@
 /* Display (small and up) */
 @media (min-width: 480px) {
   .blockSmall {
-    composes: block;
+    display: block;
   }
 
   .flexSmall {
-    composes: flex;
+    display: flex;
   }
 
   .inlineBlockSmall {
-    composes: inlineBlock;
+    display: inline-block;
+  }
+
+  .noneSmall {
+    display: none;
   }
 
   .visuallyHiddenSmall {
-    composes: visuallyHidden;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin-bottom: -1px;
+    border: 0;
+    padding-left: 0;
+    padding-right: 0;
+    clip: rect(0 0 0 0);
+    overflow: hidden;
   }
 }
 
 /* Display (large and up) */
 @media (min-width: 960px) {
   .blockLarge {
-    composes: block;
+    display: block;
   }
 
   .flexLarge {
-    composes: flex;
+    display: flex;
   }
 
   .inlineBlockLarge {
-    composes: inlineBlock;
+    display: inline-block;
+  }
+
+  .noneLarge {
+    display: none;
   }
 
   .visuallyHiddenLarge {
-    composes: visuallyHidden;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin-bottom: -1px;
+    border: 0;
+    padding-left: 0;
+    padding-right: 0;
+    clip: rect(0 0 0 0);
+    overflow: hidden;
   }
 }
 
@@ -194,22 +222,22 @@
 /* Direction (small and up) */
 @media (min-width: 480px) {
   .columnSmall {
-    composes: column;
+    flex-direction: column;
   }
 
   .rowSmall {
-    composes: row;
+    flex-direction: row;
   }
 }
 
 /* Direction (large and up) */
 @media (min-width: 960px) {
   .columnLarge {
-    composes: column;
+    flex-direction: column;
   }
 
   .rowLarge {
-    composes: row;
+    flex-direction: row;
   }
 }
 
@@ -294,54 +322,54 @@
 /* Justify content (small and up) */
 @media (min-width: 480px) {
   .justifyContentcenterSmall {
-    composes: justifyContentcenter;
+    justify-content: center;
   }
 
   .justifyContentstartSmall {
-    composes: justifyContentstart;
+    justify-content: flex-start;
   }
 
   .justifyContentendSmall {
-    composes: justifyContentend;
+    justify-content: flex-end;
   }
 
   .justifyContentbetweenSmall {
-    composes: justifyContentbetween;
+    justify-content: space-between;
   }
 
   .justifyContentaroundSmall {
-    composes: justifyContentaround;
+    justify-content: space-around;
   }
 
   .justifyContentevenlySmall {
-    composes: justifyContentevenly;
+    justify-content: space-evenly;
   }
 }
 
 /* Justify content (large and up) */
 @media (min-width: 960px) {
   .justifyContentcenterLarge {
-    composes: justifyContentcenter;
+    justify-content: center;
   }
 
   .justifyContentstartLarge {
-    composes: justifyContentstart;
+    justify-content: flex-start;
   }
 
   .justifyContentendLarge {
-    composes: justifyContentend;
+    justify-content: flex-end;
   }
 
   .justifyContentbetweenLarge {
-    composes: justifyContentbetween;
+    justify-content: space-between;
   }
 
   .justifyContentaroundLarge {
-    composes: justifyContentaround;
+    justify-content: space-around;
   }
 
   .justifyContentevenlyLarge {
-    composes: justifyContentevenly;
+    justify-content: space-evenly;
   }
 }
 

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -250,6 +250,23 @@ export const Padding: StoryObj<typeof Box> = {
   ),
 };
 
+export const Responsive: StoryObj<typeof Box> = {
+  render: () => (
+    <>
+      <Box padding={2}>
+        <Typography>Box visible on every screen width</Typography>
+      </Box>
+      <Box padding={2} display="none" smDisplay="block">
+        <Typography>Box visible on small screens (480px) and up</Typography>
+      </Box>
+
+      <Box padding={2} display="none" lgDisplay="block">
+        <Typography>Box visible on small screens (960px) and up</Typography>
+      </Box>
+    </>
+  ),
+};
+
 export const Rounding: StoryObj<typeof Box> = {
   render: () => (
     <Box display="flex" gap={4} flexWrap="wrap">

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -23,7 +23,7 @@ type As =
   | "summary";
 type Dimension = number | string;
 type Direction = "row" | "column";
-type Display = "flex" | "block" | "inlineBlock" | "visuallyHidden";
+type Display = "none" | "flex" | "block" | "inlineBlock" | "visuallyHidden";
 type Gap = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 type JustifyContent =
   | "start"
@@ -434,47 +434,69 @@ export default function Box(props: {
       smDisplay && styles[`${smDisplay}Small`],
       lgDisplay && styles[`${lgDisplay}Large`],
       flexWrap && styles.flexWrap,
-      gap && styles[`gap${gap}`],
-      margin && !marginBottom && marginStyles[`marginBottom${margin}`],
-      margin && !marginEnd && marginStyles[`marginEnd${margin}`],
-      margin && !marginStart && marginStyles[`marginStart${margin}`],
-      margin && !marginTop && marginStyles[`marginTop${margin}`],
-      marginBottom && marginStyles[`marginBottom${marginBottom}`],
-      marginEnd && marginStyles[`marginEnd${marginEnd}`],
-      marginStart && marginStyles[`marginStart${marginStart}`],
-      marginTop && marginStyles[`marginTop${marginTop}`],
-      smMargin &&
+      gap != null && styles[`gap${gap}`],
+      margin != null && !marginBottom && marginStyles[`marginBottom${margin}`],
+      margin != null && !marginEnd && marginStyles[`marginEnd${margin}`],
+      margin != null && !marginStart && marginStyles[`marginStart${margin}`],
+      margin != null && !marginTop && marginStyles[`marginTop${margin}`],
+      marginBottom != null && marginStyles[`marginBottom${marginBottom}`],
+      marginEnd != null && marginStyles[`marginEnd${marginEnd}`],
+      marginStart != null && marginStyles[`marginStart${marginStart}`],
+      marginTop != null && marginStyles[`marginTop${marginTop}`],
+      smMargin != null &&
         !smMarginBottom &&
         marginStyles[`marginBottom${smMargin}Small`],
-      smMargin && !smMarginEnd && marginStyles[`marginEnd${smMargin}Small`],
-      smMargin && !smMarginStart && marginStyles[`marginStart${smMargin}Small`],
-      smMargin && !smMarginTop && marginStyles[`marginTop${smMargin}Small`],
-      smMarginBottom && marginStyles[`marginBottom${smMarginBottom}Small`],
-      smMarginEnd && marginStyles[`marginEnd${smMarginEnd}Small`],
-      smMarginStart && marginStyles[`marginStart${smMarginStart}Small`],
-      smMarginTop && marginStyles[`marginTop${smMarginTop}Small`],
-      lgMargin &&
+      smMargin != null &&
+        !smMarginEnd &&
+        marginStyles[`marginEnd${smMargin}Small`],
+      smMargin != null &&
+        !smMarginStart &&
+        marginStyles[`marginStart${smMargin}Small`],
+      smMargin != null &&
+        !smMarginTop &&
+        marginStyles[`marginTop${smMargin}Small`],
+      smMarginBottom != null &&
+        marginStyles[`marginBottom${smMarginBottom}Small`],
+      smMarginEnd != null && marginStyles[`marginEnd${smMarginEnd}Small`],
+      smMarginStart != null && marginStyles[`marginStart${smMarginStart}Small`],
+      smMarginTop != null && marginStyles[`marginTop${smMarginTop}Small`],
+      lgMargin != null &&
         !lgMarginBottom &&
         marginStyles[`marginBottom${lgMargin}Large`],
-      lgMargin && !lgMarginEnd && marginStyles[`marginEnd${lgMargin}Large`],
-      lgMargin && !lgMarginStart && marginStyles[`marginStart${lgMargin}Large`],
-      lgMargin && !lgMarginTop && marginStyles[`marginTop${lgMargin}Large`],
-      lgMarginBottom && marginStyles[`marginBottom${lgMarginBottom}Large`],
-      lgMarginEnd && marginStyles[`marginEnd${lgMarginEnd}Large`],
-      lgMarginStart && marginStyles[`marginStart${lgMarginStart}Large`],
-      lgMarginTop && marginStyles[`marginTop${lgMarginTop}Large`],
-      padding && !paddingX && paddingStyles[`paddingX${padding}`],
-      padding && !paddingY && paddingStyles[`paddingY${padding}`],
-      paddingX && paddingStyles[`paddingX${paddingX}`],
-      paddingY && paddingStyles[`paddingY${paddingY}`],
-      smPadding && !smPaddingX && paddingStyles[`paddingX${smPadding}Small`],
-      smPadding && !smPaddingY && paddingStyles[`paddingY${smPadding}Small`],
-      smPaddingX && paddingStyles[`paddingX${smPaddingX}Small`],
-      smPaddingY && paddingStyles[`paddingY${smPaddingY}Small`],
-      lgPadding && !lgPaddingX && paddingStyles[`paddingX${lgPadding}Large`],
-      lgPadding && !lgPaddingX && paddingStyles[`paddingY${lgPadding}Large`],
-      lgPaddingX && paddingStyles[`paddingX${lgPaddingX}Large`],
-      lgPaddingY && paddingStyles[`paddingY${lgPaddingY}Large`],
+      lgMargin != null &&
+        !lgMarginEnd &&
+        marginStyles[`marginEnd${lgMargin}Large`],
+      lgMargin != null &&
+        !lgMarginStart &&
+        marginStyles[`marginStart${lgMargin}Large`],
+      lgMargin != null &&
+        !lgMarginTop &&
+        marginStyles[`marginTop${lgMargin}Large`],
+      lgMarginBottom != null &&
+        marginStyles[`marginBottom${lgMarginBottom}Large`],
+      lgMarginEnd != null && marginStyles[`marginEnd${lgMarginEnd}Large`],
+      lgMarginStart != null && marginStyles[`marginStart${lgMarginStart}Large`],
+      lgMarginTop != null && marginStyles[`marginTop${lgMarginTop}Large`],
+      padding != null && !paddingX && paddingStyles[`paddingX${padding}`],
+      padding != null && !paddingY && paddingStyles[`paddingY${padding}`],
+      paddingX != null && paddingStyles[`paddingX${paddingX}`],
+      paddingY != null && paddingStyles[`paddingY${paddingY}`],
+      smPadding != null &&
+        !smPaddingX &&
+        paddingStyles[`paddingX${smPadding}Small`],
+      smPadding != null &&
+        !smPaddingY &&
+        paddingStyles[`paddingY${smPadding}Small`],
+      smPaddingX != null && paddingStyles[`paddingX${smPaddingX}Small`],
+      smPaddingY != null && paddingStyles[`paddingY${smPaddingY}Small`],
+      lgPadding != null &&
+        !lgPaddingX &&
+        paddingStyles[`paddingX${lgPadding}Large`],
+      lgPadding != null &&
+        !lgPaddingX &&
+        paddingStyles[`paddingY${lgPadding}Large`],
+      lgPaddingX != null && paddingStyles[`paddingX${lgPaddingX}Large`],
+      lgPaddingY != null && paddingStyles[`paddingY${lgPaddingY}Large`],
       justifyContent && styles[`justifyContent${justifyContent}`],
       smJustifyContent && styles[`justifyContent${smJustifyContent}Small`],
       lgJustifyContent && styles[`justifyContent${lgJustifyContent}Large`],

--- a/packages/syntax-core/src/Box/margin.module.css
+++ b/packages/syntax-core/src/Box/margin.module.css
@@ -421,837 +421,837 @@
 /* Margin (small and up) */
 @media (min-width: 480px) {
   .marginBottom-12Small {
-    composes: marginBottom-12;
+    margin-bottom: -48px;
   }
 
   .marginBottom-11Small {
-    composes: marginBottom-11;
+    margin-bottom: -44px;
   }
 
   .marginBottom-10Small {
-    composes: marginBottom-10;
+    margin-bottom: -40px;
   }
 
   .marginBottom-9Small {
-    composes: marginBottom-9;
+    margin-bottom: -36px;
   }
 
   .marginBottom-8Small {
-    composes: marginBottom-8;
+    margin-bottom: -32px;
   }
 
   .marginBottom-7Small {
-    composes: marginBottom-7;
+    margin-bottom: -28px;
   }
 
   .marginBottom-6Small {
-    composes: marginBottom-6;
+    margin-bottom: -24px;
   }
 
   .marginBottom-5Small {
-    composes: marginBottom-5;
+    margin-bottom: -20px;
   }
 
   .marginBottom-4Small {
-    composes: marginBottom-4;
+    margin-bottom: -16px;
   }
 
   .marginBottom-3Small {
-    composes: marginBottom-3;
+    margin-bottom: -12px;
   }
 
   .marginBottom-2Small {
-    composes: marginBottom-2;
+    margin-bottom: -8px;
   }
 
   .marginBottom-1Small {
-    composes: marginBottom-1;
+    margin-bottom: -4px;
   }
 
   .marginBottom0Small {
-    composes: marginBottom0;
+    margin-bottom: 0;
   }
 
   .marginBottom1Small {
-    composes: marginBottom1;
+    margin-bottom: 4px;
   }
 
   .marginBottom2Small {
-    composes: marginBottom2;
+    margin-bottom: 8px;
   }
 
   .marginBottom3Small {
-    composes: marginBottom3;
+    margin-bottom: 12px;
   }
 
   .marginBottom4Small {
-    composes: marginBottom4;
+    margin-bottom: 16px;
   }
 
   .marginBottom5Small {
-    composes: marginBottom5;
+    margin-bottom: 20px;
   }
 
   .marginBottom6Small {
-    composes: marginBottom6;
+    margin-bottom: 24px;
   }
 
   .marginBottom7Small {
-    composes: marginBottom7;
+    margin-bottom: 28px;
   }
 
   .marginBottom8Small {
-    composes: marginBottom8;
+    margin-bottom: 32px;
   }
 
   .marginBottom9Small {
-    composes: marginBottom9;
+    margin-bottom: 36px;
   }
 
   .marginBottom10Small {
-    composes: marginBottom10;
+    margin-bottom: 40px;
   }
 
   .marginBottom11Small {
-    composes: marginBottom11;
+    margin-bottom: 44px;
   }
 
   .marginBottom12Small {
-    composes: marginBottom12;
+    margin-bottom: 48px;
   }
 
   .marginBottomautoSmall {
-    composes: marginBottomauto;
+    margin-bottom: auto;
   }
 
   .marginEnd-12Small {
-    composes: marginEnd-12;
+    margin-inline-end: -48px;
   }
 
   .marginEnd-11Small {
-    composes: marginEnd-11;
+    margin-inline-end: -44px;
   }
 
   .marginEnd-10Small {
-    composes: marginEnd-10;
+    margin-inline-end: -40px;
   }
 
   .marginEnd-9Small {
-    composes: marginEnd-9;
+    margin-inline-end: -36px;
   }
 
   .marginEnd-8Small {
-    composes: marginEnd-8;
+    margin-inline-end: -32px;
   }
 
   .marginEnd-7Small {
-    composes: marginEnd-7;
+    margin-inline-end: -28px;
   }
 
   .marginEnd-6Small {
-    composes: marginEnd-6;
+    margin-inline-end: -24px;
   }
 
   .marginEnd-5Small {
-    composes: marginEnd-5;
+    margin-inline-end: -20px;
   }
 
   .marginEnd-4Small {
-    composes: marginEnd-4;
+    margin-inline-end: -16px;
   }
 
   .marginEnd-3Small {
-    composes: marginEnd-3;
+    margin-inline-end: -12px;
   }
 
   .marginEnd-2Small {
-    composes: marginEnd-2;
+    margin-inline-end: -8px;
   }
 
   .marginEnd-1Small {
-    composes: marginEnd-1;
+    margin-inline-end: -4px;
   }
 
   .marginEnd0Small {
-    composes: marginEnd0;
+    margin-inline-end: 0;
   }
 
   .marginEnd1Small {
-    composes: marginEnd1;
+    margin-inline-end: 4px;
   }
 
   .marginEnd2Small {
-    composes: marginEnd2;
+    margin-inline-end: 8px;
   }
 
   .marginEnd3Small {
-    composes: marginEnd3;
+    margin-inline-end: 12px;
   }
 
   .marginEnd4Small {
-    composes: marginEnd4;
+    margin-inline-end: 16px;
   }
 
   .marginEnd5Small {
-    composes: marginEnd5;
+    margin-inline-end: 20px;
   }
 
   .marginEnd6Small {
-    composes: marginEnd6;
+    margin-inline-end: 24px;
   }
 
   .marginEnd7Small {
-    composes: marginEnd7;
+    margin-inline-end: 28px;
   }
 
   .marginEnd8Small {
-    composes: marginEnd8;
+    margin-inline-end: 32px;
   }
 
   .marginEnd9Small {
-    composes: marginEnd9;
+    margin-inline-end: 36px;
   }
 
   .marginEnd10Small {
-    composes: marginEnd10;
+    margin-inline-end: 40px;
   }
 
   .marginEnd11Small {
-    composes: marginEnd11;
+    margin-inline-end: 44px;
   }
 
   .marginEnd12Small {
-    composes: marginEnd12;
+    margin-inline-end: 48px;
   }
 
   .marginEndautoSmall {
-    composes: marginEndauto;
+    margin-inline-end: auto;
   }
 
   .marginStart-12Small {
-    composes: marginStart-12;
+    margin-inline-start: -48px;
   }
 
   .marginStart-11Small {
-    composes: marginStart-11;
+    margin-inline-start: -44px;
   }
 
   .marginStart-10Small {
-    composes: marginStart-10;
+    margin-inline-start: -40px;
   }
 
   .marginStart-9Small {
-    composes: marginStart-9;
+    margin-inline-start: -36px;
   }
 
   .marginStart-8Small {
-    composes: marginStart-8;
+    margin-inline-start: -32px;
   }
 
   .marginStart-7Small {
-    composes: marginStart-7;
+    margin-inline-start: -28px;
   }
 
   .marginStart-6Small {
-    composes: marginStart-6;
+    margin-inline-start: -24px;
   }
 
   .marginStart-5Small {
-    composes: marginStart-5;
+    margin-inline-start: -20px;
   }
 
   .marginStart-4Small {
-    composes: marginStart-4;
+    margin-inline-start: -16px;
   }
 
   .marginStart-3Small {
-    composes: marginStart-3;
+    margin-inline-start: -12px;
   }
 
   .marginStart-2Small {
-    composes: marginStart-2;
+    margin-inline-start: -8px;
   }
 
   .marginStart-1Small {
-    composes: marginStart-1;
+    margin-inline-start: -4px;
   }
 
   .marginStart0Small {
-    composes: marginStart0;
+    margin-inline-start: 0;
   }
 
   .marginStart1Small {
-    composes: marginStart1;
+    margin-inline-start: 4px;
   }
 
   .marginStart2Small {
-    composes: marginStart2;
+    margin-inline-start: 8px;
   }
 
   .marginStart3Small {
-    composes: marginStart3;
+    margin-inline-start: 12px;
   }
 
   .marginStart4Small {
-    composes: marginStart4;
+    margin-inline-start: 16px;
   }
 
   .marginStart5Small {
-    composes: marginStart5;
+    margin-inline-start: 20px;
   }
 
   .marginStart6Small {
-    composes: marginStart6;
+    margin-inline-start: 24px;
   }
 
   .marginStart7Small {
-    composes: marginStart7;
+    margin-inline-start: 28px;
   }
 
   .marginStart8Small {
-    composes: marginStart8;
+    margin-inline-start: 32px;
   }
 
   .marginStart9Small {
-    composes: marginStart9;
+    margin-inline-start: 36px;
   }
 
   .marginStart10Small {
-    composes: marginStart10;
+    margin-inline-start: 40px;
   }
 
   .marginStart11Small {
-    composes: marginStart11;
+    margin-inline-start: 44px;
   }
 
   .marginStart12Small {
-    composes: marginStart12;
+    margin-inline-start: 48px;
   }
 
   .marginStartautoSmall {
-    composes: marginStartauto;
+    margin-inline-start: auto;
   }
 
   .marginTop-12Small {
-    composes: marginTop-12;
+    margin-top: -48px;
   }
 
   .marginTop-11Small {
-    composes: marginTop-11;
+    margin-top: -44px;
   }
 
   .marginTop-10Small {
-    composes: marginTop-10;
+    margin-top: -40px;
   }
 
   .marginTop-9Small {
-    composes: marginTop-9;
+    margin-top: -36px;
   }
 
   .marginTop-8Small {
-    composes: marginTop-8;
+    margin-top: -32px;
   }
 
   .marginTop-7Small {
-    composes: marginTop-7;
+    margin-top: -28px;
   }
 
   .marginTop-6Small {
-    composes: marginTop-6;
+    margin-top: -24px;
   }
 
   .marginTop-5Small {
-    composes: marginTop-5;
+    margin-top: -20px;
   }
 
   .marginTop-4Small {
-    composes: marginTop-4;
+    margin-top: -16px;
   }
 
   .marginTop-3Small {
-    composes: marginTop-3;
+    margin-top: -12px;
   }
 
   .marginTop-2Small {
-    composes: marginTop-2;
+    margin-top: -8px;
   }
 
   .marginTop-1Small {
-    composes: marginTop-1;
+    margin-top: -4px;
   }
 
   .marginTop0Small {
-    composes: marginTop0;
+    margin-top: 0;
   }
 
   .marginTop1Small {
-    composes: marginTop1;
+    margin-top: 4px;
   }
 
   .marginTop2Small {
-    composes: marginTop2;
+    margin-top: 8px;
   }
 
   .marginTop3Small {
-    composes: marginTop3;
+    margin-top: 12px;
   }
 
   .marginTop4Small {
-    composes: marginTop4;
+    margin-top: 16px;
   }
 
   .marginTop5Small {
-    composes: marginTop5;
+    margin-top: 20px;
   }
 
   .marginTop6Small {
-    composes: marginTop6;
+    margin-top: 24px;
   }
 
   .marginTop7Small {
-    composes: marginTop7;
+    margin-top: 28px;
   }
 
   .marginTop8Small {
-    composes: marginTop8;
+    margin-top: 32px;
   }
 
   .marginTop9Small {
-    composes: marginTop9;
+    margin-top: 36px;
   }
 
   .marginTop10Small {
-    composes: marginTop10;
+    margin-top: 40px;
   }
 
   .marginTop11Small {
-    composes: marginTop11;
+    margin-top: 44px;
   }
 
   .marginTop12Small {
-    composes: marginTop12;
+    margin-top: 48px;
   }
 
   .marginTopautoSmall {
-    composes: marginTopauto;
+    margin-top: auto;
   }
 }
 
 /* Margin (large and up) */
 @media (min-width: 960px) {
   .marginBottom-12Large {
-    composes: marginBottom-12;
+    margin-bottom: -48px;
   }
 
   .marginBottom-11Large {
-    composes: marginBottom-11;
+    margin-bottom: -44px;
   }
 
   .marginBottom-10Large {
-    composes: marginBottom-10;
+    margin-bottom: -40px;
   }
 
   .marginBottom-9Large {
-    composes: marginBottom-9;
+    margin-bottom: -36px;
   }
 
   .marginBottom-8Large {
-    composes: marginBottom-8;
+    margin-bottom: -32px;
   }
 
   .marginBottom-7Large {
-    composes: marginBottom-7;
+    margin-bottom: -28px;
   }
 
   .marginBottom-6Large {
-    composes: marginBottom-6;
+    margin-bottom: -24px;
   }
 
   .marginBottom-5Large {
-    composes: marginBottom-5;
+    margin-bottom: -20px;
   }
 
   .marginBottom-4Large {
-    composes: marginBottom-4;
+    margin-bottom: -16px;
   }
 
   .marginBottom-3Large {
-    composes: marginBottom-3;
+    margin-bottom: -12px;
   }
 
   .marginBottom-2Large {
-    composes: marginBottom-2;
+    margin-bottom: -8px;
   }
 
   .marginBottom-1Large {
-    composes: marginBottom-1;
+    margin-bottom: -4px;
   }
 
   .marginBottom0Large {
-    composes: marginBottom0;
+    margin-bottom: 0;
   }
 
   .marginBottom1Large {
-    composes: marginBottom1;
+    margin-bottom: 4px;
   }
 
   .marginBottom2Large {
-    composes: marginBottom2;
+    margin-bottom: 8px;
   }
 
   .marginBottom3Large {
-    composes: marginBottom3;
+    margin-bottom: 12px;
   }
 
   .marginBottom4Large {
-    composes: marginBottom4;
+    margin-bottom: 16px;
   }
 
   .marginBottom5Large {
-    composes: marginBottom5;
+    margin-bottom: 20px;
   }
 
   .marginBottom6Large {
-    composes: marginBottom6;
+    margin-bottom: 24px;
   }
 
   .marginBottom7Large {
-    composes: marginBottom7;
+    margin-bottom: 28px;
   }
 
   .marginBottom8Large {
-    composes: marginBottom8;
+    margin-bottom: 32px;
   }
 
   .marginBottom9Large {
-    composes: marginBottom9;
+    margin-bottom: 36px;
   }
 
   .marginBottom10Large {
-    composes: marginBottom10;
+    margin-bottom: 40px;
   }
 
   .marginBottom11Large {
-    composes: marginBottom11;
+    margin-bottom: 44px;
   }
 
   .marginBottom12Large {
-    composes: marginBottom12;
+    margin-bottom: 48px;
   }
 
   .marginBottomautoLarge {
-    composes: marginBottomauto;
+    margin-bottom: auto;
   }
 
   .marginEnd-12Large {
-    composes: marginEnd-12;
+    margin-inline-end: -48px;
   }
 
   .marginEnd-11Large {
-    composes: marginEnd-11;
+    margin-inline-end: -44px;
   }
 
   .marginEnd-10Large {
-    composes: marginEnd-10;
+    margin-inline-end: -40px;
   }
 
   .marginEnd-9Large {
-    composes: marginEnd-9;
+    margin-inline-end: -36px;
   }
 
   .marginEnd-8Large {
-    composes: marginEnd-8;
+    margin-inline-end: -32px;
   }
 
   .marginEnd-7Large {
-    composes: marginEnd-7;
+    margin-inline-end: -28px;
   }
 
   .marginEnd-6Large {
-    composes: marginEnd-6;
+    margin-inline-end: -24px;
   }
 
   .marginEnd-5Large {
-    composes: marginEnd-5;
+    margin-inline-end: -20px;
   }
 
   .marginEnd-4Large {
-    composes: marginEnd-4;
+    margin-inline-end: -16px;
   }
 
   .marginEnd-3Large {
-    composes: marginEnd-3;
+    margin-inline-end: -12px;
   }
 
   .marginEnd-2Large {
-    composes: marginEnd-2;
+    margin-inline-end: -8px;
   }
 
   .marginEnd-1Large {
-    composes: marginEnd-1;
+    margin-inline-end: -4px;
   }
 
   .marginEnd0Large {
-    composes: marginEnd0;
+    margin-inline-end: 0;
   }
 
   .marginEnd1Large {
-    composes: marginEnd1;
+    margin-inline-end: 4px;
   }
 
   .marginEnd2Large {
-    composes: marginEnd2;
+    margin-inline-end: 8px;
   }
 
   .marginEnd3Large {
-    composes: marginEnd3;
+    margin-inline-end: 12px;
   }
 
   .marginEnd4Large {
-    composes: marginEnd4;
+    margin-inline-end: 16px;
   }
 
   .marginEnd5Large {
-    composes: marginEnd5;
+    margin-inline-end: 20px;
   }
 
   .marginEnd6Large {
-    composes: marginEnd6;
+    margin-inline-end: 24px;
   }
 
   .marginEnd7Large {
-    composes: marginEnd7;
+    margin-inline-end: 28px;
   }
 
   .marginEnd8Large {
-    composes: marginEnd8;
+    margin-inline-end: 32px;
   }
 
   .marginEnd9Large {
-    composes: marginEnd9;
+    margin-inline-end: 36px;
   }
 
   .marginEnd10Large {
-    composes: marginEnd10;
+    margin-inline-end: 40px;
   }
 
   .marginEnd11Large {
-    composes: marginEnd11;
+    margin-inline-end: 44px;
   }
 
   .marginEnd12Large {
-    composes: marginEnd12;
+    margin-inline-end: 48px;
   }
 
   .marginEndautoLarge {
-    composes: marginEndauto;
+    margin-inline-end: auto;
   }
 
   .marginStart-12Large {
-    composes: marginStart-12;
+    margin-inline-start: -48px;
   }
 
   .marginStart-11Large {
-    composes: marginStart-11;
+    margin-inline-start: -44px;
   }
 
   .marginStart-10Large {
-    composes: marginStart-10;
+    margin-inline-start: -40px;
   }
 
   .marginStart-9Large {
-    composes: marginStart-9;
+    margin-inline-start: -36px;
   }
 
   .marginStart-8Large {
-    composes: marginStart-8;
+    margin-inline-start: -32px;
   }
 
   .marginStart-7Large {
-    composes: marginStart-7;
+    margin-inline-start: -28px;
   }
 
   .marginStart-6Large {
-    composes: marginStart-6;
+    margin-inline-start: -24px;
   }
 
   .marginStart-5Large {
-    composes: marginStart-5;
+    margin-inline-start: -20px;
   }
 
   .marginStart-4Large {
-    composes: marginStart-4;
+    margin-inline-start: -16px;
   }
 
   .marginStart-3Large {
-    composes: marginStart-3;
+    margin-inline-start: -12px;
   }
 
   .marginStart-2Large {
-    composes: marginStart-2;
+    margin-inline-start: -8px;
   }
 
   .marginStart-1Large {
-    composes: marginStart-1;
+    margin-inline-start: -4px;
   }
 
   .marginStart0Large {
-    composes: marginStart0;
+    margin-inline-start: 0;
   }
 
   .marginStart1Large {
-    composes: marginStart1;
+    margin-inline-start: 4px;
   }
 
   .marginStart2Large {
-    composes: marginStart2;
+    margin-inline-start: 8px;
   }
 
   .marginStart3Large {
-    composes: marginStart3;
+    margin-inline-start: 12px;
   }
 
   .marginStart4Large {
-    composes: marginStart4;
+    margin-inline-start: 16px;
   }
 
   .marginStart5Large {
-    composes: marginStart5;
+    margin-inline-start: 20px;
   }
 
   .marginStart6Large {
-    composes: marginStart6;
+    margin-inline-start: 24px;
   }
 
   .marginStart7Large {
-    composes: marginStart7;
+    margin-inline-start: 28px;
   }
 
   .marginStart8Large {
-    composes: marginStart8;
+    margin-inline-start: 32px;
   }
 
   .marginStart9Large {
-    composes: marginStart9;
+    margin-inline-start: 36px;
   }
 
   .marginStart10Large {
-    composes: marginStart10;
+    margin-inline-start: 40px;
   }
 
   .marginStart11Large {
-    composes: marginStart11;
+    margin-inline-start: 44px;
   }
 
   .marginStart12Large {
-    composes: marginStart12;
+    margin-inline-start: 48px;
   }
 
   .marginStartautoLarge {
-    composes: marginStartauto;
+    margin-inline-start: auto;
   }
 
   .marginTop-12Large {
-    composes: marginTop-12;
+    margin-top: -48px;
   }
 
   .marginTop-11Large {
-    composes: marginTop-11;
+    margin-top: -44px;
   }
 
   .marginTop-10Large {
-    composes: marginTop-10;
+    margin-top: -40px;
   }
 
   .marginTop-9Large {
-    composes: marginTop-9;
+    margin-top: -36px;
   }
 
   .marginTop-8Large {
-    composes: marginTop-8;
+    margin-top: -32px;
   }
 
   .marginTop-7Large {
-    composes: marginTop-7;
+    margin-top: -28px;
   }
 
   .marginTop-6Large {
-    composes: marginTop-6;
+    margin-top: -24px;
   }
 
   .marginTop-5Large {
-    composes: marginTop-5;
+    margin-top: -20px;
   }
 
   .marginTop-4Large {
-    composes: marginTop-4;
+    margin-top: -16px;
   }
 
   .marginTop-3Large {
-    composes: marginTop-3;
+    margin-top: -12px;
   }
 
   .marginTop-2Large {
-    composes: marginTop-2;
+    margin-top: -8px;
   }
 
   .marginTop-1Large {
-    composes: marginTop-1;
+    margin-top: -4px;
   }
 
   .marginTop0Large {
-    composes: marginTop0;
+    margin-top: 0;
   }
 
   .marginTop1Large {
-    composes: marginTop1;
+    margin-top: 4px;
   }
 
   .marginTop2Large {
-    composes: marginTop2;
+    margin-top: 8px;
   }
 
   .marginTop3Large {
-    composes: marginTop3;
+    margin-top: 12px;
   }
 
   .marginTop4Large {
-    composes: marginTop4;
+    margin-top: 16px;
   }
 
   .marginTop5Large {
-    composes: marginTop5;
+    margin-top: 20px;
   }
 
   .marginTop6Large {
-    composes: marginTop6;
+    margin-top: 24px;
   }
 
   .marginTop7Large {
-    composes: marginTop7;
+    margin-top: 28px;
   }
 
   .marginTop8Large {
-    composes: marginTop8;
+    margin-top: 32px;
   }
 
   .marginTop9Large {
-    composes: marginTop9;
+    margin-top: 36px;
   }
 
   .marginTop10Large {
-    composes: marginTop10;
+    margin-top: 40px;
   }
 
   .marginTop11Large {
-    composes: marginTop11;
+    margin-top: 44px;
   }
 
   .marginTop12Large {
-    composes: marginTop12;
+    margin-top: 48px;
   }
 
   .marginTopautoLarge {
-    composes: marginTopauto;
+    margin-top: auto;
   }
 }

--- a/packages/syntax-core/src/Box/padding.module.css
+++ b/packages/syntax-core/src/Box/padding.module.css
@@ -132,213 +132,265 @@
 /* Padding (small and up) */
 @media (min-width: 480px) {
   .paddingX0Small {
-    composes: paddingX0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .paddingX1Small {
-    composes: paddingX1;
+    padding-left: 4px;
+    padding-right: 4px;
   }
 
   .paddingX2Small {
-    composes: paddingX2;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   .paddingX3Small {
-    composes: paddingX3;
+    padding-left: 12px;
+    padding-right: 12px;
   }
 
   .paddingX4Small {
-    composes: paddingX4;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 
   .paddingX5Small {
-    composes: paddingX5;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 
   .paddingX6Small {
-    composes: paddingX6;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 
   .paddingX7Small {
-    composes: paddingX7;
+    padding-left: 28px;
+    padding-right: 28px;
   }
 
   .paddingX8Small {
-    composes: paddingX8;
+    padding-left: 32px;
+    padding-right: 32px;
   }
 
   .paddingX9Small {
-    composes: paddingX9;
+    padding-left: 36px;
+    padding-right: 36px;
   }
 
   .paddingX10Small {
-    composes: paddingX10;
+    padding-left: 40px;
+    padding-right: 40px;
   }
 
   .paddingX11Small {
-    composes: paddingX11;
+    padding-left: 44px;
+    padding-right: 44px;
   }
 
   .paddingX12Small {
-    composes: paddingX12;
+    padding-left: 48px;
+    padding-right: 48px;
   }
 
   .paddingY0Small {
-    composes: paddingY0;
+    padding-bottom: 0;
+    padding-top: 0;
   }
 
   .paddingY1Small {
-    composes: paddingY1;
+    padding-bottom: 4px;
+    padding-top: 4px;
   }
 
   .paddingY2Small {
-    composes: paddingY2;
+    padding-bottom: 8px;
+    padding-top: 8px;
   }
 
   .paddingY3Small {
-    composes: paddingY3;
+    padding-bottom: 12px;
+    padding-top: 12px;
   }
 
   .paddingY4Small {
-    composes: paddingY4;
+    padding-bottom: 16px;
+    padding-top: 16px;
   }
 
   .paddingY5Small {
-    composes: paddingY5;
+    padding-bottom: 20px;
+    padding-top: 20px;
   }
 
   .paddingY6Small {
-    composes: paddingY6;
+    padding-bottom: 24px;
+    padding-top: 24px;
   }
 
   .paddingY7Small {
-    composes: paddingY7;
+    padding-bottom: 28px;
+    padding-top: 28px;
   }
 
   .paddingY8Small {
-    composes: paddingY8;
+    padding-bottom: 32px;
+    padding-top: 32px;
   }
 
   .paddingY9Small {
-    composes: paddingY9;
+    padding-bottom: 36px;
+    padding-top: 36px;
   }
 
   .paddingY10Small {
-    composes: paddingY10;
+    padding-bottom: 40px;
+    padding-top: 40px;
   }
 
   .paddingY11Small {
-    composes: paddingY11;
+    padding-bottom: 44px;
+    padding-top: 44px;
   }
 
   .paddingY12Small {
-    composes: paddingY12;
+    padding-bottom: 48px;
+    padding-top: 48px;
   }
 }
 
 /* Padding (large and up) */
 @media (min-width: 960px) {
   .paddingX0Large {
-    composes: paddingX0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .paddingX1Large {
-    composes: paddingX1;
+    padding-left: 4px;
+    padding-right: 4px;
   }
 
   .paddingX2Large {
-    composes: paddingX2;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   .paddingX3Large {
-    composes: paddingX3;
+    padding-left: 12px;
+    padding-right: 12px;
   }
 
   .paddingX4Large {
-    composes: paddingX4;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 
   .paddingX5Large {
-    composes: paddingX5;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 
   .paddingX6Large {
-    composes: paddingX6;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 
   .paddingX7Large {
-    composes: paddingX7;
+    padding-left: 28px;
+    padding-right: 28px;
   }
 
   .paddingX8Large {
-    composes: paddingX8;
+    padding-left: 32px;
+    padding-right: 32px;
   }
 
   .paddingX9Large {
-    composes: paddingX9;
+    padding-left: 36px;
+    padding-right: 36px;
   }
 
   .paddingX10Large {
-    composes: paddingX10;
+    padding-left: 40px;
+    padding-right: 40px;
   }
 
   .paddingX11Large {
-    composes: paddingX11;
+    padding-left: 44px;
+    padding-right: 44px;
   }
 
   .paddingX12Large {
-    composes: paddingX12;
+    padding-left: 48px;
+    padding-right: 48px;
   }
 
   .paddingY0Large {
-    composes: paddingY0;
+    padding-bottom: 0;
+    padding-top: 0;
   }
 
   .paddingY1Large {
-    composes: paddingY1;
+    padding-bottom: 4px;
+    padding-top: 4px;
   }
 
   .paddingY2Large {
-    composes: paddingY2;
+    padding-bottom: 8px;
+    padding-top: 8px;
   }
 
   .paddingY3Large {
-    composes: paddingY3;
+    padding-bottom: 12px;
+    padding-top: 12px;
   }
 
   .paddingY4Large {
-    composes: paddingY4;
+    padding-bottom: 16px;
+    padding-top: 16px;
   }
 
   .paddingY5Large {
-    composes: paddingY5;
+    padding-bottom: 20px;
+    padding-top: 20px;
   }
 
   .paddingY6Large {
-    composes: paddingY6;
+    padding-bottom: 24px;
+    padding-top: 24px;
   }
 
   .paddingY7Large {
-    composes: paddingY7;
+    padding-bottom: 28px;
+    padding-top: 28px;
   }
 
   .paddingY8Large {
-    composes: paddingY8;
+    padding-bottom: 32px;
+    padding-top: 32px;
   }
 
   .paddingY9Large {
-    composes: paddingY9;
+    padding-bottom: 36px;
+    padding-top: 36px;
   }
 
   .paddingY10Large {
-    composes: paddingY10;
+    padding-bottom: 40px;
+    padding-top: 40px;
   }
 
   .paddingY11Large {
-    composes: paddingY11;
+    padding-bottom: 44px;
+    padding-top: 44px;
   }
 
   .paddingY12Large {
-    composes: paddingY12;
+    padding-bottom: 48px;
+    padding-top: 48px;
   }
 }


### PR DESCRIPTION
# Changes

* Add `display="none"`
* Fix responsive props
* Allow for `0` on props which take in numbers (e.g. margin and padding)

# Context
Noticed a bug with using `composes` where the outputted CSS didn't contain any CSS.

Before

![Screenshot 2023-04-04 at 9 55 55 AM](https://user-images.githubusercontent.com/127199/229863429-06523577-ba60-4866-9c32-087466d9dd01.png)

After

![Screenshot 2023-04-04 at 9 56 07 AM](https://user-images.githubusercontent.com/127199/229863440-5056e4e3-1177-43ed-b7b6-b1c8ce1d0dcb.png)
