### PR TITLE
LinkButton: allow ref to be set

### DIFF
--- a/.changeset/tender-pumpkins-scream.md
+++ b/.changeset/tender-pumpkins-scream.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+LinkButton: allow 'ref' to be set

--- a/packages/syntax-core/src/LinkButton/LinkButton.test.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { expect, vi } from "vitest";
 
 import LinkButton from "./LinkButton";
+import { createRef } from "react";
 
 describe("linkButton", () => {
   it("renders successfully", () => {
@@ -80,5 +81,22 @@ describe("linkButton", () => {
     );
     const linkButton = await screen.findByTestId("linkButton-test-id");
     expect(linkButton).toHaveStyle({ width: "100%" });
+  });
+
+  it("allows ref to be set", () => {
+    const ref = createRef<HTMLAnchorElement>();
+
+    render(
+      <LinkButton
+        text="button"
+        data-testid="linkButton-test-id"
+        href="https://www.google.com"
+        ref={ref}
+      />,
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toBeTruthy();
+    expect(ref.current?.getAttribute("data-testid")).toStrictEqual(
+      "linkButton-test-id",
+    );
   });
 });

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -1,4 +1,4 @@
-import { type HtmlHTMLAttributes } from "react";
+import { forwardRef, type HtmlHTMLAttributes } from "react";
 import classNames from "classnames";
 import backgroundColor from "../colors/backgroundColor";
 import foregroundColor from "../colors/foregroundColor";
@@ -13,22 +13,7 @@ import textVariant from "../Button/constants/textVariant";
 
 import styles from "./LinkButton.module.css";
 
-/**
- * [LinkButton](https://cambly-syntax.vercel.app/?path=/docs/components-linkbutton--docs) is a "variation" of Button that should look identical to Button, but should be used to render links instead.
- */
-export default function LinkButton({
-  text,
-  href,
-  target,
-  rel,
-  "data-testid": dataTestId,
-  color = "primary",
-  size = "md",
-  fullWidth = false,
-  startIcon: StartIcon,
-  endIcon: EndIcon,
-  onClick,
-}: {
+type LinkButtonProps = {
   /**
    * Test id for the button
    */
@@ -94,42 +79,71 @@ export default function LinkButton({
    * An optional onClick event. This is used for certain wrapper's support (such as react-router-dom).
    */
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-}): JSX.Element {
-  return (
-    <a
-      href={href}
-      data-testid={dataTestId}
-      target={target}
-      rel={rel}
-      className={classNames(
-        styles.linkButton,
-        buttonStyles.button,
-        foregroundColor(color),
-        backgroundColor(color),
-        buttonStyles[size],
-        {
-          [buttonStyles.fullWidth]: fullWidth,
-          [styles.fitContent]: !fullWidth,
-          [buttonStyles.buttonGap]: size === "lg" || size === "md",
-          [buttonStyles.secondaryBorder]: color === "secondary",
-          [buttonStyles.secondaryDestructiveBorder]:
-            color === "destructive-secondary",
-        },
-      )}
-      onClick={onClick}
-    >
-      {StartIcon && (
-        <StartIcon className={classNames(buttonStyles.icon, iconSize[size])} />
-      )}
-      <Typography
-        color={foregroundTypographyColor(color)}
-        size={textVariant[size]}
+};
+
+/**
+ * [LinkButton](https://cambly-syntax.vercel.app/?path=/docs/components-linkbutton--docs) is a "variation" of Button that should look identical to Button, but should be used to render links instead.
+ */
+const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
+  (
+    {
+      text,
+      href,
+      target,
+      rel,
+      "data-testid": dataTestId,
+      color = "primary",
+      size = "md",
+      fullWidth = false,
+      startIcon: StartIcon,
+      endIcon: EndIcon,
+      onClick,
+    }: LinkButtonProps,
+    ref,
+  ) => {
+    return (
+      <a
+        href={href}
+        data-testid={dataTestId}
+        target={target}
+        ref={ref}
+        rel={rel}
+        className={classNames(
+          styles.linkButton,
+          buttonStyles.button,
+          foregroundColor(color),
+          backgroundColor(color),
+          buttonStyles[size],
+          {
+            [buttonStyles.fullWidth]: fullWidth,
+            [styles.fitContent]: !fullWidth,
+            [buttonStyles.buttonGap]: size === "lg" || size === "md",
+            [buttonStyles.secondaryBorder]: color === "secondary",
+            [buttonStyles.secondaryDestructiveBorder]:
+              color === "destructive-secondary",
+          },
+        )}
+        onClick={onClick}
       >
-        <span style={{ fontWeight: 500 }}>{text}</span>
-      </Typography>
-      {EndIcon && (
-        <EndIcon className={classNames(buttonStyles.icon, iconSize[size])} />
-      )}
-    </a>
-  );
-}
+        {StartIcon && (
+          <StartIcon
+            className={classNames(buttonStyles.icon, iconSize[size])}
+          />
+        )}
+        <Typography
+          color={foregroundTypographyColor(color)}
+          size={textVariant[size]}
+        >
+          <span style={{ fontWeight: 500 }}>{text}</span>
+        </Typography>
+        {EndIcon && (
+          <EndIcon className={classNames(buttonStyles.icon, iconSize[size])} />
+        )}
+      </a>
+    );
+  },
+);
+
+LinkButton.displayName = "LinkButton";
+
+export default LinkButton;


### PR DESCRIPTION
# Changes

* `LinkButton` allow `ref` to be set

# Why

To avoid the following error when wrapping `LinkButton` in `NextLinkButton`:

```
1) [chromium] › adult-landing.spec.ts:17:7 › Adult landing › renders without warnings or errors in the console 

    Error: Page rendered with console messages: error - Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?%s%s 

    Check the render method of `ForwardRef(LinkComponent)`.
```

# How?

By using [forwardRef](https://react.dev/reference/react/forwardRef) on `LinkButton`

# Related PRs

* #223 
* https://github.com/Cambly/Cambly-Frontend/pull/6276