### PR TITLE
LinkButton: Update box-sizing

### DIFF
--- a/.changeset/five-yaks-kneel.md
+++ b/.changeset/five-yaks-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+LinkButton: Add box-sizing: border-box to fix centering issue

--- a/packages/syntax-core/src/LinkButton/LinkButton.module.css
+++ b/packages/syntax-core/src/LinkButton/LinkButton.module.css
@@ -1,6 +1,6 @@
 .linkButton {
-  text-decoration: none;
   box-sizing: border-box;
+  text-decoration: none;
 }
 
 .linkButton:focus,

--- a/packages/syntax-core/src/LinkButton/LinkButton.module.css
+++ b/packages/syntax-core/src/LinkButton/LinkButton.module.css
@@ -1,5 +1,6 @@
 .linkButton {
   text-decoration: none;
+  box-sizing: border-box;
 }
 
 .linkButton:focus,


### PR DESCRIPTION
LinkButton previously did not have `box-sizing: border-box` which was causing it to overflow (and not be centered) in certain places of the UI. Adding that should solve it.

Example: (note: this isn't live, just a demo)

BEFORE: 
![image](https://github.com/Cambly/syntax/assets/15243713/1173b5ca-1991-48fa-9d22-17a3790af503)

AFTER: 
![image](https://github.com/Cambly/syntax/assets/15243713/fb62fbe5-34f9-4dbd-a3f6-312d8aa3746c)
