### PR TITLE
Feat: Typography transform="capitalize"

### DIFF
--- a/.changeset/small-jeans-relate.md
+++ b/.changeset/small-jeans-relate.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Typography: add "capitalize" as potential value for 'transform' prop

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -79,6 +79,10 @@
   display: inline;
 }
 
+.capitalize {
+  text-transform: capitalize;
+}
+
 .uppercase {
   text-transform: uppercase;
 }

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -47,7 +47,7 @@ export default {
       control: "text",
     },
     transform: {
-      options: ["none", "uppercase"],
+      options: ["none", "uppercase", "capitalize"],
       defaultValue: "none",
     },
     underline: {
@@ -138,6 +138,14 @@ export const Uppercase: StoryObj<typeof Typography> = {
   render: (args) => (
     <Typography {...args} transform="uppercase">
       Uppercase
+    </Typography>
+  ),
+};
+
+export const Capitalize: StoryObj<typeof Typography> = {
+  render: (args) => (
+    <Typography {...args} transform="capitalize">
+      this text is capitalized
     </Typography>
   ),
 };

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -90,11 +90,11 @@ const Typography = ({
    */
   tooltip?: string;
   /**
-   * Whether the text should be transformed to uppercase.
+   * Whether the text should be transformed to uppercase or capitalized.
    *
    * @defaultValue "none"
    */
-  transform?: "none" | "uppercase";
+  transform?: "none" | "uppercase" | "capitalize";
   /**
    * Whether the text has an underline.
    *
@@ -120,6 +120,7 @@ const Typography = ({
         inline && styles.inline,
         styles[`size${size}`],
         transform === "uppercase" && styles.uppercase,
+        transform === "capitalize" && styles.capitalize,
         underline && styles.underline,
         lineClamp != null && styles.lineClamp,
       )}


### PR DESCRIPTION
# Changes

Make `<Typography />` accept `transform="capitalize"`

# Why?

Working on implementing a design for a new `<LessonSchedulingRep />`:
https://www.figma.com/file/Y9IVAFSurWopQ7d6O2ucdx/Lesson-Rep?type=design&node-id=1-2877
<img width="142" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/5cde8980-6c39-41f7-8669-0795067c6301">

The badges capitalize the words inside.
This particular text comes back as lowercase strings.
This allows them to display as designed without having to split apart the string and transform it in JS.

After:
![image](https://github.com/Cambly/syntax/assets/1890801/029092c8-51ca-463b-b377-9755c599d189)
![image](https://github.com/Cambly/syntax/assets/1890801/f02a0b09-7362-46ef-b146-d992a8d71631)


Before:
![image](https://github.com/Cambly/syntax/assets/1890801/94948661-edcf-4021-9f7d-30b07f49a564)
![image](https://github.com/Cambly/syntax/assets/1890801/a289e83f-7b03-4eda-994a-9de046c63e7c)



