### PR TITLE
Divider: allow key to be set as a prop

### DIFF
--- a/.changeset/twelve-hotels-approve.md
+++ b/.changeset/twelve-hotels-approve.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Divider: allow 'key' as a prop

--- a/packages/syntax-core/src/Divider/Divider.test.tsx
+++ b/packages/syntax-core/src/Divider/Divider.test.tsx
@@ -8,6 +8,11 @@ describe("divider", () => {
     expect(baseElement).toBeTruthy();
   });
 
+  it("allow key to be set on Divider", () => {
+    const { baseElement } = render(<Divider key="divider-key" />);
+    expect(baseElement).toBeTruthy();
+  });
+
   it("renders an role=separator element", async () => {
     render(<Divider />);
     const separator = await screen.findAllByRole("separator");

--- a/packages/syntax-core/src/Divider/Divider.tsx
+++ b/packages/syntax-core/src/Divider/Divider.tsx
@@ -3,7 +3,7 @@ import styles from "./Divider.module.css";
 /**
  * Divider is a thin horizontal line to group content in lists and layouts.
  */
-export default function Divider({}: Record<string, never>) {
+export default function Divider(): React.ReactElement {
   return <hr className={styles.divider} />;
 }
 


### PR DESCRIPTION
# Changes

Allow `key` to be set as a prop on `<Divider />`

# Why

Any React component should accept `key` as a prop, otherwise we always have to wrap it if we use it in a list