### PR TITLE
Typography: Add lineClamp

### DIFF
--- a/.changeset/soft-dryers-tease.md
+++ b/.changeset/soft-dryers-tease.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add lineClamp to Typography

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -82,3 +82,11 @@
 .uppercase {
   text-transform: uppercase;
 }
+
+.lineClamp {
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  max-width: 100%;
+  overflow: hidden;
+  word-break: break-word;
+}

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -36,6 +36,9 @@ export default {
     inline: {
       control: "boolean",
     },
+    lineClamp: {
+      control: { type: "number", min: 0, max: 10, step: 1 },
+    },
     size: {
       options: [100, 200, 300, 500, 600, 700, 800],
       control: { type: "radio" },

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -30,6 +30,7 @@ const Typography = ({
   children,
   color = "gray900",
   inline = false,
+  lineClamp,
   size = 200,
   tooltip,
   transform = "none",
@@ -66,6 +67,12 @@ const Typography = ({
    * @defaultValue false
    */
   inline?: boolean;
+  /**
+   * The number of lines we should truncate the text at
+   *
+   * @defaultValue null
+   */
+  lineClamp?: number;
   /**
    * Size of the text.
    *
@@ -116,7 +123,11 @@ const Typography = ({
         styles[`size${size}`],
         transform === "uppercase" && styles.uppercase,
         underline && styles.underline,
+        lineClamp != null && styles.lineClamp,
       )}
+      style={{
+        WebkitLineClamp: lineClamp,
+      }}
       title={tooltip}
     >
       {children}

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -69,8 +69,6 @@ const Typography = ({
   inline?: boolean;
   /**
    * The number of lines we should truncate the text at
-   *
-   * @defaultValue null
    */
   lineClamp?: number | undefined;
   /**

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -30,7 +30,7 @@ const Typography = ({
   children,
   color = "gray900",
   inline = false,
-  lineClamp,
+  lineClamp = undefined,
   size = 200,
   tooltip,
   transform = "none",
@@ -72,7 +72,7 @@ const Typography = ({
    *
    * @defaultValue null
    */
-  lineClamp?: number;
+  lineClamp?: number | undefined;
   /**
    * Size of the text.
    *


### PR DESCRIPTION
This PR adds a `lineClamp` property to `Typography` to allow us to truncate the text at a specified number of lines

<img width="694" alt="Screenshot 2023-05-01 at 4 23 42 PM" src="https://user-images.githubusercontent.com/24359288/235548237-fbc90a3f-7da2-455a-86e8-b38084480639.png">
