### PR TITLE
Box: add rounding=circle

### DIFF
--- a/.changeset/stupid-cows-travel.md
+++ b/.changeset/stupid-cows-travel.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Box: add rounding=circle

--- a/packages/syntax-core/src/Box/Box.module.css
+++ b/packages/syntax-core/src/Box/Box.module.css
@@ -115,6 +115,10 @@
   border-radius: 32px;
 }
 
+.roundingcircle {
+  border-radius: 50%;
+}
+
 .roundingpill {
   border-radius: 999px;
 }

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -270,11 +270,11 @@ export const Responsive: StoryObj<typeof Box> = {
 export const Rounding: StoryObj<typeof Box> = {
   render: () => (
     <Box display="flex" gap={4} flexWrap="wrap">
-      {(["sm", "md", "lg", "xl", "pill"] as const).map((rounding) => (
+      {(["sm", "md", "lg", "xl", "circle", "pill"] as const).map((rounding) => (
         <Box
           key={rounding}
           rounding={rounding}
-          width={100}
+          width={rounding === "pill" ? 200 : 100}
           height={100}
           color="gray300"
           display="flex"

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -301,12 +301,13 @@ export default function Box(props: {
    * * `sm`: 8px
    * * `md`: 12px
    * * `lg`: 16px
-   * * `xl`: 24px
+   * * `xl`: 32px
+   * * `circle`: 50%
    * * `pill`: 999px
    *
    * @defaultValue "none"
    */
-  rounding?: "xl" | "lg" | "md" | "sm" | "pill" | "none";
+  rounding?: "xl" | "lg" | "md" | "sm" | "circle" | "pill" | "none";
   /**
    * The alignment of the box on the cross axis on sm (480px) or larger viewports.
    */


### PR DESCRIPTION
Previously we only had `pill` for rounding but that's confusing if you want to make something a circle:
![image](https://user-images.githubusercontent.com/127199/230643494-07a64718-7875-4ff0-81a4-1c9d144c70cb.png)
