### PR TITLE
Box: Add flex-shrink

### DIFF
--- a/.changeset/eighty-socks-drive.md
+++ b/.changeset/eighty-socks-drive.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+button: Horizontally align text

--- a/.changeset/eighty-socks-drive.md
+++ b/.changeset/eighty-socks-drive.md
@@ -2,4 +2,4 @@
 "@cambly/syntax-core": minor
 ---
 
-button: Horizontally align text
+box: Add flexShrink

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -124,17 +124,16 @@ export default function Box(props: {
    */
   display?: Display;
   /**
+   *  If the size of all flex items is larger than the flex container, items shrink to fit according to flex-shrink
+   *
+   */
+  flexShrink?: number;
+  /**
    * By default, flex items will all try to fit onto one line. But if you specify `flexWrap="wrap"`, the flex items will wrap onto multiple lines.
    *
    * @defaultValue `nowrap`
    */
   flexWrap?: "wrap" | "nowrap";
-  /**
-   *  If the size of all flex items is larger than the flex container, items shrink to fit according to flex-shrink
-   *
-   * @defaultValue `nowrap`
-   */
-  flexShrink?: number;
   /**
    * The gap between the children of the box.
    */
@@ -381,8 +380,8 @@ export default function Box(props: {
     display,
     smDisplay,
     lgDisplay,
-    flexWrap,
     flexShrink,
+    flexWrap,
     gap,
     justifyContent,
     smJustifyContent,
@@ -511,13 +510,13 @@ export default function Box(props: {
       rounding && rounding !== "none" && styles[`rounding${rounding}`],
     ),
     style: {
+      flexShrink,
       height,
       maxHeight,
       maxWidth,
       minHeight,
       minWidth,
       width,
-      flexShrink,
       ...(dangerouslySetInlineStyle?.__style ?? {}),
     },
   };

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -130,6 +130,12 @@ export default function Box(props: {
    */
   flexWrap?: "wrap" | "nowrap";
   /**
+   *  If the size of all flex items is larger than the flex container, items shrink to fit according to flex-shrink
+   *
+   * @defaultValue `nowrap`
+   */
+  flexShrink?: number;
+  /**
    * The gap between the children of the box.
    */
   gap?: Gap;
@@ -376,6 +382,7 @@ export default function Box(props: {
     smDisplay,
     lgDisplay,
     flexWrap,
+    flexShrink,
     gap,
     justifyContent,
     smJustifyContent,
@@ -510,6 +517,7 @@ export default function Box(props: {
       minHeight,
       minWidth,
       width,
+      flexShrink,
       ...(dangerouslySetInlineStyle?.__style ?? {}),
     },
   };

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -98,7 +98,6 @@
 }
 
 .textContainer {
-  flex-shrink: 0;
   padding-left: 4px;
   padding-right: 4px;
 }

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -98,6 +98,7 @@
 }
 
 .textContainer {
+  flex-shrink: 0;
   padding-left: 4px;
   padding-right: 4px;
 }


### PR DESCRIPTION
For certain languages, the text inside of `Button` was stacking. Adding flex-shrink 0 fixes the issue

Before:
![image](https://user-images.githubusercontent.com/24359288/233742888-4e867f70-db0d-45b5-b601-ff657ad2ef4f.png)

After:
<img width="1722" alt="Screenshot 2023-04-21 at 3 14 19 PM" src="https://user-images.githubusercontent.com/24359288/233742920-3bdc3d3f-6639-463c-9bcc-f90054775098.png">
