### PR TITLE
Docs: add individual links to each component

### DIFF
--- a/.changeset/tame-knives-fold.md
+++ b/.changeset/tame-knives-fold.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-floating-components": patch
+"@cambly/syntax-core": patch
+---
+
+Add individual links to components

--- a/packages/syntax-core/src/Avatar/Avatar.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import styles from "./Avatar.module.css";
 
 /**
- * Avatar is a circular image that represents a user.
+ * [Avatar](https://cambly-syntax.vercel.app/?path=/docs/components-avatar--docs) is a circular image that represents a user.
  */
 const Avatar = ({
   src,

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -12,7 +12,7 @@ const BadgeColor = [
 ] as const;
 
 /**
- * Badge is a component to display short text and give additional context to features and other components.
+ * [Badge](https://cambly-syntax.vercel.app/?path=/docs/components-badge--docs) is a component to display short text and give additional context to features and other components.
  */
 const Badge = ({
   text,

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -62,13 +62,13 @@ type Margin =
 type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 /**
- * Box is primitive design component and is used by lots of other components. It keeps details like spacing, borders and colors consistent across all of Syntax.
+ * [Box](https://cambly-syntax.vercel.app/?path=/docs/components-box--docs) is primitive design component and is used by lots of other components. It keeps details like spacing, borders and colors consistent across all of Syntax.
  *
  * Passthrough props:
  *  * `aria-*`
  *  * `data-testid`
  */
-export default forwardRef<
+const Box = forwardRef<
   HTMLDivElement,
   {
     /**
@@ -557,3 +557,5 @@ export default forwardRef<
     </BoxElement>
   );
 });
+
+export default Box;

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -97,6 +97,9 @@ type ButtonType = {
   type?: "button" | "submit" | "reset";
 };
 
+/**
+ * [Button](https://cambly-syntax.vercel.app/?path=/docs/components-button--docs) is used to trigger an action or event, such as submitting a form, opening a dialog, canceling an action, or performing a delete operation.
+ */
 const Button = forwardRef<HTMLButtonElement, ButtonType>(
   (
     {

--- a/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
@@ -10,7 +10,7 @@ const gap = {
 } as const;
 
 /**
- * Group buttons to render them in a row or column with consistent spacing between each button
+ * [ButtonGroup](https://cambly-syntax.vercel.app/?path=/docs/components-buttongroup--docs) groups buttons in a row or column with consistent spacing between each button.
  */
 const ButtonGroup = ({
   orientation = "horizontal",

--- a/packages/syntax-core/src/Card/Card.tsx
+++ b/packages/syntax-core/src/Card/Card.tsx
@@ -3,10 +3,6 @@ import Box from "../Box/Box";
 // note: only sm + lg size currently, when design decides on the medium size, we can use the "size" constant
 const CardSizes = ["sm", "lg"] as const;
 
-/**
- * Card is a basic container component to apply consistent styling and render child components.
- */
-
 type CardType = {
   /**
    * Test id for the button
@@ -27,11 +23,14 @@ type CardType = {
   size?: (typeof CardSizes)[number];
 };
 
-const Card = ({
+/**
+ * [Card](https://cambly-syntax.vercel.app/?path=/docs/components-card--docs) is a basic container component to apply consistent styling and render child components.
+ */
+export default function Card({
   children,
   size = "sm",
   "data-testid": dataTestId,
-}: CardType): JSX.Element => {
+}: CardType): JSX.Element {
   const sizeWidth = {
     sm: 352,
     lg: 744,
@@ -50,6 +49,4 @@ const Card = ({
       {children}
     </Box>
   );
-};
-
-export default Card;
+}

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -16,7 +16,7 @@ const iconWidth = {
 };
 
 /**
- * Checkbox is a clickable element that will show if an option has been selected or not
+ * [Checkbox](https://cambly-syntax.vercel.app/?path=/docs/components-checkbox--docs) is a clickable element that will show if an option has been selected or not.
  */
 const Checkbox = ({
   checked = false,

--- a/packages/syntax-core/src/Divider/Divider.tsx
+++ b/packages/syntax-core/src/Divider/Divider.tsx
@@ -1,7 +1,7 @@
 import styles from "./Divider.module.css";
 
 /**
- * Divider is a thin horizontal line to group content in lists and layouts.
+ * [Divider](https://cambly-syntax.vercel.app/?path=/docs/components-divider--docs) is a thin horizontal line to group content in lists and layouts.
  */
 export default function Divider(): React.ReactElement {
   return <hr className={styles.divider} />;

--- a/packages/syntax-core/src/Heading/Heading.tsx
+++ b/packages/syntax-core/src/Heading/Heading.tsx
@@ -1,8 +1,9 @@
 import { type ReactElement, type ReactNode } from "react";
 import { type Color } from "../constants";
 import Typography from "../Typography/Typography";
+
 /**
- * Heading enforces a consistent style & accessibility best practices for headings.
+ * [Heading](https://cambly-syntax.vercel.app/?path=/docs/components-heading--docs) enforces a consistent style & accessibility best practices for headings.
  */
 const Heading = ({
   align = "start",

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -57,7 +57,7 @@ type IconButtonType = {
 };
 
 /**
- * IconButton is a clickable element that is used to perform an action.
+ * [IconButton](https://cambly-syntax.vercel.app/?path=/docs/components-iconbutton--docs) is a clickable element that is used to perform an action.
  */
 const IconButton = forwardRef<HTMLButtonElement, IconButtonType>(
   (

--- a/packages/syntax-core/src/MiniActionCard/MiniActionCard.tsx
+++ b/packages/syntax-core/src/MiniActionCard/MiniActionCard.tsx
@@ -1,7 +1,7 @@
 import styles from "./MiniActionCard.module.css";
 
 /**
- * MiniActionCard is component that alerts users to a call to action.
+ * [MiniActionCard](https://cambly-syntax.vercel.app/?path=/docs/components-miniactioncard--docs) is component that alerts users to a call to action.
  */
 const MiniActionCard = ({
   children,

--- a/packages/syntax-core/src/Modal/Modal.tsx
+++ b/packages/syntax-core/src/Modal/Modal.tsx
@@ -85,7 +85,7 @@ type ModalType = {
 };
 
 /**
- * Modal is a dialog that appears on top of the main content and locks user interaction within the modal.
+ * [Modal](https://cambly-syntax.vercel.app/?path=/docs/components-modal--docs) is a dialog that appears on top of the main content and locks user interaction within the modal.
  */
 export default function Modal({
   header,

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -7,7 +7,7 @@ import Typography from "../Typography/Typography";
 import useFocusVisible from "../useFocusVisible";
 
 /**
- * RadioButton is a radio button with accompanying text
+ * [RadioButton](https://cambly-syntax.vercel.app/?path=/docs/components-radiobutton--docs) is a radio button with accompanying text
  */
 const RadioButton = ({
   checked = false,

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -21,7 +21,10 @@ const iconSize = {
   lg: 24,
 } as const;
 
-const SelectList = ({
+/**
+ * [SelectList](https://cambly-syntax.vercel.app/?path=/docs/components-selectlist--docs) is a dropdown menu that allows users to select one option from a list.
+ */
+export default function SelectList({
   children,
   "data-testid": dataTestId,
   disabled = false,
@@ -85,7 +88,7 @@ const SelectList = ({
    * @defaultValue "md"
    */
   size?: "sm" | "md" | "lg";
-}): ReactElement => {
+}): ReactElement {
   const id = useId();
   const { isFocusVisible } = useFocusVisible();
   const [isFocused, setIsFocused] = useState(false);
@@ -157,8 +160,6 @@ const SelectList = ({
       )}
     </div>
   );
-};
-
-export default SelectList;
+}
 
 SelectList.Option = SelectOption;

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -22,7 +22,7 @@ function textColor(color: (typeof Color)[number]): string {
 }
 
 /**
- * Typography is a component that renders text.
+ * [Typography](https://cambly-syntax.vercel.app/?path=/docs/components-typography--docs) is a component that renders text.
  */
 const Typography = ({
   align = "start",

--- a/packages/syntax-floating-components/src/Tooltip/Tooltip.tsx
+++ b/packages/syntax-floating-components/src/Tooltip/Tooltip.tsx
@@ -161,6 +161,9 @@ const useTooltipContext = () => {
   return context;
 };
 
+/**
+ * [Tooltip](https://cambly-syntax.vercel.app/?path=/docs/floating-components-tooltip--docs) displays contextual information on hover or focus.
+ */
 export function Tooltip({
   children,
   ...options


### PR DESCRIPTION
# Changes

Add a link to the storybook for each component

# Why?

Make it way easier to navigate to the docs for a specific component

![image](https://github.com/Cambly/syntax/assets/127199/f72e1485-62b8-48de-9496-ac4e75400c03)
