### PR TITLE
[gp-2242] add in usefocusvisible, use in radiobutton

### DIFF
--- a/.changeset/sour-lobsters-explain.md
+++ b/.changeset/sour-lobsters-explain.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+useFocusVisible, add in new required params (value, name) for radioButton

--- a/packages/syntax-core/src/RadioButton/RadioButton.module.css
+++ b/packages/syntax-core/src/RadioButton/RadioButton.module.css
@@ -1,13 +1,8 @@
-.radioButton {
+.radioBaseContainer {
   display: flex;
   flex-direction: row;
   align-items: center;
   cursor: pointer;
-}
-
-.focusedRadioButton {
-  box-shadow: 0 0 0 4px #000;
-  outline: solid 2px #fff;
 }
 
 .smBase {
@@ -35,11 +30,9 @@
   height: 24px;
 }
 
-.outer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.background {
   position: absolute;
+  box-sizing: border-box;
 }
 
 .sm {
@@ -54,18 +47,16 @@
   border-radius: 12px;
 }
 
-.errorOuterBackgroundColor {
-  background-color: var(--color-base-destructive-700);
-}
-
-.outerBackgroundColor {
-  background-color: var(--color-base-primary-700);
-}
-
-.background {
-  position: absolute;
-  box-sizing: border-box;
+.neutralBorder {
   border: 2px solid;
+}
+
+.smCheckedBorder {
+  border: 5px solid;
+}
+
+.mdCheckedBorder {
+  border: 8px solid;
 }
 
 .errorBorderColor {
@@ -76,18 +67,7 @@
   border-color: var(--color-base-primary-700);
 }
 
-.circle {
-  border-radius: 50%;
-}
-
-.smInner {
-  background-color: var(--color-base-white);
-  height: 6px;
-  width: 6px;
-}
-
-.mdInner {
-  background-color: var(--color-base-white);
-  height: 10px;
-  width: 10px;
+.focusedRadioButton {
+  box-shadow: 0 0 0 4px #000;
+  outline: solid 2px #fff;
 }

--- a/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
@@ -43,12 +43,14 @@ const RadioButtonInteractive = () => {
         checked={selectedOption === "male"}
         value="male"
         onChange={handleChange}
+        name="gender"
         label="Male"
       />
       <RadioButton
         checked={selectedOption === "female"}
         value="female"
         onChange={handleChange}
+        name="gender"
         label="Female"
       />
     </form>

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -3,6 +3,7 @@ import classnames from "classnames";
 
 import styles from "./RadioButton.module.css";
 import Typography from "../Typography/Typography";
+import useFocusVisible from "../useFocusVisible";
 
 /**
  * RadioButton is a radio button with accompanying text
@@ -57,6 +58,7 @@ const RadioButton = ({
   value?: string;
 }): ReactElement => {
   const [isFocused, setIsFocused] = useState(false);
+  const { isFocusVisible } = useFocusVisible();
 
   return (
     <label
@@ -87,7 +89,7 @@ const RadioButton = ({
           className={classnames(styles.outer, styles[size], {
             [styles.errorOuterBackgroundColor]: error,
             [styles.outerBackgroundColor]: !error,
-            [styles.focusedRadioButton]: isFocused,
+            [styles.focusedRadioButton]: isFocused && isFocusVisible && checked,
           })}
         >
           <div
@@ -102,7 +104,7 @@ const RadioButton = ({
           className={classnames(styles.background, styles[size], {
             [styles.errorBorderColor]: error,
             [styles.borderColor]: !error,
-            [styles.focusedRadioButton]: isFocused,
+            [styles.focusedRadioButton]: isFocused && isFocusVisible && checked,
           })}
         />
       )}

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -13,18 +13,19 @@ const RadioButton = ({
   disabled = false,
   error = false,
   label,
+  name,
   onChange,
   size = "md",
-  value = "",
+  value,
 }: {
   /**
-   * Whether or not the box is checked
+   * Whether or not the radio button is checked
    *
    * @defaultValue false
    */
   checked?: boolean;
   /**
-   * Whether or not the box is disabled
+   * Whether or not the radio button is disabled
    *
    * @defaultValue false
    */
@@ -36,11 +37,15 @@ const RadioButton = ({
    */
   error?: boolean;
   /**
-   * Always add a label tag for best accessibility practices
+   * Value to show end user
    */
   label: string;
   /**
-   * The callback to be called when the button is clicked
+   * The name of the grouping the radio buttons are in
+   */
+  name: string;
+  /**
+   * The callback to be called when the radio button is clicked
    */
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   /**
@@ -55,20 +60,27 @@ const RadioButton = ({
   /**
    * Value of the selected radio option
    */
-  value?: string;
+  value: string;
 }): ReactElement => {
   const [isFocused, setIsFocused] = useState(false);
   const { isFocusVisible } = useFocusVisible();
 
+  const sharedStyles = classnames(styles.background, styles[size], {
+    [styles.errorBorderColor]: error,
+    [styles.borderColor]: !error,
+    [styles.focusedRadioButton]: isFocused && isFocusVisible,
+  });
+
   return (
     <label
-      className={classnames(styles.radioButton, {
+      className={classnames(styles.radioBaseContainer, {
         [styles.smBase]: size === "sm",
         [styles.mdBase]: size === "md",
       })}
     >
       <input
         type="radio"
+        name={name}
         className={classnames(styles.radioStyleOverride, {
           [styles.smOverride]: size === "sm",
           [styles.mdOverride]: size === "md",
@@ -76,7 +88,7 @@ const RadioButton = ({
         checked={checked}
         onChange={onChange}
         disabled={disabled}
-        value={value ?? label}
+        value={value}
         onFocus={() => {
           setIsFocused(true);
         }}
@@ -86,27 +98,13 @@ const RadioButton = ({
       />
       {checked ? (
         <div
-          className={classnames(styles.outer, styles[size], {
-            [styles.errorOuterBackgroundColor]: error,
-            [styles.outerBackgroundColor]: !error,
-            [styles.focusedRadioButton]: isFocused && isFocusVisible && checked,
-          })}
-        >
-          <div
-            className={classnames(styles.circle, {
-              [styles.smInner]: size === "sm",
-              [styles.mdInner]: size === "md",
-            })}
-          />
-        </div>
-      ) : (
-        <div
-          className={classnames(styles.background, styles[size], {
-            [styles.errorBorderColor]: error,
-            [styles.borderColor]: !error,
-            [styles.focusedRadioButton]: isFocused && isFocusVisible && checked,
+          className={classnames(sharedStyles, {
+            [styles.mdCheckedBorder]: size === "md",
+            [styles.smCheckedBorder]: size === "sm",
           })}
         />
+      ) : (
+        <div className={classnames(sharedStyles, styles.neutralBorder)} />
       )}
       <Typography
         size={size === "md" ? 200 : 100}

--- a/packages/syntax-core/src/useFocusVisible.test.tsx
+++ b/packages/syntax-core/src/useFocusVisible.test.tsx
@@ -1,0 +1,40 @@
+import { screen, render } from "@testing-library/react";
+import useFocusVisible from "./useFocusVisible";
+import { expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+
+const TestInput = () => {
+  const { isFocusVisible } = useFocusVisible();
+  return (
+    <>
+      <input
+        type="checkbox"
+        id="checkboxId"
+        name="checkboxName"
+        data-testid="syntax-custom-checkbox-input"
+      />
+      <p data-testid="syntax-is-focus-visible">
+        {isFocusVisible ? "true" : "false"}
+      </p>
+    </>
+  );
+};
+
+describe("useFocusVisible", () => {
+  it("do not focus when a user clicks on the component", async () => {
+    render(<TestInput />);
+    const checkboxInput = screen.getByTestId("syntax-custom-checkbox-input");
+    const isFocusVisible = screen.getByTestId("syntax-is-focus-visible");
+    // eslint-disable-next-line testing-library/no-await-sync-events
+    await userEvent.click(checkboxInput);
+    expect(isFocusVisible).toHaveTextContent("false");
+  });
+
+  it("focus when a user uses a keyboard to select the component", async () => {
+    render(<TestInput />);
+    const isFocusVisible = screen.getByTestId("syntax-is-focus-visible");
+    // eslint-disable-next-line testing-library/no-await-sync-events
+    await userEvent.keyboard("{Tab}");
+    expect(isFocusVisible).toHaveTextContent("true");
+  });
+});

--- a/packages/syntax-core/src/useFocusVisible.tsx
+++ b/packages/syntax-core/src/useFocusVisible.tsx
@@ -1,0 +1,130 @@
+// Portions of the code in this file are based on code from react & react-spectrum:
+// https://github.com/facebook/react/blob/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+// https://github.com/adobe/react-spectrum/blob/c700898916bbd076bcc63e49d77c16d80623a8e7/packages/@react-aria/interactions/src/useFocusVisible.ts
+
+import { useState, useEffect } from "react";
+
+type Modality = "keyboard" | "pointer";
+type HandlerEvent = PointerEvent | MouseEvent | KeyboardEvent | FocusEvent;
+type Handler = (modality: Modality, e: HandlerEvent) => void;
+
+let hasSetupGlobalListeners = false;
+let currentModality: Modality | null = null;
+const changeHandlers = new Set<Handler>();
+let hasEventBeforeFocus = false;
+
+const isMac =
+  typeof window !== "undefined" && window.navigator != null
+    ? /^Mac/.test(window.navigator.platform)
+    : false;
+
+function isValidKey(e: KeyboardEvent) {
+  return !(e.metaKey || (!isMac && e.altKey) || e.ctrlKey);
+}
+
+function triggerChangeHandlers(modality: Modality, e: HandlerEvent) {
+  changeHandlers.forEach((handler) => {
+    handler(modality, e);
+  });
+}
+
+function handleKeyboardEvent(e: KeyboardEvent) {
+  hasEventBeforeFocus = true;
+  if (isValidKey(e)) {
+    currentModality = "keyboard";
+    triggerChangeHandlers("keyboard", e);
+  }
+}
+
+function handlePointerEvent(e: PointerEvent | MouseEvent) {
+  currentModality = "pointer";
+  if (e.type === "mousedown" || e.type === "pointerdown") {
+    hasEventBeforeFocus = true;
+    triggerChangeHandlers("pointer", e);
+  }
+}
+
+function handleFocusEvent(e: FocusEvent) {
+  // Firefox fires two extra focus events when the user first clicks into an iframe:
+  // first on the window, then on the document. We ignore these events so they don't
+  // cause keyboard focus rings to appear.
+  if (e.target === window || e.target === document) {
+    return;
+  }
+
+  // If a focus event occurs without a preceding keyboard or pointer event, switch to keyboard modality.
+  // This occurs, for example, when navigating a form with the next/previous buttons on iOS.
+  if (!hasEventBeforeFocus) {
+    currentModality = "keyboard";
+    triggerChangeHandlers("keyboard", e);
+  }
+
+  hasEventBeforeFocus = false;
+}
+
+function handleWindowBlur() {
+  // When the window is blurred, reset state. This is necessary when tabbing out of the window,
+  // for example, since a subsequent focus event won't be fired.
+  hasEventBeforeFocus = false;
+}
+
+function isFocusVisible(): boolean {
+  return currentModality !== "pointer";
+}
+
+function setupGlobalFocusEvents() {
+  if (typeof window === "undefined" || hasSetupGlobalListeners) {
+    return;
+  }
+
+  // Programmatic focus() calls shouldn't affect the current input modality.
+  // However, we need to detect other cases when a focus event occurs without
+  // a preceding user event (e.g. screen reader focus). Overriding the focus
+  // method on HTMLElement.prototype is a bit hacky, but works.
+  // $FlowExpectedError[method-unbinding]
+  const { focus } = HTMLElement.prototype;
+  // $FlowIssue[cannot-write]
+  HTMLElement.prototype.focus = function focusElement(...args) {
+    hasEventBeforeFocus = true;
+    focus.apply(this, args);
+  };
+
+  document.addEventListener("keydown", handleKeyboardEvent, true);
+  document.addEventListener("keyup", handleKeyboardEvent, true);
+
+  // Register focus events on the window so they are sure to happen
+  // before React's event listeners (registered on the document).
+  window.addEventListener("focus", handleFocusEvent, true);
+  window.addEventListener("blur", handleWindowBlur, false);
+
+  if (typeof PointerEvent !== "undefined") {
+    document.addEventListener("pointerdown", handlePointerEvent, true);
+    document.addEventListener("pointermove", handlePointerEvent, true);
+    document.addEventListener("pointerup", handlePointerEvent, true);
+  } else {
+    document.addEventListener("mousedown", handlePointerEvent, true);
+    document.addEventListener("mousemove", handlePointerEvent, true);
+    document.addEventListener("mouseup", handlePointerEvent, true);
+  }
+
+  hasSetupGlobalListeners = true;
+}
+
+export default function useFocusVisible(): {
+  isFocusVisible: boolean;
+} {
+  setupGlobalFocusEvents();
+  const [isFocusVisibleState, setFocusVisible] = useState(isFocusVisible());
+  useEffect(() => {
+    const handler = () => {
+      setFocusVisible(isFocusVisible());
+    };
+
+    changeHandlers.add(handler);
+    return () => {
+      changeHandlers.delete(handler);
+    };
+  }, []);
+
+  return { isFocusVisible: isFocusVisibleState };
+}

--- a/packages/syntax-core/src/useFocusVisible.tsx
+++ b/packages/syntax-core/src/useFocusVisible.tsx
@@ -82,6 +82,7 @@ function setupGlobalFocusEvents() {
   // a preceding user event (e.g. screen reader focus). Overriding the focus
   // method on HTMLElement.prototype is a bit hacky, but works.
   // $FlowExpectedError[method-unbinding]
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { focus } = HTMLElement.prototype;
   // $FlowIssue[cannot-write]
   HTMLElement.prototype.focus = function focusElement(...args) {


### PR DESCRIPTION
This solves the "use focus styling only when user uses keyboard to select components" rather than using the focus styling when using both keyboard and the mouse cursor

- added in useFocusVisible (from https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/useFocusVisible.js)
      - added in tests for useFocusVisible
- added in `name` field to radio button for proper grouping
- simplified styling for radio button      

