### PR TITLE
Generate Script: update script + test wording

### DIFF
--- a/generate-component/Template.test.tsx
+++ b/generate-component/Template.test.tsx
@@ -4,7 +4,7 @@ import Template from "./Template";
 
 // NOTE: Update this to be the lowercased version!
 describe("Template", () => {
-  it("it should render successfully", () => {
+  it("renders successfully", () => {
     // Update tests here:
     // Don't forget to add your props!
     render(<Template text="text!!" />);

--- a/generate-component/index.ts
+++ b/generate-component/index.ts
@@ -83,7 +83,7 @@ async function generateComponent() {
     );
 
     // insert new component into 'packages/syntax-core/src/index.tsx file
-    // updateIndexFile(name);
+    updateIndexFile(name);
 
     console.log(
       `TODO: Update the describe block of your newly generated .test.tsx to be lowercased! e.g: describe("template", ....)\n`,


### PR DESCRIPTION
no changeset because this doesnt require version bump, just utility

- update index function was commented out during testing, uncommenting it out now.
- update tests wording to be consistent with our current test wording