### PR TITLE
Box: remove flexShrink property and introduce flex property instead

### DIFF
--- a/.changeset/perfect-dodos-call.md
+++ b/.changeset/perfect-dodos-call.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+Box: remove flexShrink property and introduce flex property instead

--- a/packages/syntax-core/src/Box/Box.module.css
+++ b/packages/syntax-core/src/Box/Box.module.css
@@ -2,6 +2,14 @@
   box-sizing: border-box;
 }
 
+.flexnone {
+  flex: 0 0 auto;
+}
+
+.flexgrow {
+  flex: 1 1 auto;
+}
+
 .flexWrap {
   flex-wrap: wrap;
 }

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -2,6 +2,8 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import allColors from "../colors/allColors";
 import Box from "./Box";
 import Typography from "../Typography/Typography";
+import Button from "../Button/Button";
+import Heading from "../Heading/Heading";
 
 export default {
   title: "Components/Box",
@@ -46,6 +48,10 @@ export default {
     },
     dangerouslySetInlineStyle: {
       control: { type: "object" },
+    },
+    flex: {
+      control: { type: "radio" },
+      options: ["grow", "shrink", "none"],
     },
     flexWrap: {
       options: ["wrap", "nowrap"],
@@ -323,6 +329,66 @@ export const Rounding: StoryObj<typeof Box> = {
           </Typography>
         </Box>
       ))}
+    </Box>
+  ),
+};
+
+export const Flex: StoryObj<typeof Box> = {
+  render: () => (
+    <Box display="flex" direction="column" gap={4}>
+      <Box>
+        <Heading>Default</Heading>
+
+        <Box display="flex" gap={2}>
+          <Box>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur.
+            </Typography>
+          </Box>
+
+          <Box>
+            <Button
+              onClick={() => {
+                /* empty */
+              }}
+              text="Go back"
+            ></Button>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box>
+        <Heading>
+          flex=&quot;none&quot; on Box wrapping the &lt;Button /&gt;;
+        </Heading>
+
+        <Box display="flex" gap={2}>
+          <Box>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur.
+            </Typography>
+          </Box>
+
+          <Box flex="none">
+            <Button
+              onClick={() => {
+                /* empty */
+              }}
+              text="Go back"
+            ></Button>
+          </Box>
+        </Box>
+      </Box>
     </Box>
   ),
 };

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -126,10 +126,15 @@ export default forwardRef<
      */
     display?: Display;
     /**
-     *  If the size of all flex items is larger than the flex container, items shrink to fit according to flex-shrink
+     * Sets the flex behavior of a flex item.
      *
+     * * `none`: The item will not grow or shrink
+     * * `shrink`: The item will shrink if necessary (default browser behavior)
+     * * `grow`: The item will grow if necessary
+     *
+     * @defaultValue `shrink`
      */
-    flexShrink?: number;
+    flex?: "none" | "shrink" | "grow";
     /**
      * By default, flex items will all try to fit onto one line. But if you specify `flexWrap="wrap"`, the flex items will wrap onto multiple lines.
      *
@@ -389,7 +394,7 @@ export default forwardRef<
     display,
     smDisplay,
     lgDisplay,
-    flexShrink,
+    flex,
     flexWrap,
     gap,
     justifyContent,
@@ -448,6 +453,7 @@ export default forwardRef<
       display && styles[display],
       smDisplay && styles[`${smDisplay}Small`],
       lgDisplay && styles[`${lgDisplay}Large`],
+      flex && (flex === "none" || flex === "grow") && styles[`flex${flex}`],
       flexWrap && styles.flexWrap,
       gap != null && styles[`gap${gap}`],
       margin != null && !marginBottom && marginStyles[`marginBottom${margin}`],
@@ -519,7 +525,6 @@ export default forwardRef<
       rounding && rounding !== "none" && styles[`rounding${rounding}`],
     ),
     style: {
-      flexShrink,
       height,
       maxHeight,
       maxWidth,


### PR DESCRIPTION
# Changes

* Remove `flexShrink` property on `<Box />`
* Introduce `flex` property on `<Box />`
* Add example to showcase the new property

# Notes

* If we previously did `flexShrink={0}`, we should now use `flex="none"` instead
* This is a breaking change so we'll need to make changes in Cambly-Frontend when performing the Syntax upgrade

# Example
![image](https://github.com/Cambly/syntax/assets/127199/13f24e79-87ed-47a8-adbc-79a8aa177898)
