### PR TITLE
RadioButton declare div before input. Fixes bug when place in a HOC with customized z-index

### DIFF
--- a/.changeset/moody-coats-cheer.md
+++ b/.changeset/moody-coats-cheer.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+fix radio button behavior when z-index is customized such as in a modal

--- a/packages/syntax-core/src/RadioButton/RadioButton.module.css
+++ b/packages/syntax-core/src/RadioButton/RadioButton.module.css
@@ -19,6 +19,7 @@
 .radioStyleOverride {
   opacity: 0;
   margin: 0;
+  cursor: pointer;
 }
 
 .smOverride {

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -89,6 +89,16 @@ const RadioButton = ({
         [styles.mdBase]: size === "md",
       })}
     >
+      {checked ? (
+        <div
+          className={classnames(sharedStyles, {
+            [styles.mdCheckedBorder]: size === "md",
+            [styles.smCheckedBorder]: size === "sm",
+          })}
+        />
+      ) : (
+        <div className={classnames(sharedStyles, styles.neutralBorder)} />
+      )}
       <input
         data-testid={dataTestId}
         type="radio"
@@ -109,16 +119,6 @@ const RadioButton = ({
           setIsFocused(false);
         }}
       />
-      {checked ? (
-        <div
-          className={classnames(sharedStyles, {
-            [styles.mdCheckedBorder]: size === "md",
-            [styles.smCheckedBorder]: size === "sm",
-          })}
-        />
-      ) : (
-        <div className={classnames(sharedStyles, styles.neutralBorder)} />
-      )}
       {label && (
         <Typography
           size={size === "md" ? 200 : 100}


### PR DESCRIPTION
button was not clickable when z-index is customized