### PR TITLE
Box: pass through 'role' attribute

### DIFF
--- a/.changeset/fuzzy-foxes-smile.md
+++ b/.changeset/fuzzy-foxes-smile.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Box: pass through 'role' prop

--- a/packages/syntax-core/src/Box/Box.test.tsx
+++ b/packages/syntax-core/src/Box/Box.test.tsx
@@ -11,7 +11,12 @@ describe("box", () => {
 
   it("passes trough certain props", () => {
     render(
-      <Box aria-labelledby="other-element" data-testid="testId" id="id">
+      <Box
+        aria-labelledby="other-element"
+        data-testid="testId"
+        id="id"
+        role="dialog"
+      >
         Test
       </Box>,
     );
@@ -19,6 +24,8 @@ describe("box", () => {
     const box = screen.getByTestId("testId");
     expect(box).toBeInTheDocument();
     expect(box.getAttribute("aria-labelledby")).toBe("other-element");
+    expect(box.getAttribute("data-testid")).toBe("testId");
+    expect(box.getAttribute("role")).toBe("dialog");
     expect(box.getAttribute("id")).toBe("id");
   });
 

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { ReactElement, ReactNode } from "react";
+import { type AriaRole, ReactElement, ReactNode } from "react";
 import styles from "./Box.module.css";
 import marginStyles from "./margin.module.css";
 import paddingStyles from "./padding.module.css";
@@ -300,6 +300,12 @@ export default function Box(props: {
    */
   position?: "absolute" | "fixed" | "relative" | "static" | "sticky";
   /**
+   * The role attribute of the box.
+   *
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) for the list of valid roles.
+   */
+  role?: AriaRole;
+  /**
    * Border radius of the box.
    *
    * * `none`: 0px
@@ -526,6 +532,7 @@ export default function Box(props: {
   >((acc, [key]) => {
     if (
       key === "id" ||
+      key === "role" ||
       key.startsWith("aria-") ||
       key.startsWith("data-testid")
     ) {


### PR DESCRIPTION
# Changes

Pass through `role` attribute on `Box`

# Why

Helps with `Box` adoption and ensuring we have all accessibility attributes available