### PR TITLE
Internal: require pnpm 8.6.6 or larger to avoid deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 # Install node
 nvm install
 # Install dependencies
-npm install -g pnpm
+npm install -g pnpm@8.6.6
 pnpm install
 # Run the dev server
 pnpm dev

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "engines": {
     "npm": "please-use-pnpm",
-    "pnpm": "^8.6.0"
+    "pnpm": "^8.6.6"
   }
 }


### PR DESCRIPTION
# Changes

Require pnpm 8.6.6 or larger to avoid deprecation warning

```
pnpm i -g pnpm@8.6.0
WARN  deprecated pnpm@8.6.0: This version contains a regression. Upgrade to v8.6.2 or newer
```

More context: https://github.com/pnpm/pnpm/releases/tag/v8.6.2