### PR TITLE
Checkbox/RadioButton: update disabled states

### DIFF
--- a/.changeset/perfect-eyes-listen.md
+++ b/.changeset/perfect-eyes-listen.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Checkbox/RadioButton: update disabled states

--- a/packages/syntax-core/src/Checkbox/Checkbox.module.css
+++ b/packages/syntax-core/src/Checkbox/Checkbox.module.css
@@ -13,18 +13,24 @@
 .inputOverlay {
   opacity: 0;
   position: absolute;
-  z-index: 1;
-  cursor: pointer;
   margin: 0;
 }
 
 .checkbox {
   position: relative;
-  cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
+}
+
+.stateDisabled {
+  cursor: auto;
+  opacity: 0.3;
+}
+
+.stateEnabled {
+  cursor: pointer;
 }
 
 .uncheckedBox {

--- a/packages/syntax-core/src/Checkbox/Checkbox.module.css
+++ b/packages/syntax-core/src/Checkbox/Checkbox.module.css
@@ -5,13 +5,9 @@
   align-items: center;
 }
 
-.checkboxContainer {
-  display: flex;
-  flex-direction: row;
-}
-
 .inputOverlay {
   opacity: 0;
+  pointer-events: none;
   position: absolute;
   margin: 0;
 }

--- a/packages/syntax-core/src/Checkbox/Checkbox.module.css
+++ b/packages/syntax-core/src/Checkbox/Checkbox.module.css
@@ -7,7 +7,6 @@
 
 .inputOverlay {
   opacity: 0;
-  pointer-events: none;
   position: absolute;
   margin: 0;
 }
@@ -20,12 +19,15 @@
   box-sizing: border-box;
 }
 
-.stateDisabled {
-  cursor: auto;
+.disabled {
   opacity: 0.3;
 }
 
-.stateEnabled {
+.cursorDisabled {
+  cursor: auto;
+}
+
+.cursorEnabled {
   cursor: pointer;
 }
 

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -83,7 +83,12 @@ const Checkbox = ({
   });
 
   return (
-    <label className={classNames(styles.mainContainer)}>
+    <label
+      className={classNames(
+        styles.mainContainer,
+        styles[`state${disabled ? "Disabled" : "Enabled"}`],
+      )}
+    >
       <div className={styles.checkboxContainer}>
         <input
           data-testid={dataTestId}

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -86,7 +86,10 @@ const Checkbox = ({
     <label
       className={classNames(
         styles.mainContainer,
-        styles[`state${disabled ? "Disabled" : "Enabled"}`],
+        styles[`cursor${disabled ? "Disabled" : "Enabled"}`],
+        {
+          [styles.disabled]: disabled,
+        },
       )}
     >
       <div className={checked ? checkedStyling : uncheckedStyling}>
@@ -102,7 +105,11 @@ const Checkbox = ({
       <input
         data-testid={dataTestId}
         type="checkbox"
-        className={classNames(styles.inputOverlay, styles[size])}
+        className={classNames(
+          styles.inputOverlay,
+          styles[size],
+          styles[`cursor${disabled ? "Disabled" : "Enabled"}`],
+        )}
         checked={checked}
         onChange={onChange}
         disabled={disabled}

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -89,32 +89,30 @@ const Checkbox = ({
         styles[`state${disabled ? "Disabled" : "Enabled"}`],
       )}
     >
-      <div className={styles.checkboxContainer}>
-        <input
-          data-testid={dataTestId}
-          type="checkbox"
-          className={classNames(styles.inputOverlay, styles[size])}
-          checked={checked}
-          onChange={onChange}
-          disabled={disabled}
-          onFocus={() => {
-            setIsFocused(true);
-          }}
-          onBlur={() => {
-            setIsFocused(false);
-          }}
-        />
-        <div className={checked ? checkedStyling : uncheckedStyling}>
-          {checked && (
-            <svg aria-hidden="true" viewBox="0 0 24 24" width={iconWidth[size]}>
-              <path
-                fill="#fff"
-                d="m9 16.2-3.5-3.5a.9839.9839 0 0 0-1.4 0c-.39.39-.39 1.01 0 1.4l4.19 4.19c.39.39 1.02.39 1.41 0L20.3 7.7c.39-.39.39-1.01 0-1.4a.9839.9839 0 0 0-1.4 0L9 16.2z"
-              ></path>
-            </svg>
-          )}
-        </div>
+      <div className={checked ? checkedStyling : uncheckedStyling}>
+        {checked && (
+          <svg aria-hidden="true" viewBox="0 0 24 24" width={iconWidth[size]}>
+            <path
+              fill="#fff"
+              d="m9 16.2-3.5-3.5a.9839.9839 0 0 0-1.4 0c-.39.39-.39 1.01 0 1.4l4.19 4.19c.39.39 1.02.39 1.41 0L20.3 7.7c.39-.39.39-1.01 0-1.4a.9839.9839 0 0 0-1.4 0L9 16.2z"
+            ></path>
+          </svg>
+        )}
       </div>
+      <input
+        data-testid={dataTestId}
+        type="checkbox"
+        className={classNames(styles.inputOverlay, styles[size])}
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        onFocus={() => {
+          setIsFocused(true);
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+        }}
+      />
       <Typography
         size={typographySize[size]}
         color={error ? "destructive-primary" : "gray800"}

--- a/packages/syntax-core/src/RadioButton/RadioButton.module.css
+++ b/packages/syntax-core/src/RadioButton/RadioButton.module.css
@@ -1,19 +1,30 @@
 .radioBaseContainer {
   display: flex;
   flex-direction: row;
+  gap: 8px;
   align-items: center;
-  cursor: pointer;
   position: relative;
+}
+
+.radioBaseContainer:focus-within {
+  outline: 2px solid var(--color-base-primary-700);
+}
+
+.stateDisabled {
+  cursor: auto;
+  opacity: 0.3;
+}
+
+.stateEnabled {
+  cursor: pointer;
 }
 
 .smBase {
   height: 16px;
-  gap: 4px;
 }
 
 .mdBase {
   height: 32px;
-  gap: 16px;
 }
 
 .radioStyleOverride {

--- a/packages/syntax-core/src/RadioButton/RadioButton.module.css
+++ b/packages/syntax-core/src/RadioButton/RadioButton.module.css
@@ -6,12 +6,15 @@
   position: relative;
 }
 
-.stateDisabled {
-  cursor: auto;
+.disabled {
   opacity: 0.3;
 }
 
-.stateEnabled {
+.cursorDisabled {
+  cursor: auto;
+}
+
+.cursorEnabled {
   cursor: pointer;
 }
 
@@ -26,7 +29,6 @@
 .radioStyleOverride {
   margin: 0;
   opacity: 0;
-  pointer-events: none;
 }
 
 .smOverride {

--- a/packages/syntax-core/src/RadioButton/RadioButton.module.css
+++ b/packages/syntax-core/src/RadioButton/RadioButton.module.css
@@ -6,10 +6,6 @@
   position: relative;
 }
 
-.radioBaseContainer:focus-within {
-  outline: 2px solid var(--color-base-primary-700);
-}
-
 .stateDisabled {
   cursor: auto;
   opacity: 0.3;
@@ -28,9 +24,9 @@
 }
 
 .radioStyleOverride {
-  opacity: 0;
   margin: 0;
-  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .smOverride {

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -86,8 +86,9 @@ const RadioButton = ({
     <label
       className={classnames(
         styles.radioBaseContainer,
-        styles[`state${disabled ? "Disabled" : "Enabled"}`],
+        styles[`cursor${disabled ? "Disabled" : "Enabled"}`],
         {
+          [styles.disabled]: disabled,
           [styles.smBase]: size === "sm",
           [styles.mdBase]: size === "md",
         },
@@ -108,10 +109,14 @@ const RadioButton = ({
         type="radio"
         id={id}
         name={name}
-        className={classnames(styles.radioStyleOverride, {
-          [styles.smOverride]: size === "sm",
-          [styles.mdOverride]: size === "md",
-        })}
+        className={classnames(
+          styles.radioStyleOverride,
+          styles[`cursor${disabled ? "Disabled" : "Enabled"}`],
+          {
+            [styles.smOverride]: size === "sm",
+            [styles.mdOverride]: size === "md",
+          },
+        )}
         checked={checked}
         onChange={onChange}
         disabled={disabled}

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -84,10 +84,14 @@ const RadioButton = ({
 
   return (
     <label
-      className={classnames(styles.radioBaseContainer, {
-        [styles.smBase]: size === "sm",
-        [styles.mdBase]: size === "md",
-      })}
+      className={classnames(
+        styles.radioBaseContainer,
+        styles[`state${disabled ? "Disabled" : "Enabled"}`],
+        {
+          [styles.smBase]: size === "sm",
+          [styles.mdBase]: size === "md",
+        },
+      )}
     >
       {checked ? (
         <div


### PR DESCRIPTION
# Changes

* Update disabled states for `Checkbox` and `RadioButton`
* `RadioButton` fix spacing between label and radio button - always set it to 8px

# Why?

Before it was really hard to see whether a Checkbox or RadioButton was disabled

# Screenshots

<img width="199" alt="Screenshot 2023-06-23 at 8 59 49 AM" src="https://github.com/Cambly/syntax/assets/127199/006feda3-97f6-4e64-b137-d369a70a65c8">
<img width="214" alt="Screenshot 2023-06-23 at 8 58 24 AM" src="https://github.com/Cambly/syntax/assets/127199/f39b628b-6bac-4aac-9efb-1f19d35f88a0">

