### PR TITLE
SelectList: remove label as req'd prop

### DIFF
--- a/.changeset/chilled-teachers-double.md
+++ b/.changeset/chilled-teachers-double.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+SelectList: Remove label as required prop

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -58,7 +58,7 @@ const SelectList = ({
   /**
    * Text shown above select box
    */
-  label: string;
+  label?: string;
   /**
    * The callback to be called when an option is selected
    */
@@ -92,11 +92,13 @@ const SelectList = ({
         [styles.opacityOverlay]: disabled,
       })}
     >
-      <label htmlFor={id} className={styles.outerTextContainer}>
-        <Typography size={100} color="gray700">
-          {label}
-        </Typography>
-      </label>
+      {label && (
+        <label htmlFor={id} className={styles.outerTextContainer}>
+          <Typography size={100} color="gray700">
+            {label}
+          </Typography>
+        </label>
+      )}
       <div className={styles.selectWrapper}>
         <select
           id={id}


### PR DESCRIPTION
There are some places where `SelectList` is used, but label isn't. (Like in the NonAuthNavBar).