### PR TITLE
Patch button border colors + apply to IconButton

### DIFF
--- a/.changeset/fresh-years-beam.md
+++ b/.changeset/fresh-years-beam.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+IconButton secondary + destructive-secondary borders + match colors to Figma

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -98,11 +98,11 @@
 }
 
 .secondaryBorder {
-  border: 1px solid var(--color-base-primary-700);
+  border: 1px solid var(--color-base-primary-300);
 }
 
 .secondaryDestructiveBorder {
-  border: 1px solid var(--color-base-destructive-700);
+  border: 1px solid var(--color-base-destructive-300);
 }
 
 @keyframes syntaxButtonLoadingRotate {

--- a/packages/syntax-core/src/IconButton/IconButton.module.css
+++ b/packages/syntax-core/src/IconButton/IconButton.module.css
@@ -78,3 +78,11 @@
   /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
   width: 24px !important;
 }
+
+.secondaryBorder {
+  border: 1px solid var(--color-base-primary-300);
+}
+
+.secondaryDestructiveBorder {
+  border: 1px solid var(--color-base-destructive-300);
+}

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -86,6 +86,11 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonType>(
           foregroundColor(color),
           backgroundColor(color),
           styles[size],
+          {
+            [styles.secondaryBorder]: color === "secondary",
+            [styles.secondaryDestructiveBorder]:
+              color === "destructive-secondary",
+          },
         )}
         ref={ref}
       >


### PR DESCRIPTION
- `<IconButton />` and `<Button />` have the same borders
- `"secondary"` + `"destructive-secondary"`
- border-colors changed from `700` -> `300` to match Figma

## Figma:

https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=1186%3A3565&mode=dev
https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=1342%3A3040&mode=dev

<img width="331" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/2cd32d2f-a066-432f-bea0-e41025cd31a7">
<img width="304" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/40e800d0-4c32-4d97-ac1f-515026ceb38c">


## After:
<img width="102" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/dc4e6dce-977b-40bd-a81a-10cc96cfa9e5">
<img width="90" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/250e72bd-0b2a-456a-8d0e-581f7d628869">
<img width="177" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/be19d676-ae44-4781-b8a4-dcfdaf441639">
<img width="189" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/327aed37-1ba7-489a-842c-d43ea42c647d">


## Before:
<img width="89" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/17b6f985-5dc7-49ad-89c6-eaa08941d66e">
<img width="95" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/8242951f-cf12-47ff-a1f5-46284ac08ffd">
<img width="190" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/366ba280-24f0-46b9-a8e8-5eeedf2f4e4f">
<img width="200" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/707d6e41-a9c4-4209-963c-544468b3757c">

