### PR TITLE
Badge: remove explicit line-height, decrease icon size to 12px

### DIFF
--- a/packages/syntax-core/src/Badge/Badge.module.css
+++ b/packages/syntax-core/src/Badge/Badge.module.css
@@ -1,13 +1,6 @@
 .icon {
   /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  height: 16px !important;
+  height: 12px !important;
   /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  width: 16px !important;
-
-  /**
-   * The badge size is 22px total, text is size 14px, there is 4px top + 4px bottom padding
-   * Adjust the margins on the (optional) icon so that is displays the right size but does not affect overall height
-   */
-  margin-top: -1px;
-  margin-bottom: -1px;
+  width: 12px !important;
 }

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -54,7 +54,6 @@ const Badge = ({
     paddingY={1}
     rounding="full"
     backgroundColor={color}
-    dangerouslySetInlineStyle={{ __style: { lineHeight: "14px" } }}
   >
     <Typography color={textColorForBackgroundColor(color)} size={100}>
       <Box display="flex" gap={1} alignItems="center" justifyContent="start">


### PR DESCRIPTION
@christianvuerings , this PR is following up on your review comments from here:
https://github.com/Cambly/syntax/pull/213#discussion_r1282411980
https://github.com/Cambly/syntax/pull/213#discussion_r1282414338

- met with @ajmooo  to discuss the 14px line-height I added in + background on why
- when seeing the issue, decision was to reduce icon size to 12px
- with that, the badges stay the same height regardless of whether it is displaying an icon or not (this was the original issue that prompted the margin-hack in https://github.com/Cambly/syntax/pull/213

Figma links with the updates:
https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=5903%3A6371&mode=dev
https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=3954%3A11320&mode=dev

### After:
<img width="251" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/9302e5cc-e39d-44c0-b882-391d0a427b81">

### Before:
<img width="243" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/f9b55a9c-b585-4bb0-bfea-213d8d92e87c">
