### PR TITLE
LinkButton: add rel prop for best practices

### DIFF
--- a/.changeset/wise-tips-live.md
+++ b/.changeset/wise-tips-live.md
@@ -3,3 +3,4 @@
 ---
 
 Add rel tags for linkbutton
+Add more specific styling to override camblystrap.

--- a/.changeset/wise-tips-live.md
+++ b/.changeset/wise-tips-live.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add rel tags for linkbutton

--- a/packages/syntax-core/src/LinkButton/LinkButton.module.css
+++ b/packages/syntax-core/src/LinkButton/LinkButton.module.css
@@ -1,4 +1,5 @@
-.linkButton {
+.linkButton:focus,
+.linkButton:hover {
   text-decoration: none;
 }
 

--- a/packages/syntax-core/src/LinkButton/LinkButton.module.css
+++ b/packages/syntax-core/src/LinkButton/LinkButton.module.css
@@ -1,3 +1,7 @@
+.linkButton {
+  text-decoration: none;
+}
+
 .linkButton:focus,
 .linkButton:hover {
   text-decoration: none;

--- a/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
@@ -22,6 +22,19 @@ export default {
       options: ["_blank", "_self", "_parent", "_top", ""],
       control: { type: "radio" },
     },
+    rel: {
+      options: [
+        "prev",
+        "next",
+        "nofollow",
+        "noreferrer",
+        "search",
+        "tag",
+        "related",
+        "alternate",
+      ],
+      control: { type: "radio" },
+    },
     color: {
       options: [
         "primary",

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -1,3 +1,4 @@
+import { type HtmlHTMLAttributes } from "react";
 import classNames from "classnames";
 import backgroundColor from "../colors/backgroundColor";
 import foregroundColor from "../colors/foregroundColor";
@@ -50,15 +51,7 @@ export default function LinkButton({
    * The target attribute specifies where to open the linked document.
    *
    */
-  rel?:
-    | "prev"
-    | "next"
-    | "nofollow"
-    | "noreferrer"
-    | "search"
-    | "tag"
-    | "related"
-    | "alternate";
+  rel?: HtmlHTMLAttributes<HTMLAnchorElement>["rel"];
   /**
    * The color of the button
    *

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -19,6 +19,7 @@ export default function LinkButton({
   text,
   href,
   target,
+  rel,
   "data-testid": dataTestId,
   color = "primary",
   size = "md",
@@ -45,6 +46,19 @@ export default function LinkButton({
    *
    */
   target?: "_blank" | "_self" | "_parent" | "_top";
+  /**
+   * The target attribute specifies where to open the linked document.
+   *
+   */
+  rel?:
+    | "prev"
+    | "next"
+    | "nofollow"
+    | "noreferrer"
+    | "search"
+    | "tag"
+    | "related"
+    | "alternate";
   /**
    * The color of the button
    *
@@ -93,6 +107,7 @@ export default function LinkButton({
       href={href}
       data-testid={dataTestId}
       target={target}
+      rel={rel}
       className={classNames(
         styles.linkButton,
         buttonStyles.button,


### PR DESCRIPTION
Missing rel prop for best practices.

Depending on the discussion on what happens re: `camblystrap` overriding css for `LinkButton` as well, might need a `!important`, but waiting on that to merge this.