### PR TITLE
Typography / Heading: allow data-testid to be set

### DIFF
--- a/.changeset/tough-trees-laugh.md
+++ b/.changeset/tough-trees-laugh.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Allow `data-testid` to be set on `Typography` and `Heading`

--- a/packages/syntax-core/src/Heading/Heading.test.tsx
+++ b/packages/syntax-core/src/Heading/Heading.test.tsx
@@ -39,4 +39,9 @@ describe("heading", () => {
       "Heading 6",
     );
   });
+
+  it("sets test id", () => {
+    render(<Heading data-testid="heading-testid">Test</Heading>);
+    expect(screen.getByTestId("heading-testid")).toBeInTheDocument();
+  });
 });

--- a/packages/syntax-core/src/Heading/Heading.tsx
+++ b/packages/syntax-core/src/Heading/Heading.tsx
@@ -10,6 +10,7 @@ const Heading = ({
   as = "h1",
   children,
   color = "gray900",
+  "data-testid": dataTestId,
   size = 500,
 }: {
   /**
@@ -37,6 +38,10 @@ const Heading = ({
    */
   color?: (typeof Color)[number];
   /**
+   * Test id for the text.
+   */
+  "data-testid"?: string;
+  /**
    * Size of the text.
    *
    * * `500`: 20px
@@ -50,7 +55,14 @@ const Heading = ({
 }): ReactElement => {
   const weight = [700, 800].includes(size) ? "heavy" : "bold";
   return (
-    <Typography align={align} as={as} color={color} size={size} weight={weight}>
+    <Typography
+      align={align}
+      as={as}
+      color={color}
+      data-testid={dataTestId}
+      size={size}
+      weight={weight}
+    >
       {children}
     </Typography>
   );

--- a/packages/syntax-core/src/Typography/Typography.test.tsx
+++ b/packages/syntax-core/src/Typography/Typography.test.tsx
@@ -39,4 +39,9 @@ describe("typography", () => {
       "Heading 6",
     );
   });
+
+  it("sets test id", () => {
+    render(<Typography data-testid="typography-testid">Test</Typography>);
+    expect(screen.getByTestId("typography-testid")).toBeInTheDocument();
+  });
 });

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -29,6 +29,7 @@ const Typography = ({
   as = "div",
   children,
   color = "gray900",
+  "data-testid": dataTestId,
   inline = false,
   lineClamp = undefined,
   size = 200,
@@ -61,6 +62,10 @@ const Typography = ({
    * @defaultValue "gray900"
    */
   color?: (typeof Color)[number];
+  /**
+   * Test id for the text
+   */
+  "data-testid"?: string;
   /**
    * Whether the text should flow inline with other elements.
    *
@@ -123,6 +128,7 @@ const Typography = ({
         underline && styles.underline,
         lineClamp != null && styles.lineClamp,
       )}
+      data-testid={dataTestId}
       style={{
         WebkitLineClamp: lineClamp,
       }}


### PR DESCRIPTION
# Changes

Allow `data-testid` to be set on `Typography` and `Heading`

# Why

Enables more intuitive and readable code that can be used for testing:

```tsx
// Before
<Heading>
  <span data-testid="heading-testid">{heading}</span>
</Heading>
```

```tsx
// After
<Heading data-testid="heading-testid">
  {heading}
</Heading>
```


# Related PRs

* #157 