### PR TITLE
SelectList: render helperText when errorText is an empty string

### DIFF
--- a/.changeset/good-lamps-rush.md
+++ b/.changeset/good-lamps-rush.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+SelectList: render helper text when error text is an empty string

--- a/packages/syntax-core/src/SelectList/SelectList.test.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.test.tsx
@@ -140,4 +140,54 @@ describe("select", () => {
     expect(option2.selected).toBeTruthy();
     expect(option1.selected).toBeFalsy();
   });
+
+  it("renders error text when the error text is set", () => {
+    render(
+      <div data-testid="syntax-select-container">
+        <SelectList
+          data-testid="syntax-select"
+          selectedValue=""
+          onChange={vi.fn()}
+          helperText="helper text"
+          errorText={"error text"}
+          label="Select"
+        >
+          <SelectList.Option
+            key={"key"}
+            value={"value"}
+            label={"label"}
+            data-testid={`syntax-select-label`}
+          />
+        </SelectList>
+      </div>,
+    );
+    expect(screen.getByTestId("syntax-select-container").textContent).toContain(
+      "error text",
+    );
+  });
+
+  it("renders helper text when the error text is an empty string", () => {
+    render(
+      <div data-testid="syntax-select-container">
+        <SelectList
+          data-testid="syntax-select"
+          selectedValue=""
+          onChange={vi.fn()}
+          helperText="helper text"
+          errorText={""}
+          label="Select"
+        >
+          <SelectList.Option
+            key={"key"}
+            value={"value"}
+            label={"label"}
+            data-testid={`syntax-select-label`}
+          />
+        </SelectList>
+      </div>,
+    );
+    expect(screen.getByTestId("syntax-select-container").textContent).toContain(
+      "helper text",
+    );
+  });
 });

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -143,7 +143,7 @@ const SelectList = ({
           size={100}
           color={errorText ? "destructive-primary" : "gray700"}
         >
-          {errorText ?? helperText}
+          {errorText ? errorText : helperText}
         </Typography>
       </div>
     </div>


### PR DESCRIPTION
# Changes

* SelectList: render helperText when errorText is an empty string
* Add tests