### PR TITLE
SelectList: avoid long text overlapping caret

### DIFF
--- a/.changeset/fifty-brooms-ring.md
+++ b/.changeset/fifty-brooms-ring.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+SelectList: avoid long text overlapping caret

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -30,7 +30,7 @@
   justify-content: space-between;
   margin: 0;
   outline: 0;
-  padding: 0 12px;
+  padding: 0 36px 0 12px;
   width: 100%;
 }
 


### PR DESCRIPTION
# Changes

SelectList: avoid long text overlapping caret

## Before
![Screenshot 2023-08-30 at 10 33 30 AM](https://github.com/Cambly/syntax/assets/127199/14366e67-b80b-4576-88ff-8495921fd1ca)

## After
![Screenshot 2023-08-30 at 10 33 08 AM](https://github.com/Cambly/syntax/assets/127199/cc3b51b4-8941-47fd-b824-8173542c0eb0)

