### PR TITLE
Typography: add interactive weight

### DIFF
--- a/.changeset/modern-ants-reply.md
+++ b/.changeset/modern-ants-reply.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+typography: add interactive font-weight

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -63,6 +63,10 @@
   font-weight: 400;
 }
 
+.interactive {
+  font-weight: 500;
+}
+
 .semiBold {
   font-weight: 600;
 }


### PR DESCRIPTION
Some of AJ's designs require a specific 500 font-weight for interactive text. Currently I've named that variant `interactive` but not sure if we want another name that is less tied to its use and more tied to a descriptor like `regular` and `semiBold`