### PR TITLE
Chip: Update chip to have cursor on hover

### DIFF
--- a/.changeset/quick-dots-breathe.md
+++ b/.changeset/quick-dots-breathe.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Chip/add-cursor-pointer-on-hover

--- a/packages/syntax-core/src/Chip/Chip.module.css
+++ b/packages/syntax-core/src/Chip/Chip.module.css
@@ -6,6 +6,7 @@
   border-radius: 1000px;
   justify-content: center;
   text-align: center;
+  cursor: pointer;
 }
 
 .selectedChip {


### PR DESCRIPTION
Chip is a clickable element and should have a cursor on hover. Adding `cursor: pointer` should fix this issue.

https://www.loom.com/share/14724ecbb04f499999bed4ed8b46374b