### PR TITLE
IconButton: make accessibilityLabel required

### DIFF
--- a/.changeset/heavy-moons-report.md
+++ b/.changeset/heavy-moons-report.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+IconButton: make accessibilityLabel required

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -35,7 +35,7 @@ type IconButtonType = {
   /**
    * The label to be used for accessibility
    */
-  accessibilityLabel?: string;
+  accessibilityLabel: string;
   /**
    * The icon to be displayed. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
    */


### PR DESCRIPTION
# Changes

**BREAKING CHANGE!**
Make accessibilityLabel required on `IconButton`

# Why?

Enforces every IconButton to have a correct accessibility label

Avoids issues like this:
![image](https://github.com/Cambly/syntax/assets/127199/fdddc707-d4ea-4128-9ddf-c3030486b8b7)
