### PR TITLE
Button/Checkbox/IconButton/RadioButton/SelectList: add data-testid

### DIFF
--- a/.changeset/two-garlics-appear.md
+++ b/.changeset/two-garlics-appear.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add data-testid

--- a/packages/syntax-core/src/Button/Button.test.tsx
+++ b/packages/syntax-core/src/Button/Button.test.tsx
@@ -70,4 +70,17 @@ describe("button", () => {
     await userEvent.click(button[0]);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it("sets the data-testid", () => {
+    const handleClick = vi.fn();
+    render(
+      <Button
+        data-testid="button-test-id"
+        onClick={handleClick}
+        text="Continue"
+        accessibilityLabel="Continue to the next step"
+      />,
+    );
+    expect(screen.getByTestId("button-test-id")).toBeInTheDocument();
+  });
 });

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -26,6 +26,10 @@ const iconSize = {
 
 type ButtonType = {
   /**
+   * Test id for the button
+   */
+  "data-testid"?: string;
+  /**
    * The text to be displayed inside the button
    */
   text: string;
@@ -92,6 +96,7 @@ type ButtonType = {
 const Button = forwardRef<HTMLButtonElement, ButtonType>(
   (
     {
+      "data-testid": dataTestId,
       text,
       loadingText,
       color = "primary",
@@ -109,6 +114,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonType>(
   ) => {
     return (
       <button
+        data-testid={dataTestId}
         ref={ref}
         aria-label={accessibilityLabel}
         type="button"

--- a/packages/syntax-core/src/Checkbox/Checkbox.test.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.test.tsx
@@ -30,6 +30,18 @@ describe("checkbox", () => {
     await userEvent.click(checkbox);
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
+  it("sets the data-testid correctly", () => {
+    const handleChange = vi.fn();
+    render(
+      <Checkbox
+        data-testid="checkbox-test-id"
+        checked
+        label="test"
+        onChange={handleChange}
+      />,
+    );
+    expect(screen.getByTestId("checkbox-test-id")).toBeInTheDocument();
+  });
   it("successfully grabs input checked status when clicked", async () => {
     const handleChange = vi.fn();
     render(

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -20,6 +20,7 @@ const iconWidth = {
  */
 const Checkbox = ({
   checked = false,
+  "data-testid": dataTestId,
   disabled = false,
   size = "md",
   label,
@@ -32,6 +33,10 @@ const Checkbox = ({
    * @defaultValue false
    */
   checked: boolean;
+  /**
+   * Test id for the checkbox
+   */
+  "data-testid"?: string;
   /**
    * The callback to be called when the checkbox value changes
    */
@@ -81,6 +86,7 @@ const Checkbox = ({
     <label className={classNames(styles.mainContainer)}>
       <div className={styles.checkboxContainer}>
         <input
+          data-testid={dataTestId}
           type="checkbox"
           className={classNames(styles.inputOverlay, styles[size])}
           checked={checked}

--- a/packages/syntax-core/src/IconButton/IconButton.test.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.test.tsx
@@ -58,4 +58,17 @@ describe("iconButton", () => {
     await userEvent.click(button[0]);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it("sets the data-testid", () => {
+    const handleClick = vi.fn();
+    render(
+      <IconButton
+        data-testid="iconbutton-test-id"
+        onClick={handleClick}
+        icon={Star}
+        accessibilityLabel="Continue to the next step"
+      />,
+    );
+    expect(screen.getByTestId("iconbutton-test-id")).toBeInTheDocument();
+  });
 });

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -19,6 +19,10 @@ type IconButtonType = {
    */
   color?: (typeof Color)[number];
   /**
+   * Test id for the button
+   */
+  "data-testid"?: string;
+  /**
    * The size of the button
    *
    * * `sm`: 32px
@@ -60,6 +64,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonType>(
     {
       accessibilityLabel,
       color = "primary",
+      "data-testid": dataTestId,
       disabled = false,
       icon: Icon,
       size = "md",
@@ -71,6 +76,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonType>(
     return (
       <button
         aria-label={accessibilityLabel}
+        data-testid={dataTestId}
         type="button"
         title={tooltip}
         disabled={disabled}

--- a/packages/syntax-core/src/RadioButton/RadioButton.test.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.test.tsx
@@ -8,6 +8,8 @@ describe("radioButton", () => {
     const { baseElement } = render(
       <RadioButton
         label="Radio Button Label"
+        name="radio-button"
+        value="radio-button-value"
         onChange={() => {
           /* empty */
         }}
@@ -18,7 +20,14 @@ describe("radioButton", () => {
 
   it("fires onChange when clicked", async () => {
     const handleChange = vi.fn();
-    render(<RadioButton label="Radio Button Label" onChange={handleChange} />);
+    render(
+      <RadioButton
+        label="Radio Button Label"
+        name="radio-button"
+        value="radio-button-value"
+        onChange={handleChange}
+      />,
+    );
     const radioButton = await screen.findByLabelText("Radio Button Label");
     // eslint-disable-next-line testing-library/no-await-sync-events
     await userEvent.click(radioButton);
@@ -30,6 +39,8 @@ describe("radioButton", () => {
     render(
       <RadioButton
         checked={true}
+        name="radio-button"
+        value="radio-button-value"
         label="Radio Button Label"
         onChange={handleChange}
       />,
@@ -47,6 +58,8 @@ describe("radioButton", () => {
     render(
       <RadioButton
         checked={false}
+        name="radio-button"
+        value="radio-button-value"
         label="Radio Button Label"
         onChange={handleChange}
       />,
@@ -62,5 +75,20 @@ describe("radioButton", () => {
         }),
       }),
     );
+  });
+
+  it("sets the data-testid", () => {
+    const handleChange = vi.fn();
+    render(
+      <RadioButton
+        checked={false}
+        data-testid="radiobutton-test-id"
+        name="radio-button"
+        value="radio-button-value"
+        label="Radio Button Label"
+        onChange={handleChange}
+      />,
+    );
+    expect(screen.getByTestId("radiobutton-test-id")).toBeInTheDocument();
   });
 });

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -11,6 +11,7 @@ import useFocusVisible from "../useFocusVisible";
  */
 const RadioButton = ({
   checked = false,
+  "data-testid": dataTestId,
   disabled = false,
   error = false,
   label,
@@ -25,6 +26,10 @@ const RadioButton = ({
    * @defaultValue false
    */
   checked?: boolean;
+  /**
+   * Test id for the radio button
+   */
+  "data-testid"?: string;
   /**
    * Whether or not the radio button is disabled
    *
@@ -80,6 +85,7 @@ const RadioButton = ({
       })}
     >
       <input
+        data-testid={dataTestId}
         type="radio"
         name={name}
         className={classnames(styles.radioStyleOverride, {

--- a/packages/syntax-core/src/SelectList/SelectList.test.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.test.tsx
@@ -19,13 +19,19 @@ const SelectDropdown = ({
   }));
   return (
     <SelectList
+      data-testid="syntax-select"
       selectedValue={selectedValue}
       onChange={onChange}
       placeholderText="placeholder"
       label="Select"
     >
       {options.map(({ label, value }) => (
-        <SelectList.Option key={value} value={value} label={label} />
+        <SelectList.Option
+          key={value}
+          value={value}
+          label={label}
+          data-testid={`syntax-select-${value}`}
+        />
       ))}
     </SelectList>
   );
@@ -51,8 +57,6 @@ const InteractiveSelectDropdown = ({
     />
   );
 };
-
-const selectTestId = "syntax-select";
 
 describe("select", () => {
   it("renders successfully", () => {
@@ -93,13 +97,13 @@ describe("select", () => {
     const secondSelectionValue = "2";
     // eslint-disable-next-line testing-library/no-await-sync-events
     await userEvent.selectOptions(
-      screen.getByTestId(selectTestId),
+      screen.getByTestId("syntax-select"),
       firstSelectionValue,
     );
     expect(handleChange).toHaveBeenCalledWith(firstSelectionValue);
     // eslint-disable-next-line testing-library/no-await-sync-events
     await userEvent.selectOptions(
-      screen.getByTestId(selectTestId),
+      screen.getByTestId("syntax-select"),
       secondSelectionValue,
     );
     expect(handleChange).toHaveBeenCalledTimes(2);
@@ -118,20 +122,20 @@ describe("select", () => {
     const secondSelectionValue = "2";
     // eslint-disable-next-line testing-library/no-await-sync-events
     await userEvent.selectOptions(
-      screen.getByTestId(selectTestId),
+      screen.getByTestId("syntax-select"),
       firstSelectionValue,
     );
     const option1 = screen.getByTestId<HTMLOptionElement>(
-      `${selectTestId}-${firstSelectionValue}`,
+      `${"syntax-select"}-${firstSelectionValue}`,
     );
     expect(option1.selected).toBeTruthy();
     // eslint-disable-next-line testing-library/no-await-sync-events
     await userEvent.selectOptions(
-      screen.getByTestId(selectTestId),
+      screen.getByTestId("syntax-select"),
       secondSelectionValue,
     );
     const option2 = screen.getByTestId<HTMLOptionElement>(
-      `${selectTestId}-${secondSelectionValue}`,
+      `${"syntax-select"}-${secondSelectionValue}`,
     );
     expect(option2.selected).toBeTruthy();
     expect(option1.selected).toBeFalsy();

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -23,6 +23,7 @@ const iconSize = {
 
 const SelectList = ({
   children,
+  "data-testid": dataTestId,
   disabled = false,
   errorText,
   helperText,
@@ -36,6 +37,10 @@ const SelectList = ({
    * One or more SelectList.Option components.
    */
   children: ReactNode;
+  /**
+   * Test id for the select element
+   */
+  "data-testid"?: string;
   /**
    * true if the select dropdown is disabled
    * @defaultValue false
@@ -95,7 +100,7 @@ const SelectList = ({
       <div className={styles.selectWrapper}>
         <select
           id={id}
-          data-testid="syntax-select"
+          data-testid={dataTestId}
           disabled={disabled}
           className={classNames(styles.selectBox, styles[size], {
             [styles.unselected]: !selectedValue && !errorText,

--- a/packages/syntax-core/src/SelectList/SelectOption.tsx
+++ b/packages/syntax-core/src/SelectList/SelectOption.tsx
@@ -1,19 +1,17 @@
 import React, { type ReactElement } from "react";
 
 const SelectOption = ({
+  "data-testid": dataTestId,
   value,
   label,
   disabled = false,
 }: {
+  "data-testid"?: string;
   value: string;
   label: string;
   disabled?: boolean;
 }): ReactElement => (
-  <option
-    data-testid={`syntax-select-${value}`}
-    value={value}
-    disabled={disabled}
-  >
+  <option data-testid={dataTestId} value={value} disabled={disabled}>
     {label}
   </option>
 );


### PR DESCRIPTION
# Changes

Add a consistent `data-testid` attribute to our current interactive elements

# Why

Makes it way easier to use these components in tests

# Notes

SelectList previously set its test id to `select-list` but it was always the same an no way to override it