### PR TITLE
Update Avatar to include a 1px white border

### DIFF
--- a/.changeset/popular-pots-attend.md
+++ b/.changeset/popular-pots-attend.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add 1px white border to Avatar

--- a/packages/syntax-core/src/Avatar/Avatar.module.css
+++ b/packages/syntax-core/src/Avatar/Avatar.module.css
@@ -1,27 +1,31 @@
+:root {
+  --syntax-avatar-border-width: 1px;
+}
+
 .avatar {
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
   border-radius: 50%;
-  border: 1px solid #fff;
+  border: var(--syntax-avatar-border-width) solid #fff;
 }
 
 .sm {
-  width: 22px;
-  height: 22px;
+  width: calc(24px - var(--syntax-avatar-border-width) * 2);
+  height: calc(24px - var(--syntax-avatar-border-width) * 2);
 }
 
 .md {
-  width: 38px;
-  height: 38px;
+  width: calc(40px - var(--syntax-avatar-border-width) * 2);
+  height: calc(40px - var(--syntax-avatar-border-width) * 2);
 }
 
 .lg {
-  width: 70px;
-  height: 70px;
+  width: calc(72px - var(--syntax-avatar-border-width) * 2);
+  height: calc(72px - var(--syntax-avatar-border-width) * 2);
 }
 
 .xl {
-  width: 126px;
-  height: 126px;
+  width: calc(128px - var(--syntax-avatar-border-width) * 2);
+  height: calc(128px - var(--syntax-avatar-border-width) * 2);
 }

--- a/packages/syntax-core/src/Avatar/Avatar.module.css
+++ b/packages/syntax-core/src/Avatar/Avatar.module.css
@@ -3,24 +3,25 @@
   background-size: cover;
   background-repeat: no-repeat;
   border-radius: 50%;
+  border: 1px solid #fff;
 }
 
 .sm {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
 }
 
 .md {
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
 }
 
 .lg {
-  width: 72px;
-  height: 72px;
+  width: 70px;
+  height: 70px;
 }
 
 .xl {
-  width: 128px;
-  height: 128px;
+  width: 126px;
+  height: 126px;
 }


### PR DESCRIPTION
Discussion is in [this slack](https://cambly.slack.com/archives/C033ZPY5M46/p1691699159828119)

Background set to black for this screenshot for clarity
<img width="909" alt="image" src="https://github.com/Cambly/syntax/assets/36240753/9901b7f0-9402-4e0e-a348-7bd0e0531fbd">

As AJ noted, the 1px should be an _internal stroke_ so the size shouldn't increase as a result of adding the white border. Inspected that they're the same as they were both - as an example, a medium-sized avatar is still 40px

<img width="367" alt="image" src="https://github.com/Cambly/syntax/assets/36240753/d234335d-eec9-4749-a839-2be00140b525">
 
