### PR TITLE
Internal: enable a few more TypeScript ESLint rules

### DIFF
--- a/.changeset/popular-plants-talk.md
+++ b/.changeset/popular-plants-talk.md
@@ -1,0 +1,7 @@
+---
+"@cambly/eslint-config-syntax": patch
+"@cambly/syntax-codemods": patch
+"@cambly/syntax-core": patch
+---
+
+Internal: enable a few more TypeScript ESLint rules

--- a/packages/eslint-config-syntax/index.js
+++ b/packages/eslint-config-syntax/index.js
@@ -20,8 +20,19 @@ module.exports = {
         "plugin:@typescript-eslint/strict",
       ],
       rules: {
+        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/consistent-type-imports": [
+          "error",
+          { fixStyle: "inline-type-imports" },
+        ],
+        "@typescript-eslint/explicit-module-boundary-types": "error",
+        "@typescript-eslint/no-empty-function": "error",
         "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/no-shadow": "error",
         "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-use-before-define": "error",
+        "@typescript-eslint/no-var-requires": "error",
+        "@typescript-eslint/prefer-ts-expect-error": "error",
       },
     },
     {

--- a/packages/syntax-codemods/src/run-js-codeshift.ts
+++ b/packages/syntax-codemods/src/run-js-codeshift.ts
@@ -4,7 +4,7 @@ export default function runJscodeshift(
   transformerPath: string,
   flags: Record<string, unknown>,
   files: string[],
-) {
+): ReturnType<typeof Runner.run> {
   return Runner.run(transformerPath, files, {
     ignorePattern: ["**/node_modules/**", "**/dist/**"],
     extensions: "tsx,ts,jsx,js",

--- a/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/base.input.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/base.input.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { Box } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
 
-export default function Example() {
+export default function Example(): ReactElement {
   const color = "red";
   return (
     <>

--- a/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/base.output.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/base.output.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { Box } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
 
-export default function Example() {
+export default function Example(): ReactElement {
   const color = "red";
   return (
     <>

--- a/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/full.input.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/full.input.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 
 import { Box, Typography } from "@cambly/syntax-core";
 

--- a/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/full.output.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/box-color-to-backgroundcolor/full.output.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 
 import { Box, Typography } from "@cambly/syntax-core";
 

--- a/packages/syntax-codemods/src/transforms/__fixtures__/box-rounding-to-full/base.input.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/box-rounding-to-full/base.input.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { Box } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
 
-export default function Example() {
+export default function Example(): ReactElement {
   return (
     <>
       <Box rounding="sm" />

--- a/packages/syntax-codemods/src/transforms/__fixtures__/box-rounding-to-full/base.output.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/box-rounding-to-full/base.output.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { Box } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
 
-export default function Example() {
+export default function Example(): ReactElement {
   return (
     <>
       <Box rounding="sm" />

--- a/packages/syntax-codemods/src/transforms/__tests__/box-color-to-backgroundcolor.test.ts
+++ b/packages/syntax-codemods/src/transforms/__tests__/box-color-to-backgroundcolor.test.ts
@@ -49,6 +49,14 @@ describe("box-color-to-backgroundcolor", () => {
       },
     });
 
-    expect(format(String(output))).toStrictEqual(format(outputCode));
+    expect(
+      format(String(output), {
+        parser: "babel",
+      }),
+    ).toStrictEqual(
+      format(outputCode, {
+        parser: "babel",
+      }),
+    );
   });
 });

--- a/packages/syntax-codemods/src/transforms/__tests__/box-rounding-to-full.test.ts
+++ b/packages/syntax-codemods/src/transforms/__tests__/box-rounding-to-full.test.ts
@@ -49,6 +49,14 @@ describe("box-rounding-to-full", () => {
       },
     });
 
-    expect(format(String(output))).toStrictEqual(format(outputCode));
+    expect(
+      format(String(output), {
+        parser: "babel",
+      }),
+    ).toStrictEqual(
+      format(outputCode, {
+        parser: "babel",
+      }),
+    );
   });
 });

--- a/packages/syntax-codemods/src/transforms/box-color-to-backgroundcolor.ts
+++ b/packages/syntax-codemods/src/transforms/box-color-to-backgroundcolor.ts
@@ -1,8 +1,11 @@
-import { API, FileInfo } from "jscodeshift";
+import { type API, type FileInfo } from "jscodeshift";
 
 export const parser = "tsx";
 
-export default function transformer(fileInfo: FileInfo, api: API) {
+export default function transformer(
+  fileInfo: FileInfo,
+  api: API,
+): string | null {
   const j = api.jscodeshift;
   const src = j(fileInfo.source);
 

--- a/packages/syntax-codemods/src/transforms/box-rounding-to-full.ts
+++ b/packages/syntax-codemods/src/transforms/box-rounding-to-full.ts
@@ -3,11 +3,14 @@
 // to
 // <Box rounding="full" />.
 
-import { API, FileInfo } from "jscodeshift";
+import { type API, type FileInfo } from "jscodeshift";
 
 export const parser = "tsx";
 
-export default function transformer(fileInfo: FileInfo, api: API) {
+export default function transformer(
+  fileInfo: FileInfo,
+  api: API,
+): string | null {
   const j = api.jscodeshift;
   const src = j(fileInfo.source);
 

--- a/packages/syntax-core/src/Avatar/Avatar.stories.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Avatar from "./Avatar";
 import image from "../../../../apps/storybook/assets/images/jane.webp";
 

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import allColors from "../colors/allColors";
 import Box from "./Box";
 import Typography from "../Typography/Typography";

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -1,9 +1,9 @@
 import classNames from "classnames";
-import { type AriaRole, ReactElement, ReactNode } from "react";
+import { type AriaRole, type ReactElement, type ReactNode } from "react";
 import styles from "./Box.module.css";
 import marginStyles from "./margin.module.css";
 import paddingStyles from "./padding.module.css";
-import allColors from "../colors/allColors";
+import type allColors from "../colors/allColors";
 import colorStyles from "../colors/colors.module.css";
 import { forwardRef } from "react";
 

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Button from "./Button";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
 import backgroundColor from "../colors//backgroundColor";
 import foregroundColor from "../colors/foregroundColor";
-import React, { ReactElement } from "react";
-import { Color, Size } from "../constants";
+import React, { type ReactElement } from "react";
+import { type Color, type Size } from "../constants";
 import styles from "./Button.module.css";
 
 const textVariant = {

--- a/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
@@ -1,6 +1,6 @@
-import { ReactElement, ReactNode } from "react";
+import { type ReactElement, type ReactNode } from "react";
 import styles from "./ButtonGroup.module.css";
-import { Size } from "../constants";
+import { type Size } from "../constants";
 import classNames from "classnames";
 
 const gap = {

--- a/packages/syntax-core/src/ButtonGroup/Buttongroup.stories.tsx
+++ b/packages/syntax-core/src/ButtonGroup/Buttongroup.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import ButtonGroup from "./ButtonGroup";
 import Button from "../Button/Button";
 

--- a/packages/syntax-core/src/Card/Card.stories.tsx
+++ b/packages/syntax-core/src/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Card from "./Card";
 import Box from "../Box/Box";
 import Heading from "../Heading/Heading";

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Checkbox from "./Checkbox";
 import React, { useState } from "react";
 

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from "react";
+import React, { type ReactElement, useState } from "react";
 import classNames from "classnames";
 import useFocusVisible from "../useFocusVisible";
 import styles from "./Checkbox.module.css";

--- a/packages/syntax-core/src/Divider/Divider.stories.tsx
+++ b/packages/syntax-core/src/Divider/Divider.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Divider from "./Divider";
 
 export default {

--- a/packages/syntax-core/src/Heading/Heading.stories.tsx
+++ b/packages/syntax-core/src/Heading/Heading.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Heading from "./Heading";
 
 export default {

--- a/packages/syntax-core/src/Heading/Heading.tsx
+++ b/packages/syntax-core/src/Heading/Heading.tsx
@@ -1,5 +1,5 @@
-import { ReactElement, ReactNode } from "react";
-import { Color } from "../constants";
+import { type ReactElement, type ReactNode } from "react";
+import { type Color } from "../constants";
 import Typography from "../Typography/Typography";
 /**
  * Heading enforces a consistent style & accessibility best practices for headings.

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import IconButton from "./IconButton";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import Star from "@mui/icons-material/Star";

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
 import backgroundColor from "../colors//backgroundColor";
 import foregroundColor from "../colors/foregroundColor";
-import React, { ReactElement } from "react";
-import { Color, Size } from "../constants";
+import React, { type ReactElement } from "react";
+import { type Color, type Size } from "../constants";
 import styles from "./IconButton.module.css";
 
 const iconSize = {

--- a/packages/syntax-core/src/MiniActionCard/MiniActionCard.stories.tsx
+++ b/packages/syntax-core/src/MiniActionCard/MiniActionCard.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import MiniActionCard from "./MiniActionCard";
 import image from "../../../../apps/storybook/assets/images/book.svg";
 

--- a/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import RadioButton from "./RadioButton";
 import React, { useState } from "react";
 

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from "react";
+import React, { type ReactElement, useState } from "react";
 import classnames from "classnames";
 
 import styles from "./RadioButton.module.css";

--- a/packages/syntax-core/src/SelectList/SelectList.stories.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.stories.tsx
@@ -1,6 +1,6 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import SelectList from "./SelectList";
-import React, { useState, ReactElement } from "react";
+import React, { useState, type ReactElement } from "react";
 import SelectOption from "./SelectOption";
 
 export default {

--- a/packages/syntax-core/src/SelectList/SelectList.test.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.test.tsx
@@ -4,27 +4,6 @@ import { expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
-const InteractiveSelectDropdown = ({
-  numberOfOptions,
-  handleChange,
-}: {
-  numberOfOptions: number;
-  handleChange: (value: string) => void;
-}) => {
-  const [selectedValue, setSelectedValue] = useState("");
-  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    handleChange(e.target.value);
-    setSelectedValue(e.target.value);
-  };
-  return (
-    <SelectDropdown
-      onChange={onChange}
-      selectedValue={selectedValue}
-      numberOfOptions={numberOfOptions}
-    />
-  );
-};
-
 const SelectDropdown = ({
   numberOfOptions,
   onChange,
@@ -49,6 +28,27 @@ const SelectDropdown = ({
         <SelectList.Option key={value} value={value} label={label} />
       ))}
     </SelectList>
+  );
+};
+
+const InteractiveSelectDropdown = ({
+  numberOfOptions,
+  handleChange,
+}: {
+  numberOfOptions: number;
+  handleChange: (value: string) => void;
+}) => {
+  const [selectedValue, setSelectedValue] = useState("");
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    handleChange(e.target.value);
+    setSelectedValue(e.target.value);
+  };
+  return (
+    <SelectDropdown
+      onChange={onChange}
+      selectedValue={selectedValue}
+      numberOfOptions={numberOfOptions}
+    />
   );
 };
 

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -1,4 +1,9 @@
-import React, { ReactElement, ReactNode, useId, useState } from "react";
+import React, {
+  type ReactElement,
+  type ReactNode,
+  useId,
+  useState,
+} from "react";
 import classNames from "classnames";
 import {
   ColorBaseDestructive700,

--- a/packages/syntax-core/src/SelectList/SelectOption.tsx
+++ b/packages/syntax-core/src/SelectList/SelectOption.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 
 const SelectOption = ({
   value,

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryObj, Meta } from "@storybook/react";
+import { type StoryObj, type Meta } from "@storybook/react";
 import Typography from "./Typography";
 
 export default {

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
-import { ReactElement, ReactNode } from "react";
-import { Color } from "../constants";
+import { type ReactElement, type ReactNode } from "react";
+import { type Color } from "../constants";
 import styles from "./Typography.module.css";
 import colorStyles from "../colors/colors.module.css";
 

--- a/packages/syntax-core/src/colors/backgroundColor.ts
+++ b/packages/syntax-core/src/colors/backgroundColor.ts
@@ -1,4 +1,4 @@
-import { Color } from "../constants";
+import { type Color } from "../constants";
 import styles from "./colors.module.css";
 
 export default function backgroundColor(color: (typeof Color)[number]): string {

--- a/packages/syntax-core/src/colors/foregroundColor.ts
+++ b/packages/syntax-core/src/colors/foregroundColor.ts
@@ -1,4 +1,4 @@
-import { Color } from "../constants";
+import { type Color } from "../constants";
 import styles from "./colors.module.css";
 
 export default function foregroundColor(color: (typeof Color)[number]): string {


### PR DESCRIPTION
# Changes

* Enables a few more TypeScript ESLint rules to enforce consistent type imports / explicit boundaries and only use functions after they have been defined