### PR TITLE
SelectList: stopPropagation onClick + doc fixes

### DIFF
--- a/.changeset/fluffy-scissors-sit.md
+++ b/.changeset/fluffy-scissors-sit.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+SelectList: stopPropagation onClick

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -32,7 +32,7 @@
   margin: 0;
 }
 
-.seletBoxMouseFocusStyling {
+.selectMouseFocusStyling {
   border: 1px solid var(--color-base-primary-700);
   box-shadow: 0 0 0 1px var(--color-base-primary-700);
 }

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -48,7 +48,6 @@ const SelectList = ({
   disabled?: boolean;
   /**
    * Text shown below select box if there is an input error.
-   * Should only have a value if error = true
    */
   errorText?: string;
   /**
@@ -110,9 +109,10 @@ const SelectList = ({
             [styles.selectError]: errorText,
             [focusStyles.accessibilityOutlineFocus]:
               isFocused && isFocusVisible, // for focus keyboard
-            [styles.seletBoxMouseFocusStyling]: isFocused && !isFocusVisible, // for focus mouse
+            [styles.selectMouseFocusStyling]: isFocused && !isFocusVisible, // for focus mouse
           })}
           onChange={onChange}
+          onClick={(e) => e.stopPropagation()}
           value={
             placeholderText && !selectedValue ? placeholderText : selectedValue
           }


### PR DESCRIPTION
# Changes

* SelectList: add `stopPropagation` on `onClick` to prevent an issue we on our Cambly landing pages on smaller screens
* SelectList: doc fixes
* SelectList: fix misspelling

## Before

Popover automatically closes when you click the select list, preventing you from selecting a language

https://github.com/Cambly/syntax/assets/127199/ea4251a2-3933-4e43-8d4c-261b92cd5007


## After

Popover doesn't close when you click the select list, so you can select a language

https://github.com/Cambly/syntax/assets/127199/29c071a5-5a96-4d7d-a115-7a616d5003af


