### PR TITLE
Feat: `<Badge icon={IconComponent} />`

### DIFF
--- a/.changeset/metal-beds-end.md
+++ b/.changeset/metal-beds-end.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Feat: Badge: can render `icon` prop

--- a/packages/syntax-core/src/Badge/Badge.module.css
+++ b/packages/syntax-core/src/Badge/Badge.module.css
@@ -1,0 +1,13 @@
+.icon {
+  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
+  height: 16px !important;
+  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
+  width: 16px !important;
+
+  /**
+   * The badge size is 22px total, text is size 14px, there is 4px top + 4px bottom padding
+   * Adjust the margins on the (optional) icon so that is displays the right size but does not affect overall height
+   */
+  margin-top: -1px;
+  margin-bottom: -1px;
+}

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -1,5 +1,6 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import Badge from "./Badge";
+import RepeatIcon from "@mui/icons-material/Repeat";
 
 export default {
   title: "Components/Badge",
@@ -30,4 +31,12 @@ export default {
 
 export const Default: StoryObj<typeof Badge> = {
   args: { text: "Call to action" },
+};
+
+export const WithIcon: StoryObj<typeof Badge> = {
+  args: {
+    color: "gray200",
+    icon: RepeatIcon,
+    text: "Every Wednesday",
+  },
 };

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -1,6 +1,5 @@
 import Typography from "../Typography/Typography";
 import Box from "../Box/Box";
-import { type ReactElement } from "react";
 import styles from "./Badge.module.css";
 
 const BadgeColor = [

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -1,5 +1,7 @@
 import Typography from "../Typography/Typography";
 import Box from "../Box/Box";
+import { type ReactElement } from "react";
+import styles from "./Badge.module.css";
 
 const BadgeColor = [
   "gray200",
@@ -28,13 +30,18 @@ const textColorForBackgroundColor = (
  * [Badge](https://cambly-syntax.vercel.app/?path=/docs/components-badge--docs) is a component to display short text and give additional context to features and other components.
  */
 const Badge = ({
+  icon: Icon,
   text,
   color = "primary700",
 }: {
   /**
+   * The icon to be displayed. Please use a [Material Icon](https://material.io/resources/icons/)
+   */
+  icon?: React.ComponentType<{ className: string }>;
+  /**
    * The text to display inside the badge
    */
-  text: string;
+  text: string | ReactElement;
   /**
    * The color of the badge
    *
@@ -48,13 +55,19 @@ const Badge = ({
     paddingY={1}
     rounding="full"
     backgroundColor={color}
+    dangerouslySetInlineStyle={{ __style: { lineHeight: "14px" } }}
   >
-    <Typography
-      color={textColorForBackgroundColor(color)}
-      size={100}
-      weight="bold"
-    >
-      {text}
+    <Typography color={textColorForBackgroundColor(color)} size={100}>
+      <Box display="flex" gap={1} alignItems="center" justifyContent="start">
+        {Icon && <Icon className={styles.icon} />}
+        <Typography
+          color={textColorForBackgroundColor(color)}
+          size={100}
+          weight="bold"
+        >
+          {text}
+        </Typography>
+      </Box>
     </Typography>
   </Box>
 );

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -41,7 +41,7 @@ const Badge = ({
   /**
    * The text to display inside the badge
    */
-  text: string | ReactElement;
+  text: string;
   /**
    * The color of the badge
    *


### PR DESCRIPTION
## What

This PR adds an `icon` prop to `<Badge />`.
- ex: `<Badge icon={RestartIcon} text="Restart" />`

It allows for the rendering of an IconComponent before badge text string

@somethiiing your comment [here](https://github.com/Cambly/Cambly-Frontend/pull/6084#discussion_r1279202650) helped me decide how to implement this 🙏 🙏 

## Why

The design I am implementing calls for an Icon displayed in a Badge:  https://www.figma.com/file/Y9IVAFSurWopQ7d6O2ucdx/Scheduling-Rep?node-id=159%3A6571&mode=dev

Screenshots:

Badge in figma:
![image](https://github.com/Cambly/syntax/assets/1890801/bfd778d2-db22-4d46-8b69-128c5be3731e)


syntax storybook:
![image](https://github.com/Cambly/syntax/assets/1890801/84f74270-fe7e-43fe-91ad-3408bc5563b2)

