### PR TITLE
Internal: inline design system tokens to avoid unexpected token 'exports' error

### DIFF
--- a/.changeset/late-parrots-approve.md
+++ b/.changeset/late-parrots-approve.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Internal: inline design system tokens to avoid unexpected token 'exports' error

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import {
   ColorBaseDestructive700,
   ColorBaseGray800,
-} from "@cambly/syntax-design-tokens/dist/js/index.js";
+} from "@cambly/syntax-design-tokens";
 import Typography from "../Typography/Typography";
 import styles from "./SelectList.module.css";
 import SelectOption from "./SelectOption";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   entry: ["src/index.tsx"],
   format: ["cjs", "esm"],
   external: ["react", "react-dom"],
+  noExternal: ["@cambly/syntax-design-tokens"],
   sourcemap: true,
   dts: true,
   // ESBuild does not yet support CSS Modules


### PR DESCRIPTION
After 2.2.0 we saw the following error in our frontend code:

```
2:27:18 PM next.1   |  error - /Users/christian/cambly/Cambly-Frontend/node_modules/@cambly/syntax-design-tokens/dist/js/index.js:6
2:27:18 PM next.1   |  export const ColorBaseBlack = "#000000";
2:27:18 PM next.1   |  ^^^^^^
2:27:18 PM next.1   |  SyntaxError: Unexpected token 'export'
```

**Issue**: @cambly/syntax-design-tokens used ES6 `export` statements which weren't supported

**Solution**: Inline @cambly/syntax-design-tokens constants 

![Screenshot 2023-04-05 at 2 26 39 PM](https://user-images.githubusercontent.com/127199/230215828-322158c5-2d56-4d58-97ac-b3058bc57fc0.png)
