### PR TITLE
Make className optional on icons

### DIFF
--- a/.changeset/long-dots-cheer.md
+++ b/.changeset/long-dots-cheer.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Make className on icons optional

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -36,7 +36,7 @@ const Badge = ({
   /**
    * The icon to be displayed. Please use a [Material Icon](https://material.io/resources/icons/)
    */
-  icon?: React.ComponentType<{ className: string }>;
+  icon?: React.ComponentType<{ className?: string }>;
   /**
    * The text to display inside the badge
    */

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -75,11 +75,11 @@ type ButtonType = {
   /**
    * The icon to be displayed at the start of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
    */
-  startIcon?: React.ComponentType<{ className: string }>;
+  startIcon?: React.ComponentType<{ className?: string }>;
   /**
    * The icon to be displayed at the end of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
    */
-  endIcon?: React.ComponentType<{ className: string }>;
+  endIcon?: React.ComponentType<{ className?: string }>;
   /**
    * The callback to be called when the button is clicked
    */

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -39,7 +39,7 @@ type IconButtonType = {
   /**
    * The icon to be displayed. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
    */
-  icon: React.ComponentType<{ className: string }>;
+  icon: React.ComponentType<{ className?: string }>;
   /**
    * If `true`, the button will be disabled
    *

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -85,11 +85,11 @@ export default function LinkButton({
   /**
    * The icon to be displayed at the start of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
    */
-  startIcon?: React.ComponentType<{ className: string }>;
+  startIcon?: React.ComponentType<{ className?: string }>;
   /**
    * The icon to be displayed at the end of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
    */
-  endIcon?: React.ComponentType<{ className: string }>;
+  endIcon?: React.ComponentType<{ className?: string }>;
   /**
    * An optional onClick event. This is used for certain wrapper's support (such as react-router-dom).
    */


### PR DESCRIPTION
# Why

Enables us to start using custom icons - not just material UI icons