### PR TITLE
Feat: Badge color="gray200"

### DIFF
--- a/.changeset/shaggy-panthers-mate.md
+++ b/.changeset/shaggy-panthers-mate.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Badge: add "gray200" as possible color

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -13,6 +13,7 @@ export default {
   argTypes: {
     color: {
       options: [
+        "gray200",
         "gray900",
         "destructive700",
         "orange700",

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -2,6 +2,7 @@ import Typography from "../Typography/Typography";
 import Box from "../Box/Box";
 
 const BadgeColor = [
+  "gray200",
   "gray900",
   "destructive700",
   "orange700",
@@ -10,6 +11,18 @@ const BadgeColor = [
   "primary700",
   "purple700",
 ] as const;
+
+const textColorForBackgroundColor = (
+  color: (typeof BadgeColor)[number],
+): "gray900" | "white" => {
+  switch (color) {
+    case "gray200":
+    case "yellow700":
+      return "gray900";
+    default:
+      return "white";
+  }
+};
 
 /**
  * [Badge](https://cambly-syntax.vercel.app/?path=/docs/components-badge--docs) is a component to display short text and give additional context to features and other components.
@@ -37,7 +50,7 @@ const Badge = ({
     backgroundColor={color}
   >
     <Typography
-      color={color === "yellow700" ? "gray900" : "white"}
+      color={textColorForBackgroundColor(color)}
       size={100}
       weight="bold"
     >


### PR DESCRIPTION
# Changes

Make `"gray200"` a valid `color` for `<Badge />`

# Why?

Working on implementing a design for a new `<LessonSchedulingRep />`:
https://www.figma.com/file/Y9IVAFSurWopQ7d6O2ucdx/Lesson-Rep?node-id=49%3A3791&mode=dev
<img width="200" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/a52ba655-c309-48ea-979a-ece1f85d2ab3">


The badge denoting a Private lesson is light gray with dark text.

After:
<img width="263" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/38504c5a-55ea-41ba-8de0-df0d0e72cdee">
