### PR TITLE
Button / IconButton: make onClick optional

### DIFF
--- a/.changeset/fluffy-masks-invite.md
+++ b/.changeset/fluffy-masks-invite.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Button / IconButton: make onClick optional

--- a/packages/syntax-core/src/Button/Button.test.tsx
+++ b/packages/syntax-core/src/Button/Button.test.tsx
@@ -70,6 +70,22 @@ describe("button", () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
+  it("fires the onSubmit event on a form when button of type submit is clicked", async () => {
+    const handleSubmit = vi.fn();
+    render(
+      <form onSubmit={handleSubmit}>
+        <Button
+          type="submit"
+          text="Continue"
+          accessibilityLabel="Continue to the next step"
+        />
+      </form>,
+    );
+    const button = await screen.findByLabelText("Continue to the next step");
+    await userEvent.click(button);
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it("sets the data-testid", () => {
     const handleClick = vi.fn();
     render(

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -86,7 +86,7 @@ type ButtonType = {
   /**
    * The callback to be called when the button is clicked
    */
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /**
    * The tooltip to be displayed when the user hovers over the button
    */

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -49,7 +49,7 @@ type IconButtonType = {
   /**
    * The callback to be called when the button is clicked
    */
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /**
    * The tooltip to be displayed when the user hovers over the button
    */


### PR DESCRIPTION
# Changes

Button / IconButton: make onClick optional

# Why?

See `Button` test - it allows for a `Button` with `type="submit"` to submit a form