### PR TITLE
TextField: add component

### DIFF
--- a/.changeset/nine-queens-pull.md
+++ b/.changeset/nine-queens-pull.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TextField: add component

--- a/packages/syntax-core/src/TextField/TextField.module.css
+++ b/packages/syntax-core/src/TextField/TextField.module.css
@@ -1,0 +1,48 @@
+.textfield {
+  appearance: none;
+  border: 1px solid var(--color-base-gray-700);
+  box-sizing: border-box;
+  font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 0 12px;
+  width: 100%;
+}
+
+.textfield:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
+}
+
+.textfield:disabled {
+  cursor: auto;
+}
+
+.label {
+  cursor: pointer;
+}
+
+.sm {
+  height: 32px;
+  border-radius: 12px;
+}
+
+.md {
+  height: 40px;
+  border-radius: 12px;
+}
+
+.lg {
+  height: 48px;
+  border-radius: 16px;
+}
+
+.inputError {
+  color: var(--color-base-destructive-700);
+  border-color: var(--color-base-destructive-700);
+  background-color: var(--color-base-destructive-100);
+}
+
+.inputError::placeholder {
+  color: var(--color-base-destructive-700);
+}

--- a/packages/syntax-core/src/TextField/TextField.stories.tsx
+++ b/packages/syntax-core/src/TextField/TextField.stories.tsx
@@ -1,0 +1,82 @@
+import { type StoryObj, type Meta } from "@storybook/react";
+import TextField from "./TextField";
+import React, { useState } from "react";
+
+export default {
+  title: "Components/TextField",
+  component: TextField,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=1007%3A4103",
+    },
+  },
+  argTypes: {
+    autoComplete: {
+      options: ["current-password", "new-password", "off", "on", "email"],
+      control: { type: "select" },
+    },
+    disabled: {
+      control: "boolean",
+    },
+    placeholder: {
+      control: "text",
+    },
+    size: {
+      options: ["sm", "md", "lg"],
+      control: { type: "radio" },
+    },
+    type: {
+      options: [
+        "button",
+        "checkbox",
+        "color",
+        "date",
+        "datetime-local",
+        "email",
+        "file",
+        "hidden",
+        "image",
+        "month",
+        "number",
+        "password",
+        "radio",
+        "range",
+        "reset",
+        "search",
+        "submit",
+        "tel",
+        "text",
+        "time",
+        "url",
+        "week",
+      ],
+      control: { type: "select" },
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof TextField>;
+
+function TextFieldDefault({
+  label = "TextField label",
+  placeholder = "Placeholder",
+  value: initialValue = "",
+  ...rest
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <TextField
+      label={label}
+      placeholder={placeholder}
+      onChange={(event) => {
+        setValue(event.target.value);
+      }}
+      value={initialValue || value}
+      {...rest}
+    />
+  );
+}
+
+export const Default: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault {...args} />,
+};

--- a/packages/syntax-core/src/TextField/TextField.test.tsx
+++ b/packages/syntax-core/src/TextField/TextField.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import TextField from "./TextField";
+import { expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+describe("textField", () => {
+  it("renders successfully", () => {
+    const { baseElement } = render(
+      <TextField label="TextField label" value="" onChange={() => undefined} />,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it("displays the label", () => {
+    render(
+      <TextField label="TextField label" value="" onChange={() => undefined} />,
+    );
+    expect(screen.getByText("TextField label")).toBeInTheDocument();
+  });
+
+  it("displays the placeholder", () => {
+    render(
+      <TextField
+        label="TextField label"
+        placeholder="Placeholder"
+        value=""
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByPlaceholderText("Placeholder")).toBeInTheDocument();
+  });
+
+  it("displays the value", () => {
+    render(
+      <TextField
+        label="TextField label"
+        value="Value"
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByDisplayValue("Value")).toBeInTheDocument();
+  });
+
+  it("displays the error", () => {
+    render(
+      <TextField
+        label="TextField label"
+        value=""
+        onChange={() => undefined}
+        errorText="Error"
+      />,
+    );
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("displays the helper text", () => {
+    render(
+      <TextField
+        label="TextField label"
+        value=""
+        onChange={() => undefined}
+        helperText="Helper text"
+      />,
+    );
+    expect(screen.getByText("Helper text")).toBeInTheDocument();
+  });
+
+  it("displays the disabled state", () => {
+    render(
+      <TextField
+        label="TextField label"
+        value=""
+        onChange={() => undefined}
+        disabled
+      />,
+    );
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("fires the onChange event", async () => {
+    const handleChange = vi.fn();
+    render(
+      <TextField
+        label="TextField label"
+        value=""
+        onChange={handleChange}
+        data-testid="syntax-textfield"
+      />,
+    );
+    const textField = screen.getByTestId("syntax-textfield");
+    await userEvent.type(textField, "test");
+    expect(handleChange).toHaveBeenCalledTimes(4);
+  });
+
+  it("successfully grabs input value when changed", async () => {
+    function TextFieldWithState() {
+      const [value, setValue] = useState("");
+      return (
+        <TextField
+          label="TextField label"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+          }}
+          data-testid="syntax-textfield"
+        />
+      );
+    }
+
+    render(<TextFieldWithState />);
+    const textField = screen.getByTestId("syntax-textfield");
+    await userEvent.type(textField, "test");
+    expect(textField).toHaveValue("test");
+  });
+
+  it("sets the data-testid correctly", () => {
+    render(
+      <TextField
+        data-testid="textfield-test-id"
+        label="TextField label"
+        value=""
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("textfield-test-id")).toBeInTheDocument();
+  });
+});

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -1,0 +1,137 @@
+import React, {
+  type ReactElement,
+  type HTMLInputTypeAttribute,
+  useId,
+} from "react";
+import classNames from "classnames";
+import styles from "./TextField.module.css";
+import Box from "../Box/Box";
+import Typography from "../Typography/Typography";
+
+/**
+ * [TextField](https://cambly-syntax.vercel.app/?path=/docs/components-textfield--docs) is a component that allows users to enter text.
+ */
+export default function TextField({
+  autoComplete,
+  "data-testid": dataTestId,
+  disabled = false,
+  errorText = "",
+  helperText = "",
+  id,
+  label,
+  onChange,
+  placeholder = "",
+  size = "md",
+  type = "text",
+  value = "",
+}: {
+  /**
+   * The autocomplete attribute specifies whether or not an input field should have autocomplete enabled.
+   *
+   * Feel free to add new values from the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) as needed
+   */
+  autoComplete?: "current-password" | "new-password" | "off" | "on" | "email";
+  /**
+   * A data-testid to make querying for the TextField easier.
+   */
+  "data-testid"?: string;
+  /**
+   * If true, the TextField will be disabled.
+   *
+   * @defaultValue false
+   */
+  disabled?: boolean;
+  /**
+   * Text shown below TextField if there is an input error.
+   */
+  errorText?: string;
+  /**
+   * Informative helper text shown below TextField
+   */
+  helperText?: string;
+  /**
+   * TextField id, if not provided, a unique id will be generated
+   */
+  id?: string;
+  /**
+   * TextField visible label
+   */
+  label: string;
+  /**
+   * The callback to be called the input changes
+   */
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Optional TextField placeholder text
+   */
+  placeholder?: string;
+  /**
+   * Size of the TextField
+   * * `sm`: 32px
+   * * `md`: 40px
+   * * `lg`: 48px
+   *
+   * @defaultValue "md"
+   */
+  size?: "sm" | "md" | "lg";
+  /**
+   * Input type of the TextField
+   *
+   * See [full list of input types](https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types)
+   */
+  type?: HTMLInputTypeAttribute;
+  /**
+   * Value of the TextField
+   */
+  value: string;
+}): ReactElement {
+  const reactId = useId();
+  const inputId = id ?? reactId;
+
+  return (
+    <Box
+      display="flex"
+      direction="column"
+      gap={2}
+      width="100%"
+      dangerouslySetInlineStyle={{
+        __style: {
+          opacity: disabled ? 0.5 : 1,
+        },
+      }}
+    >
+      {label && (
+        <label className={styles.label} htmlFor={inputId}>
+          <Box paddingX={1}>
+            <Typography size={100} color="gray700">
+              {label}
+            </Typography>
+          </Box>
+        </label>
+      )}
+      <input
+        autoComplete={autoComplete}
+        className={classNames(styles.textfield, styles[size], {
+          [styles.inputError]: errorText,
+        })}
+        data-testid={dataTestId}
+        disabled={disabled}
+        id={inputId}
+        type={type}
+        onChange={onChange}
+        placeholder={placeholder}
+        value={value}
+      />
+      {(helperText || errorText) && (
+        <Box paddingX={1}>
+          <Typography
+            size={100}
+            color={errorText ? "destructive-primary" : "gray700"}
+          >
+            {errorText || helperText}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/syntax-core/src/index.tsx
+++ b/packages/syntax-core/src/index.tsx
@@ -12,6 +12,7 @@ import MiniActionCard from "./MiniActionCard/MiniActionCard";
 import Modal from "./Modal/Modal";
 import RadioButton from "./RadioButton/RadioButton";
 import SelectList from "./SelectList/SelectList";
+import TextField from "./TextField/TextField";
 import Typography from "./Typography/Typography";
 
 export {
@@ -29,5 +30,6 @@ export {
   Modal,
   RadioButton,
   SelectList,
+  TextField,
   Typography,
 };


### PR DESCRIPTION
# Changes

Add the `TextField` component which currently lives in `Cambly-Frontend`

# Screenshot

![image](https://github.com/Cambly/syntax/assets/127199/a90f7fb7-06e8-445e-a881-bd00b0d90783)
