### PR TITLE
LinkButton: Api with Wrapper

### DIFF
--- a/.changeset/nice-rockets-play.md
+++ b/.changeset/nice-rockets-play.md
@@ -3,3 +3,4 @@
 ---
 
 LinkButton: Add component
+Buttons: Update Buttons with Typography instead of custom css.

--- a/.changeset/nice-rockets-play.md
+++ b/.changeset/nice-rockets-play.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+LinkButton: Add component

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -130,23 +130,3 @@
   stroke-dashoffset: 0;
   transform-origin: center;
 }
-
-/** TODO Change with `Typography` component when available */
-.buttonText {
-  color: inherit;
-  font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Helvetica, Arial, sans-serif;
-  font-weight: 500;
-}
-
-.buttonTextSmall {
-  font-size: 12px;
-}
-
-.buttonTextMedium {
-  font-size: 14px;
-}
-
-.buttonTextLarge {
-  font-size: 16px;
-}

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -1,28 +1,16 @@
-import classNames from "classnames";
-import backgroundColor from "../colors//backgroundColor";
-import foregroundColor from "../colors/foregroundColor";
 import React, { forwardRef } from "react";
+import classNames from "classnames";
+
+import backgroundColor from "../colors//backgroundColor";
+import foregroundColor, {
+  foregroundTypographyColor,
+} from "../colors/foregroundColor";
 import { type Color, type Size } from "../constants";
+import Typography from "../Typography/Typography";
+import Box from "../Box/Box";
+
+import { textVariant, iconSize, loadingIconSize } from "./ButtonConstants";
 import styles from "./Button.module.css";
-
-const textVariant = {
-  // Replace with `Typography` once it lands in `syntax-core`
-  ["sm"]: styles.buttonTextSmall,
-  ["md"]: styles.buttonTextMedium,
-  ["lg"]: styles.buttonTextLarge,
-} as const;
-
-const loadingIconSize = {
-  ["sm"]: 16,
-  ["md"]: 20,
-  ["lg"]: 24,
-};
-
-const iconSize = {
-  ["sm"]: styles.smIcon,
-  ["md"]: styles.mdIcon,
-  ["lg"]: styles.lgIcon,
-};
 
 type ButtonType = {
   /**
@@ -144,12 +132,14 @@ const Button = forwardRef<HTMLButtonElement, ButtonType>(
           <StartIcon className={classNames(styles.icon, iconSize[size])} />
         )}
         {((loading && loadingText) || (!loading && text)) && (
-          <div className={styles.textContainer}>
-            {/* Replace with `Typography` once it lands in `syntax-core` */}
-            <div className={classNames(styles.buttonText, textVariant[size])}>
+          <Box paddingX={1}>
+            <Typography
+              size={textVariant[size]}
+              color={foregroundTypographyColor(color)}
+            >
               {loading ? loadingText : text}
-            </div>
-          </div>
+            </Typography>
+          </Box>
         )}
         {!loading && EndIcon && (
           <EndIcon className={classNames(styles.icon, iconSize[size])} />

--- a/packages/syntax-core/src/Button/ButtonConstants.ts
+++ b/packages/syntax-core/src/Button/ButtonConstants.ts
@@ -1,0 +1,20 @@
+import styles from "./Button.module.css";
+
+export const textVariant = {
+  // Replace with `Typography` once it lands in `syntax-core`
+  ["sm"]: 100,
+  ["md"]: 200,
+  ["lg"]: 300,
+} as const;
+
+export const loadingIconSize = {
+  ["sm"]: 16,
+  ["md"]: 20,
+  ["lg"]: 24,
+};
+
+export const iconSize = {
+  ["sm"]: styles.smIcon,
+  ["md"]: styles.mdIcon,
+  ["lg"]: styles.lgIcon,
+};

--- a/packages/syntax-core/src/LinkButton/LinkButton.module.css
+++ b/packages/syntax-core/src/LinkButton/LinkButton.module.css
@@ -1,0 +1,7 @@
+.linkButton {
+  text-decoration: none;
+}
+
+.fitContent {
+  width: fit-content;
+}

--- a/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
@@ -1,0 +1,90 @@
+import { type StoryObj, type Meta } from "@storybook/react";
+import LinkButton from "./LinkButton";
+import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
+
+export default {
+  title: "Components/LinkButton",
+  component: LinkButton,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/Cambly-Design-System-(Draft)?node-id=994%3A2346",
+    },
+  },
+  argTypes: {
+    color: {
+      text: {
+        control: { type: "text" },
+      },
+      options: [
+        "primary",
+        "secondary",
+        "tertiary",
+        "destructive-primary",
+        "destructive-secondary",
+        "destructive-tertiary",
+        "success",
+        "branded",
+      ],
+      control: { type: "radio" },
+    },
+    size: {
+      options: ["sm", "md", "lg"],
+      control: { type: "radio" },
+    },
+    fullWidth: {
+      control: "boolean",
+    },
+    onClick: { action: "clicked" },
+    href: {
+      control: { type: "text" },
+    },
+    openInNewWindow: {
+      control: "boolean",
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof LinkButton>;
+
+export const Default: StoryObj<typeof LinkButton> = {
+  args: {
+    text: "Call to action",
+    href: "https://www.google.com",
+    openInNewWindow: true,
+  },
+  render: ({ ...args }) => <LinkButton {...args} />,
+};
+
+export const Small: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, size: "sm" },
+};
+export const Medium: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, size: "md" },
+};
+export const Large: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, size: "lg" },
+};
+export const Secondary: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, color: "secondary" },
+};
+export const Tertiary: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, color: "tertiary" },
+};
+export const DestructivePrimary: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, color: "destructive-primary" },
+};
+export const DestructiveSecondary: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, color: "destructive-secondary" },
+};
+export const DestructiveTertiary: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, color: "destructive-tertiary" },
+};
+export const Branded: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, color: "branded" },
+};
+export const WithStartIcon: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, startIcon: FavoriteBorder },
+};
+export const WithEndIcon: StoryObj<typeof LinkButton> = {
+  args: { ...Default.args, endIcon: FavoriteBorder },
+};

--- a/packages/syntax-core/src/LinkButton/LinkButton.test.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.test.tsx
@@ -1,0 +1,11 @@
+import { screen, render } from "@testing-library/react";
+import LinkButton from "./LinkButton";
+
+describe("linkbutton", () => {
+  it("it should render successfully", () => {
+    // Update tests here:
+    // Don't forget to add your props!
+    render(<LinkButton />);
+    expect(screen).toBeTruthy();
+  });
+});

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -29,7 +29,17 @@ function A({
   );
 }
 
-const LinkButton = ({
+/**
+ * LinkButton is a "variation" of Button that should look identical to Button, but should be used to render links instead.
+ * It uses the wrapper prop to allow for usage inside Next.js or react-router (Examples below).
+ *
+ * ```
+ * import Link from "next/link";
+ *
+ * <LinkButton wrapper={Link} text="Get Started" />
+ * ```
+ */
+export default function LinkButton({
   text,
   color = "primary",
   size = "md",
@@ -39,6 +49,8 @@ const LinkButton = ({
   wrapper: Wrapper = A,
   href,
   openInNewWindow = false,
+  nextPrefetch,
+  nextReplace,
 }: {
   /**
    * Test id for the button
@@ -85,6 +97,8 @@ const LinkButton = ({
     children: ReactNode;
     href: string;
     openInNewWindow: boolean;
+    nextReplace?: boolean;
+    nextPrefetch?: boolean;
   }>;
   /**
    * The link or url that the button should redirect to.
@@ -94,9 +108,30 @@ const LinkButton = ({
    * If `true`, the link will open in a new window/tab.
    */
   openInNewWindow?: boolean;
-}): JSX.Element => {
+  /**
+   * Only used when wrapper is Next.js Link.
+   * Docs: https://nextjs.org/docs/pages/api-reference/components/link#replace
+   *
+   * If "true", When true, next/link will replace the current history state instead of adding a new URL into the browser’s history stack.
+   */
+  nextReplace?: boolean;
+  /**
+   * Only used when wrapper is Next.js Link.
+   * Docs: https://nextjs.org/docs/pages/api-reference/components/link#prefetch
+   *
+   * Defaults to "true" already in next/link.
+   * When true, next/link will prefetch the page (denoted by the href) in the background. This is useful for improving the performance of client-side navigations. Any <Link /> in the viewport (initially or through scroll) will be preloaded.
+   * Prefetch can be disabled by passing prefetch={false}.
+   */
+  nextPrefetch?: boolean;
+}): JSX.Element {
   return (
-    <Wrapper href={href} openInNewWindow={openInNewWindow}>
+    <Wrapper
+      href={href}
+      openInNewWindow={openInNewWindow}
+      nextPrefetch={nextPrefetch}
+      nextReplace={nextReplace}
+    >
       <div
         className={classNames(
           styles.linkButton,
@@ -129,6 +164,4 @@ const LinkButton = ({
       </div>
     </Wrapper>
   );
-};
-
-export default LinkButton;
+}

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -1,0 +1,134 @@
+import classNames from "classnames";
+import backgroundColor from "../colors/backgroundColor";
+import foregroundColor, {
+  foregroundTypographyColor,
+} from "../colors/foregroundColor";
+import React, { type ReactElement, type ReactNode } from "react";
+import { type Color, type Size } from "../constants";
+import Typography from "../Typography/Typography";
+
+import buttonStyles from "../Button/Button.module.css";
+import { textVariant, iconSize } from "../Button/ButtonConstants";
+
+import styles from "./LinkButton.module.css";
+
+function A({
+  children,
+  href,
+  openInNewWindow,
+}: {
+  children: ReactNode;
+  href: string;
+  openInNewWindow: boolean;
+}): ReactElement {
+  const target = openInNewWindow ? "_blank" : "";
+  return (
+    <a href={href} target={target}>
+      {children}
+    </a>
+  );
+}
+
+const LinkButton = ({
+  text,
+  color = "primary",
+  size = "md",
+  fullWidth = false,
+  startIcon: StartIcon,
+  endIcon: EndIcon,
+  wrapper: Wrapper = A,
+  href,
+  openInNewWindow = false,
+}: {
+  /**
+   * Test id for the button
+   */
+  "data-testid"?: string;
+  /**
+   * The text to be displayed inside the button
+   */
+  text: string;
+  /**
+   * The color of the button
+   *
+   * @defaultValue "primary"
+   */
+  color?: (typeof Color)[number];
+  /**
+   * The size of the button
+   *
+   * * `sm`: 32px
+   * * `md`: 40px
+   * * `lg`: 48px
+   *
+   * @defaultValue "md"
+   */
+  size?: (typeof Size)[number];
+  /**
+   * If `true`, the button will take up the full width of its container
+   *
+   * @defaultValue false
+   */
+  fullWidth?: boolean;
+  /**
+   * The icon to be displayed at the start of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
+   */
+  startIcon?: React.ComponentType<{ className: string }>;
+  /**
+   * The icon to be displayed at the end of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
+   */
+  endIcon?: React.ComponentType<{ className: string }>;
+  /**
+   * The custom wrapper for LinkButton, This wrapper is used to change the default "a" tag to something like Next.js Link or react-router-dom's Link.
+   */
+  wrapper?: React.ComponentType<{
+    children: ReactNode;
+    href: string;
+    openInNewWindow: boolean;
+  }>;
+  /**
+   * The link or url that the button should redirect to.
+   */
+  href: string;
+  /**
+   * If `true`, the link will open in a new window/tab.
+   */
+  openInNewWindow?: boolean;
+}): JSX.Element => {
+  return (
+    <Wrapper href={href} openInNewWindow={openInNewWindow}>
+      <div
+        className={classNames(
+          styles.linkButton,
+          buttonStyles.button,
+          foregroundColor(color),
+          backgroundColor(color),
+          buttonStyles[size],
+          {
+            [buttonStyles.fullWidth]: fullWidth,
+            [styles.fitContent]: !fullWidth,
+            [buttonStyles.buttonGap]: size === "lg" || size === "md",
+            [buttonStyles.secondaryBorder]: color === "secondary",
+            [buttonStyles.secondaryDestructiveBorder]:
+              color === "destructive-secondary",
+          },
+        )}
+      >
+        {StartIcon && (
+          <StartIcon className={classNames(styles.icon, iconSize[size])} />
+        )}
+        <Typography
+          color={foregroundTypographyColor(color)}
+          size={textVariant[size]}
+        >
+          {text}
+        </Typography>
+        {EndIcon && (
+          <EndIcon className={classNames(styles.icon, iconSize[size])} />
+        )}
+      </div>
+    </Wrapper>
+  );
+};
+
+export default LinkButton;

--- a/packages/syntax-core/src/colors/foregroundColor.ts
+++ b/packages/syntax-core/src/colors/foregroundColor.ts
@@ -15,3 +15,20 @@ export default function foregroundColor(color: (typeof Color)[number]): string {
       return styles.whiteColor;
   }
 }
+
+export function foregroundTypographyColor(
+  color: (typeof Color)[number],
+): (typeof Color)[number] {
+  switch (color) {
+    case "secondary":
+    case "tertiary":
+      return "primary";
+    case "destructive-secondary":
+    case "destructive-tertiary":
+      return "white";
+    case "branded":
+      return "gray900";
+    default:
+      return "white";
+  }
+}

--- a/packages/syntax-core/src/colors/foregroundColor.ts
+++ b/packages/syntax-core/src/colors/foregroundColor.ts
@@ -25,7 +25,7 @@ export function foregroundTypographyColor(
       return "primary";
     case "destructive-secondary":
     case "destructive-tertiary":
-      return "white";
+      return "destructive-primary";
     case "branded":
       return "gray900";
     default:

--- a/packages/syntax-core/src/index.tsx
+++ b/packages/syntax-core/src/index.tsx
@@ -4,10 +4,11 @@ import Box from "./Box/Box";
 import Button from "./Button/Button";
 import ButtonGroup from "./ButtonGroup/ButtonGroup";
 import Card from "./Card/Card";
+import Checkbox from "./Checkbox/Checkbox";
 import Divider from "./Divider/Divider";
 import Heading from "./Heading/Heading";
 import IconButton from "./IconButton/IconButton";
-import Checkbox from "./Checkbox/Checkbox";
+import LinkButton from "./LinkButton/LinkButton";
 import MiniActionCard from "./MiniActionCard/MiniActionCard";
 import Modal from "./Modal/Modal";
 import RadioButton from "./RadioButton/RadioButton";
@@ -25,6 +26,7 @@ export {
   Heading,
   IconButton,
   Checkbox,
+  LinkButton,
   MiniActionCard,
   Modal,
   RadioButton,


### PR DESCRIPTION
Keeping this PR open to compare which API for LinkButton is better: this one or [no wrapper](https://github.com/Cambly/syntax/pull/202).


One of the issues with this API is handling all the passthrough props is unsustainable and if the need ever happens, we'd need to pass in more and more props.

In addition, typing is a bit more difficult because of Wrapper being so varied. 
- next/link is `Link<RouteType>`
- react-router-dom's link is: `unknown>(props: LinkProps<S> & React.RefAttributes<HTMLAnchorElement>)`
- a tags are JSX.Element

Because of the two reasons, I'm leaning towards the "no wrapper" approach. But once again, just leaving this pr open to keep the code in case we decide to go with this version
