### PR TITLE
Docs: fix generated docs for forwardRef components

### DIFF
--- a/.changeset/serious-rockets-smell.md
+++ b/.changeset/serious-rockets-smell.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Docs: fix generated docs for forwardRef components

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -61,6 +61,315 @@ type Margin =
   | "auto";
 type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
+type BoxProps = {
+  /**
+   * The alignment of the box on the cross axis.
+   *
+   * Responsive props:
+   * * `smAlignItems`
+   * * `lgAlignItems`
+   */
+  alignItems?: AlignItems;
+  /**
+   * Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.
+   */
+  alignSelf?: "auto" | "start" | "end" | "center" | "baseline" | "stretch";
+  /**
+   * The underlying DOM element usually set for accessibility or SEO reasons.
+   *
+   * @defaultValue "div"
+   */
+  as?: As;
+  /**
+   * The background color of the box.
+   */
+  backgroundColor?: (typeof allColors)[number];
+  /**
+   * The children to be rendered inside the box.
+   */
+  children?: ReactNode;
+  /**
+   * An "escape hatch" used to apply styles not otherwise available on Box.
+   *
+   * Please use this sparingly and only when you have a good reason to.
+   */
+  dangerouslySetInlineStyle?: {
+    __style: Record<string, string | number | null>;
+  };
+  /**
+   * The flex direction of the box.
+   *
+   * Responsive props:
+   * * `smDirection`
+   * * `lgDirection`
+   *
+   * @defaultValue `row`
+   */
+  direction?: Direction;
+  /**
+   * The display property specifies the display behavior (the type of rendering box) of an element.
+   *
+   * Responsive props:
+   * * `smDisplay`
+   * * `lgDisplay`
+   *
+   * @defaultValue `block`
+   */
+  display?: Display;
+  /**
+   * Sets the flex behavior of a flex item.
+   *
+   * * `none`: The item will not grow or shrink
+   * * `shrink`: The item will shrink if necessary (default browser behavior)
+   * * `grow`: The item will grow if necessary
+   *
+   * @defaultValue `shrink`
+   */
+  flex?: "none" | "shrink" | "grow";
+  /**
+   * By default, flex items will all try to fit onto one line. But if you specify `flexWrap="wrap"`, the flex items will wrap onto multiple lines.
+   *
+   * @defaultValue `nowrap`
+   */
+  flexWrap?: "wrap" | "nowrap";
+  /**
+   * The gap between the children of the box.
+   */
+  gap?: Gap;
+  /**
+   * The id of the element.
+   */
+  id?: string;
+  /**
+   * The alignment of the box on the cross axis on lg (960px) or larger viewports.
+   */
+  lgAlignItems?: AlignItems;
+  /**
+   * The flex direction on lg (960px) or larger viewports.
+   */
+  lgDirection?: Direction;
+  /**
+   * The display style on lg (960px) or larger viewports.
+   */
+  lgDisplay?: Display;
+  /**
+   * The alignment of the box on the cross axis on lg (960px) or larger viewports.
+   */
+  lgJustifyContent?: JustifyContent;
+  /**
+   * Margin on lg (960px) or larger viewports.
+   */
+  lgMargin?: Margin;
+  /**
+   * Bottom margin on lg (960px) or larger viewports.
+   */
+  lgMarginBottom?: Margin;
+  /**
+   * Margin to the right in left-to-right languages, and to the left in right-to-left languages on lg (960px) or larger viewports.
+   */
+  lgMarginEnd?: Margin;
+  /**
+   * Margin to the left in left-to-right languages, and to the right in right-to-left languages on lg (960px) or larger viewports.
+   */
+  lgMarginStart?: Margin;
+  /**
+   * Top margin on lg (960px) or larger viewports.
+   */
+  lgMarginTop?: Margin;
+  /**
+   * The padding of the box on lg (960px) or larger viewports.
+   */
+  lgPadding?: Padding;
+  /**
+   * The padding of the box on the x-axis on lg (960px) or larger viewports.
+   */
+  lgPaddingX?: Padding;
+  /**
+   * The padding of the box on the y-axis on lg (960px) or larger viewports.
+   */
+  lgPaddingY?: Padding;
+  /**
+   * The margin of the box.
+   *
+   * Responsive props:
+   * * `smMargin`
+   * * `lgMargin`
+   *
+   * @defaultValue 0
+   */
+  margin?: Margin;
+  /**
+   * Bottom margin of the box.
+   *
+   * Responsive props:
+   * * `smMarginBottom`
+   * * `lgMarginBottom`
+   *
+   */
+  marginBottom?: Margin;
+  /**
+   * Margin to the right in left-to-right languages, and to the left in right-to-left languages.
+   *
+   * Responsive props:
+   * * `smMarginEnd`
+   * * `lgMarginEnd`
+   *
+   */
+  marginEnd?: Margin;
+  /**
+   * Margin to the left in left-to-right languages, and to the right in right-to-left languages.
+   *
+   * Responsive props:
+   * * `smMarginStart`
+   * * `lgMarginStart`
+   *
+   */
+  marginStart?: Margin;
+  /**
+   * Top margin of the box.
+   *
+   * Responsive props:
+   * * `smMarginTop`
+   * * `lgMarginTop`
+   *
+   */
+  marginTop?: Margin;
+  /**
+   * The maximum height of the box.
+   */
+  maxHeight?: Dimension;
+  /**
+   * The maximum width of the box.
+   */
+  maxWidth?: Dimension;
+  /**
+   * The minimum height of the box.
+   */
+  minHeight?: Dimension;
+  /**
+   * The minimum width of the box.
+   */
+  minWidth?: Dimension;
+  /**
+   * The height of the box.
+   */
+  height?: Dimension;
+  /**
+   * The alignment of the box on the main axis.
+   *
+   * Responsive props:
+   * * `smJustifyContent`
+   * * `lgJustifyContent`
+   *
+   * @defaultValue "start"
+   */
+  justifyContent?: JustifyContent;
+  /**
+   * The padding of the box.
+   *
+   * Responsive props:
+   * * `smPadding`
+   * * `lgPadding`
+   *
+   * @defaultValue 0
+   */
+  padding?: Padding;
+  /**
+   * The padding of the box on the x-axis.
+   *
+   * Responsive props:
+   * * `smPaddingX`
+   * * `lgPaddingX`
+   *
+   */
+  paddingX?: Padding;
+  /**
+   * The padding of the box on the y-axis.
+   *
+   * Responsive props:
+   * * `smPaddingY`
+   * * `lgPaddingY`
+   */
+  paddingY?: Padding;
+  /**
+   * The position of the box.
+   *
+   * @defaultValue "static"
+   */
+  position?: "absolute" | "fixed" | "relative" | "static" | "sticky";
+  /**
+   * The role attribute of the box.
+   *
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) for the list of valid roles.
+   */
+  role?: AriaRole;
+  /**
+   * Border radius of the box.
+   *
+   * * `none`: 0px
+   * * `sm`: 8px
+   * * `md`: 12px
+   * * `lg`: 16px
+   * * `xl`: 32px
+   * * `full`: 999px
+   *
+   * @defaultValue "none"
+   */
+  rounding?: "xl" | "lg" | "md" | "sm" | "full" | "none";
+  /**
+   * The alignment of the box on the cross axis on sm (480px) or larger viewports.
+   */
+  smAlignItems?: AlignItems;
+  /**
+   * The flex direction on sm (480px) or larger viewports.
+   */
+  smDirection?: Direction;
+  /**
+   * The display style on sm (480px) or larger viewports.
+   */
+  smDisplay?: Display;
+  /**
+   * The alignment of the box on the main axis on sm (480px) or larger viewports.
+   */
+  smJustifyContent?: JustifyContent;
+  /**
+   * Margin on sm (480px) or larger viewports.
+   */
+  smMargin?: Margin;
+  /**
+   * Bottom margin on sm (480px) or larger viewports.
+   */
+  smMarginBottom?: Margin;
+  /**
+   * Margin to the right in left-to-right languages, and to the left in right-to-left languages on sm (480px) or larger viewports.
+   */
+  smMarginEnd?: Margin;
+  /**
+   * Margin to the left in left-to-right languages, and to the right in right-to-left languages on sm (480px) or larger viewports.
+   */
+  smMarginStart?: Margin;
+  /**
+   * Top margin on sm (480px) or larger viewports.
+   */
+  smMarginTop?: Margin;
+  /**
+   * The padding of the box on sm (480px) or larger viewports.
+   */
+  smPadding?: Padding;
+  /**
+   * The padding of the box on the x-axis on sm (480px) or larger viewports.
+   */
+  smPaddingX?: Padding;
+  /**
+   * The padding of the box on the y-axis on sm (480px) or larger viewports.
+   */
+  smPaddingY?: Padding;
+  /**
+   * The width of the box.
+   */
+  width?: Dimension;
+};
+
 /**
  * [Box](https://cambly-syntax.vercel.app/?path=/docs/components-box--docs) is primitive design component and is used by lots of other components. It keeps details like spacing, borders and colors consistent across all of Syntax.
  *
@@ -68,317 +377,10 @@ type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
  *  * `aria-*`
  *  * `data-testid`
  */
-const Box = forwardRef<
-  HTMLDivElement,
-  {
-    /**
-     * The alignment of the box on the cross axis.
-     *
-     * Responsive props:
-     * * `smAlignItems`
-     * * `lgAlignItems`
-     */
-    alignItems?: AlignItems;
-    /**
-     * Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.
-     */
-    alignSelf?: "auto" | "start" | "end" | "center" | "baseline" | "stretch";
-    /**
-     * The underlying DOM element usually set for accessibility or SEO reasons.
-     *
-     * @defaultValue "div"
-     */
-    as?: As;
-    /**
-     * The background color of the box.
-     */
-    backgroundColor?: (typeof allColors)[number];
-    /**
-     * The children to be rendered inside the box.
-     */
-    children?: ReactNode;
-    /**
-     * An "escape hatch" used to apply styles not otherwise available on Box.
-     *
-     * Please use this sparingly and only when you have a good reason to.
-     */
-    dangerouslySetInlineStyle?: {
-      __style: Record<string, string | number | null>;
-    };
-    /**
-     * The flex direction of the box.
-     *
-     * Responsive props:
-     * * `smDirection`
-     * * `lgDirection`
-     *
-     * @defaultValue `row`
-     */
-    direction?: Direction;
-    /**
-     * The display property specifies the display behavior (the type of rendering box) of an element.
-     *
-     * Responsive props:
-     * * `smDisplay`
-     * * `lgDisplay`
-     *
-     * @defaultValue `block`
-     */
-    display?: Display;
-    /**
-     * Sets the flex behavior of a flex item.
-     *
-     * * `none`: The item will not grow or shrink
-     * * `shrink`: The item will shrink if necessary (default browser behavior)
-     * * `grow`: The item will grow if necessary
-     *
-     * @defaultValue `shrink`
-     */
-    flex?: "none" | "shrink" | "grow";
-    /**
-     * By default, flex items will all try to fit onto one line. But if you specify `flexWrap="wrap"`, the flex items will wrap onto multiple lines.
-     *
-     * @defaultValue `nowrap`
-     */
-    flexWrap?: "wrap" | "nowrap";
-    /**
-     * The gap between the children of the box.
-     */
-    gap?: Gap;
-    /**
-     * The id of the element.
-     */
-    id?: string;
-    /**
-     * The alignment of the box on the cross axis on lg (960px) or larger viewports.
-     */
-    lgAlignItems?: AlignItems;
-    /**
-     * The flex direction on lg (960px) or larger viewports.
-     */
-    lgDirection?: Direction;
-    /**
-     * The display style on lg (960px) or larger viewports.
-     */
-    lgDisplay?: Display;
-    /**
-     * The alignment of the box on the cross axis on lg (960px) or larger viewports.
-     */
-    lgJustifyContent?: JustifyContent;
-    /**
-     * Margin on lg (960px) or larger viewports.
-     */
-    lgMargin?: Margin;
-    /**
-     * Bottom margin on lg (960px) or larger viewports.
-     */
-    lgMarginBottom?: Margin;
-    /**
-     * Margin to the right in left-to-right languages, and to the left in right-to-left languages on lg (960px) or larger viewports.
-     */
-    lgMarginEnd?: Margin;
-    /**
-     * Margin to the left in left-to-right languages, and to the right in right-to-left languages on lg (960px) or larger viewports.
-     */
-    lgMarginStart?: Margin;
-    /**
-     * Top margin on lg (960px) or larger viewports.
-     */
-    lgMarginTop?: Margin;
-    /**
-     * The padding of the box on lg (960px) or larger viewports.
-     */
-    lgPadding?: Padding;
-    /**
-     * The padding of the box on the x-axis on lg (960px) or larger viewports.
-     */
-    lgPaddingX?: Padding;
-    /**
-     * The padding of the box on the y-axis on lg (960px) or larger viewports.
-     */
-    lgPaddingY?: Padding;
-    /**
-     * The margin of the box.
-     *
-     * Responsive props:
-     * * `smMargin`
-     * * `lgMargin`
-     *
-     * @defaultValue 0
-     */
-    margin?: Margin;
-    /**
-     * Bottom margin of the box.
-     *
-     * Responsive props:
-     * * `smMarginBottom`
-     * * `lgMarginBottom`
-     *
-     */
-    marginBottom?: Margin;
-    /**
-     * Margin to the right in left-to-right languages, and to the left in right-to-left languages.
-     *
-     * Responsive props:
-     * * `smMarginEnd`
-     * * `lgMarginEnd`
-     *
-     */
-    marginEnd?: Margin;
-    /**
-     * Margin to the left in left-to-right languages, and to the right in right-to-left languages.
-     *
-     * Responsive props:
-     * * `smMarginStart`
-     * * `lgMarginStart`
-     *
-     */
-    marginStart?: Margin;
-    /**
-     * Top margin of the box.
-     *
-     * Responsive props:
-     * * `smMarginTop`
-     * * `lgMarginTop`
-     *
-     */
-    marginTop?: Margin;
-    /**
-     * The maximum height of the box.
-     */
-    maxHeight?: Dimension;
-    /**
-     * The maximum width of the box.
-     */
-    maxWidth?: Dimension;
-    /**
-     * The minimum height of the box.
-     */
-    minHeight?: Dimension;
-    /**
-     * The minimum width of the box.
-     */
-    minWidth?: Dimension;
-    /**
-     * The height of the box.
-     */
-    height?: Dimension;
-    /**
-     * The alignment of the box on the main axis.
-     *
-     * Responsive props:
-     * * `smJustifyContent`
-     * * `lgJustifyContent`
-     *
-     * @defaultValue "start"
-     */
-    justifyContent?: JustifyContent;
-    /**
-     * The padding of the box.
-     *
-     * Responsive props:
-     * * `smPadding`
-     * * `lgPadding`
-     *
-     * @defaultValue 0
-     */
-    padding?: Padding;
-    /**
-     * The padding of the box on the x-axis.
-     *
-     * Responsive props:
-     * * `smPaddingX`
-     * * `lgPaddingX`
-     *
-     */
-    paddingX?: Padding;
-    /**
-     * The padding of the box on the y-axis.
-     *
-     * Responsive props:
-     * * `smPaddingY`
-     * * `lgPaddingY`
-     */
-    paddingY?: Padding;
-    /**
-     * The position of the box.
-     *
-     * @defaultValue "static"
-     */
-    position?: "absolute" | "fixed" | "relative" | "static" | "sticky";
-    /**
-     * The role attribute of the box.
-     *
-     * See [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) for the list of valid roles.
-     */
-    role?: AriaRole;
-    /**
-     * Border radius of the box.
-     *
-     * * `none`: 0px
-     * * `sm`: 8px
-     * * `md`: 12px
-     * * `lg`: 16px
-     * * `xl`: 32px
-     * * `full`: 999px
-     *
-     * @defaultValue "none"
-     */
-    rounding?: "xl" | "lg" | "md" | "sm" | "full" | "none";
-    /**
-     * The alignment of the box on the cross axis on sm (480px) or larger viewports.
-     */
-    smAlignItems?: AlignItems;
-    /**
-     * The flex direction on sm (480px) or larger viewports.
-     */
-    smDirection?: Direction;
-    /**
-     * The display style on sm (480px) or larger viewports.
-     */
-    smDisplay?: Display;
-    /**
-     * The alignment of the box on the main axis on sm (480px) or larger viewports.
-     */
-    smJustifyContent?: JustifyContent;
-    /**
-     * Margin on sm (480px) or larger viewports.
-     */
-    smMargin?: Margin;
-    /**
-     * Bottom margin on sm (480px) or larger viewports.
-     */
-    smMarginBottom?: Margin;
-    /**
-     * Margin to the right in left-to-right languages, and to the left in right-to-left languages on sm (480px) or larger viewports.
-     */
-    smMarginEnd?: Margin;
-    /**
-     * Margin to the left in left-to-right languages, and to the right in right-to-left languages on sm (480px) or larger viewports.
-     */
-    smMarginStart?: Margin;
-    /**
-     * Top margin on sm (480px) or larger viewports.
-     */
-    smMarginTop?: Margin;
-    /**
-     * The padding of the box on sm (480px) or larger viewports.
-     */
-    smPadding?: Padding;
-    /**
-     * The padding of the box on the x-axis on sm (480px) or larger viewports.
-     */
-    smPaddingX?: Padding;
-    /**
-     * The padding of the box on the y-axis on sm (480px) or larger viewports.
-     */
-    smPaddingY?: Padding;
-    /**
-     * The width of the box.
-     */
-    width?: Dimension;
-  }
->(function Box(props, ref): ReactElement {
+const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
+  props: BoxProps,
+  ref,
+): ReactElement {
   const { as: BoxElement = "div", children, ...boxProps } = props;
 
   const {

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -13,7 +13,7 @@ import textVariant from "./constants/textVariant";
 import loadingIconSize from "./constants/loadingIconSize";
 import styles from "./Button.module.css";
 
-type ButtonType = {
+type ButtonProps = {
   /**
    * Test id for the button
    */
@@ -97,7 +97,7 @@ type ButtonType = {
 /**
  * [Button](https://cambly-syntax.vercel.app/?path=/docs/components-button--docs) is used to trigger an action or event, such as submitting a form, opening a dialog, canceling an action, or performing a delete operation.
  */
-const Button = forwardRef<HTMLButtonElement, ButtonType>(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       "data-testid": dataTestId,
@@ -114,7 +114,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonType>(
       onClick,
       tooltip,
       type = "button",
-    },
+    }: ButtonProps,
     ref,
   ) => {
     return (

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -11,7 +11,7 @@ const iconSize = {
   ["lg"]: styles.lgIcon,
 };
 
-type IconButtonType = {
+type IconButtonProps = {
   /**
    * The color of the button
    *
@@ -59,7 +59,7 @@ type IconButtonType = {
 /**
  * [IconButton](https://cambly-syntax.vercel.app/?path=/docs/components-iconbutton--docs) is a clickable element that is used to perform an action.
  */
-const IconButton = forwardRef<HTMLButtonElement, IconButtonType>(
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
       accessibilityLabel,
@@ -70,7 +70,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonType>(
       size = "md",
       tooltip,
       onClick,
-    },
+    }: IconButtonProps,
     ref,
   ) => {
     return (

--- a/packages/syntax-core/src/Modal/Modal.tsx
+++ b/packages/syntax-core/src/Modal/Modal.tsx
@@ -27,7 +27,50 @@ const sizeWidth = {
   lg: 600,
 } as const;
 
-type ModalType = {
+/**
+ * [Modal](https://cambly-syntax.vercel.app/?path=/docs/components-modal--docs) is a dialog that appears on top of the main content and locks user interaction within the modal.
+ *
+ ```
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      {showModal && <Modal
+        header="header text"
+        onDismiss={() => setShowModal(false)}
+        footer={
+          <>
+            <Button
+              text="Cancel"
+              color="secondary"
+              onClick={() => {}}
+            />
+            <Button
+              text="Confirm"
+              onClick={() => {}}
+            />
+          </>
+        }
+      >
+        <Typography>
+          Body text goes here!
+        </Typography>
+      </Modal> }
+    </>
+  )
+  ```
+ */
+export default function Modal({
+  header,
+  children,
+  image,
+  onDismiss,
+  footer,
+  accessibilityCloseLabel = "close modal",
+  size = "sm",
+  zIndex = 1,
+  "data-testid": dataTestId,
+}: {
   /**
    * The modal's main content. Should typically take in `Typography`'d text.
    */
@@ -95,52 +138,7 @@ type ModalType = {
    * Test id for the modal
    */
   "data-testid"?: string;
-};
-
-/**
- * [Modal](https://cambly-syntax.vercel.app/?path=/docs/components-modal--docs) is a dialog that appears on top of the main content and locks user interaction within the modal.
- *
- ```
-  const [showModal, setShowModal] = useState(false)
-
-  return (
-    <>
-      {showModal && <Modal
-        header="header text"
-        onDismiss={() => setShowModal(false)}
-        footer={
-          <>
-            <Button
-              text="Cancel"
-              color="secondary"
-              onClick={() => {}}
-            />
-            <Button
-              text="Confirm"
-              onClick={() => {}}
-            />
-          </>
-        }
-      >
-        <Typography>
-          Body text goes here!
-        </Typography>
-      </Modal> }
-    </>
-  )
-  ```
- */
-export default function Modal({
-  header,
-  children,
-  image,
-  onDismiss,
-  footer,
-  accessibilityCloseLabel = "close modal",
-  size = "sm",
-  zIndex = 1,
-  "data-testid": dataTestId,
-}: ModalType): ReactElement {
+}): ReactElement {
   return (
     <Layer zIndex={zIndex}>
       <StopScroll>

--- a/packages/syntax-floating-components/src/Tooltip/Tooltip.tsx
+++ b/packages/syntax-floating-components/src/Tooltip/Tooltip.tsx
@@ -58,7 +58,15 @@ type TooltipOptions = {
   strategy?: Strategy;
 };
 
-type UseTooltipType = UseFloatingReturn & {
+export function useTooltip({
+  delay = 0,
+  initialOpen = false,
+  open: controlledOpen,
+  placement = "right",
+  strategy = "absolute",
+  onOpen = undefined,
+  onClose = undefined,
+}: TooltipOptions): UseFloatingReturn & {
   getReferenceProps: (
     userProps?: React.HTMLProps<Element> | undefined,
   ) => Record<string, unknown>;
@@ -71,17 +79,7 @@ type UseTooltipType = UseFloatingReturn & {
   arrowRef: React.MutableRefObject<null>;
   open: boolean;
   setOpen: (open: boolean) => void;
-};
-
-export function useTooltip({
-  delay = 0,
-  initialOpen = false,
-  open: controlledOpen,
-  placement = "right",
-  strategy = "absolute",
-  onOpen = undefined,
-  onClose = undefined,
-}: TooltipOptions): UseTooltipType {
+} {
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(initialOpen);
 
   const arrowRef = React.useRef(null);
@@ -147,9 +145,9 @@ export function useTooltip({
   );
 }
 
-type ContextType = ReturnType<typeof useTooltip> | null;
-
-const TooltipContext = React.createContext<ContextType>(null);
+const TooltipContext = React.createContext<ReturnType<
+  typeof useTooltip
+> | null>(null);
 
 const useTooltipContext = () => {
   const context = React.useContext(TooltipContext);


### PR DESCRIPTION
# Changes

Fixes an issue with generated docs not working as expected when we use `forwardRef`. Description for each prop and whether the prop is required was not showing up

## Before

![Screenshot 2023-08-14 at 12 34 13 PM](https://github.com/Cambly/syntax/assets/127199/315c447a-8d70-4e2d-b8ff-59ca97a09a61)

## After

![Screenshot 2023-08-14 at 12 33 56 PM](https://github.com/Cambly/syntax/assets/127199/f7b60432-06a2-4863-94af-04a4602943ae)

# How did you find a solution?

Looked at the test cases in `react-docgen` which don't use a generic for `React.forwardRef`:
https://github.com/reactjs/react-docgen/pull/277/files#diff-de4b771f65b56eed28f15d85b12e65a9a94643474177ce33588e0ee63ec836edR5-R7

So the fix is to annotate the type again.
