### PR TITLE
Button: update border styles for secondary + destructive secondary.

### DIFF
--- a/.changeset/empty-cups-grow.md
+++ b/.changeset/empty-cups-grow.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Update border stylings for secondary + destructive-secondary

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -102,6 +102,14 @@
   padding-right: 4px;
 }
 
+.secondaryBorder {
+  border: 1px solid var(--color-base-primary-700);
+}
+
+.secondaryDestructiveBorder {
+  border: 1px solid var(--color-base-destructive-700);
+}
+
 @keyframes syntaxButtonLoadingRotate {
   0% {
     transform-origin: 50% 50%;

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -107,9 +107,17 @@ const Button = ({
 }): ReactElement => {
   const contextProps = useContext(ButtonGroupContext);
 
-  const size = contextProps?.size ?? sizeProp;
-  const disabled = contextProps?.disabled ?? disabledProp;
-  const fullWidth = contextProps?.fullWidth ?? fullWidthProp;
+  /**
+   * Using logical OR (||) here instead of nullish coalescing (??)
+   * because we want to be able set the prop to true to enable the prop
+   * See: [When should I use ??  vs ||](https://stackoverflow.com/questions/61480993/when-should-i-use-nullish-coalescing-vs-logical-or)
+   */
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const size = contextProps?.size || sizeProp;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const disabled = contextProps?.disabled || disabledProp;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const fullWidth = contextProps?.fullWidth || fullWidthProp;
 
   return (
     <button

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -107,9 +107,9 @@ const Button = ({
 }): ReactElement => {
   const contextProps = useContext(ButtonGroupContext);
 
-  const size = contextProps?.size || sizeProp;
-  const disabled = contextProps?.disabled || disabledProp;
-  const fullWidth = contextProps?.fullWidth || fullWidthProp;
+  const size = contextProps?.size ?? sizeProp;
+  const disabled = contextProps?.disabled ?? disabledProp;
+  const fullWidth = contextProps?.fullWidth ?? fullWidthProp;
 
   return (
     <button
@@ -126,6 +126,9 @@ const Button = ({
         {
           [styles.fullWidth]: fullWidth,
           [styles.buttonGap]: size === "lg" || size === "md",
+          [styles.secondaryBorder]: color === "secondary",
+          [styles.secondaryDestructiveBorder]:
+            color === "destructive-secondary",
         },
       )}
     >


### PR DESCRIPTION
# Updating Border Styles for secondary + destructive secondary to match new figma designs:


## After SS:
![image](https://user-images.githubusercontent.com/15243713/231001705-eb9135a5-85ee-4ee9-b47e-e7dfe9ed67a9.png)
![image](https://user-images.githubusercontent.com/15243713/231001711-b8421f5d-d66f-4ecc-9dd9-692faea83dd4.png)


## Before SS:
![image](https://user-images.githubusercontent.com/15243713/231001819-848eedcb-d62c-46f3-a782-57265f1aa0ac.png)
![image](https://user-images.githubusercontent.com/15243713/231001825-47e20cd9-eb49-4247-96bc-98e004a043ca.png)
