### PR TITLE
TapArea: add component

### DIFF
--- a/.changeset/olive-kings-drop.md
+++ b/.changeset/olive-kings-drop.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TapArea: add component

--- a/packages/syntax-core/src/Box/Box.module.css
+++ b/packages/syntax-core/src/Box/Box.module.css
@@ -106,27 +106,6 @@
   align-self: auto;
 }
 
-/* Border Radius */
-.roundingsm {
-  border-radius: 8px;
-}
-
-.roundingmd {
-  border-radius: 12px;
-}
-
-.roundinglg {
-  border-radius: 16px;
-}
-
-.roundingxl {
-  border-radius: 32px;
-}
-
-.roundingfull {
-  border-radius: 999px;
-}
-
 /* Display (base) */
 .block {
   display: block;

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -5,6 +5,7 @@ import marginStyles from "./margin.module.css";
 import paddingStyles from "./padding.module.css";
 import type allColors from "../colors/allColors";
 import colorStyles from "../colors/colors.module.css";
+import roundingStyles from "../rounding.module.css";
 import { forwardRef } from "react";
 
 type AlignItems = "baseline" | "center" | "end" | "start" | "stretch";
@@ -524,7 +525,7 @@ const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
       smJustifyContent && styles[`justifyContent${smJustifyContent}Small`],
       lgJustifyContent && styles[`justifyContent${lgJustifyContent}Large`],
       position && position !== "static" && styles[position],
-      rounding && rounding !== "none" && styles[`rounding${rounding}`],
+      rounding && rounding !== "none" && roundingStyles[`rounding${rounding}`],
     ),
     style: {
       height,

--- a/packages/syntax-core/src/TapArea/TapArea.module.css
+++ b/packages/syntax-core/src/TapArea/TapArea.module.css
@@ -1,0 +1,38 @@
+.tapArea {
+  box-sizing: border-box;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.disabled {
+  filter: opacity(50%);
+  background-image: none;
+  transform: none;
+  cursor: auto;
+}
+
+.enabled {
+  cursor: pointer;
+}
+
+.enabled:hover {
+  background-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.1) 0%,
+    rgba(0, 0, 0, 0.1) 100%
+  );
+  transition-duration: 0.2s;
+  cursor: pointer;
+}
+
+.enabled:focus-visible {
+  background-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.2) 0%,
+    rgba(0, 0, 0, 0.2) 100%
+  );
+  box-shadow: 0 0 0 4px #000;
+  outline: solid 2px #fff;
+}

--- a/packages/syntax-core/src/TapArea/TapArea.stories.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.stories.tsx
@@ -1,0 +1,84 @@
+import { type StoryObj, type Meta } from "@storybook/react";
+import TapArea from "./TapArea";
+import Avatar from "../Avatar/Avatar";
+import image from "../../../../apps/storybook/assets/images/jane.webp";
+import Box from "../Box/Box";
+import Typography from "../Typography/Typography";
+
+export default {
+  title: "Components/TapArea",
+  component: TapArea,
+  argTypes: {
+    disabled: {
+      control: "boolean",
+    },
+    onClick: { action: "clicked" },
+    rounding: {
+      options: ["none", "sm", "md", "lg", "xl", "full"],
+      control: { type: "select" },
+    },
+    tabIndex: {
+      control: { type: "number" },
+      options: [0, -1],
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof TapArea>;
+
+export const Default: StoryObj<typeof TapArea> = {
+  args: {
+    children: (
+      <Box display="flex" alignItems="center" gap={4} padding={2}>
+        <Avatar accessibilityLabel="Jane" src={image} size="md" />
+        <Typography size={500}>Jane Doe</Typography>
+      </Box>
+    ),
+  },
+};
+
+export const Disabled: StoryObj<typeof Default> = {
+  args: { ...Default.args, disabled: true },
+};
+
+const roundingLookup = {
+  sm: "8px",
+  md: "12px",
+  lg: "16px",
+  xl: "32px",
+  full: "999px",
+} as const;
+
+export const Rounding: StoryObj<typeof Box> = {
+  render: () => (
+    <>
+      <Box display="flex" direction="column" gap={4}>
+        <Typography>Hover to see the rounding effect</Typography>
+
+        <Box
+          display="flex"
+          gap={4}
+          flexWrap="wrap"
+          backgroundColor="gray100"
+          padding={4}
+        >
+          {(["sm", "md", "lg", "xl", "full"] as const).map((rounding) => (
+            <TapArea
+              key={rounding}
+              rounding={rounding}
+              fullWidth={false}
+              onClick={() => {
+                /* empty */
+              }}
+            >
+              <Box display="flex" alignItems="center" gap={2} padding={2}>
+                <Typography tooltip={`${roundingLookup[rounding]}`}>
+                  rounding=&quot;{rounding}&quot;
+                </Typography>
+              </Box>
+            </TapArea>
+          ))}
+        </Box>
+      </Box>
+    </>
+  ),
+};

--- a/packages/syntax-core/src/TapArea/TapArea.test.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.test.tsx
@@ -1,0 +1,170 @@
+import { screen, render } from "@testing-library/react";
+import TapArea from "./TapArea";
+import { expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+
+describe("tapArea", () => {
+  it("renders successfully", () => {
+    const { baseElement } = render(
+      <TapArea
+        onClick={() => {
+          /* empty */
+        }}
+      />,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it("renders an role=button element", async () => {
+    render(
+      <TapArea
+        onClick={() => {
+          /* empty */
+        }}
+      />,
+    );
+    const tapArea = await screen.findAllByRole("button");
+    expect(tapArea).toHaveLength(1);
+  });
+
+  it("renders its children", async () => {
+    render(
+      <TapArea
+        onClick={() => {
+          /* empty */
+        }}
+      >
+        <div data-testid="tap-area-child-testid">Continue</div>
+      </TapArea>,
+    );
+    const child = await screen.findByTestId("tap-area-child-testid");
+    expect(child).toHaveTextContent("Continue");
+  });
+
+  it("correctly applies fullWidth when set", async () => {
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        fullWidth
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    expect(tapArea).toHaveStyle({ width: "100%" });
+  });
+
+  it("sets an accessibility label", async () => {
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        accessibilityLabel="Continue to the next step"
+        fullWidth
+      />,
+    );
+    const tapArea = await screen.findAllByLabelText(
+      "Continue to the next step",
+    );
+    expect(tapArea).toHaveLength(1);
+  });
+
+  it("fires onClick when clicked and the TapArea is enabled", async () => {
+    const handleTap = vi.fn();
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={handleTap}
+        accessibilityLabel="Continue to the next step"
+      />,
+    );
+    const tapArea = await screen.findAllByLabelText(
+      "Continue to the next step",
+    );
+    await userEvent.click(tapArea[0]);
+    expect(handleTap).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire the onClick when clicked and the TapArea is disabled", async () => {
+    const handleTap = vi.fn();
+    render(
+      <TapArea
+        disabled
+        data-testid="tap-area-testid"
+        onClick={handleTap}
+        accessibilityLabel="Continue to the next step"
+      />,
+    );
+    const tapArea = await screen.findAllByLabelText(
+      "Continue to the next step",
+    );
+    await userEvent.click(tapArea[0]);
+    expect(handleTap).toHaveBeenCalledTimes(0);
+  });
+
+  it("allows us to focus the TapArea", async () => {
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    tapArea.focus();
+    expect(tapArea).toHaveFocus();
+  });
+
+  it("does not allow us to focus the TapArea when it's disabled", async () => {
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        disabled
+        onClick={() => {
+          /* empty */
+        }}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    tapArea.focus();
+    expect(tapArea).not.toHaveFocus();
+  });
+
+  it("to focus the TapArea programatically when tabindex = -1", async () => {
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        tabIndex={-1}
+        onClick={() => {
+          /* empty */
+        }}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    tapArea.focus();
+    expect(tapArea).toHaveFocus();
+  });
+
+  it("forward the ref correctly", () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        ref={ref}
+        onClick={() => {
+          /* empty */
+        }}
+      />,
+    );
+    expect(ref.current instanceof HTMLDivElement).toBeTruthy();
+    expect(ref.current?.getAttribute("data-testid")).toStrictEqual(
+      "tap-area-testid",
+    );
+  });
+});

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -1,0 +1,96 @@
+import React, { type ReactNode, forwardRef } from "react";
+import classNames from "classnames";
+import styles from "./TapArea.module.css";
+import roundingStyles from "../rounding.module.css";
+
+type TapAreaProps = {
+  /**
+   * The children to be rendered inside the tap area.
+   */
+  children?: ReactNode;
+  /**
+   * The label to be used for accessibility
+   */
+  accessibilityLabel?: string;
+  /**
+   * Test id for the tap area
+   */
+  "data-testid"?: string;
+  /**
+   * If `true`, the tap area will be disabled
+   *
+   * @defaultValue false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the tap area will be full width
+   */
+  fullWidth?: boolean;
+  /**
+   * The callback to be called when the tap area is clicked
+   */
+  onClick: React.MouseEventHandler<HTMLDivElement>;
+  /**
+   * Border radius of the tap area.
+   *
+   * * `none`: 0px
+   * * `sm`: 8px
+   * * `md`: 12px
+   * * `lg`: 16px
+   * * `xl`: 32px
+   * * `full`: 999px
+   *
+   * @defaultValue "none"
+   */
+  rounding?: "xl" | "lg" | "md" | "sm" | "full" | "none";
+  /**
+   * The tab index of the tap area
+   */
+  tabIndex?: 0 | -1;
+};
+
+/**
+ * [TapArea](https://cambly-syntax.vercel.app/?path=/docs/components-taparea--docs) allows components to be clickable and touchable in an accessible way.
+ */
+const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
+  (
+    {
+      children,
+      accessibilityLabel,
+      "data-testid": dataTestId,
+      disabled = false,
+      fullWidth = true,
+      onClick,
+      rounding = "none",
+      tabIndex = 0,
+    }: TapAreaProps,
+    ref,
+  ) => {
+    const handleClick: React.MouseEventHandler<HTMLDivElement> = (event) =>
+      !disabled ? onClick(event) : undefined;
+
+    return (
+      <div
+        aria-disabled={disabled}
+        aria-label={accessibilityLabel}
+        className={classNames(
+          styles.tapArea,
+          styles[`${disabled ? "disabled" : "enabled"}`],
+          fullWidth && styles.fullWidth,
+          rounding !== "none" && roundingStyles[`rounding${rounding}`],
+        )}
+        data-testid={dataTestId}
+        onClick={handleClick}
+        ref={ref}
+        role="button"
+        tabIndex={disabled ? undefined : tabIndex}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+TapArea.displayName = "TapArea";
+
+export default TapArea;

--- a/packages/syntax-core/src/index.tsx
+++ b/packages/syntax-core/src/index.tsx
@@ -14,6 +14,7 @@ import MiniActionCard from "./MiniActionCard/MiniActionCard";
 import Modal from "./Modal/Modal";
 import RadioButton from "./RadioButton/RadioButton";
 import SelectList from "./SelectList/SelectList";
+import TapArea from "./TapArea/TapArea";
 import TextField from "./TextField/TextField";
 import Typography from "./Typography/Typography";
 
@@ -34,6 +35,7 @@ export {
   Modal,
   RadioButton,
   SelectList,
+  TapArea,
   TextField,
   Typography,
 };

--- a/packages/syntax-core/src/rounding.module.css
+++ b/packages/syntax-core/src/rounding.module.css
@@ -1,0 +1,20 @@
+/* Border Radius */
+.roundingsm {
+  border-radius: 8px;
+}
+
+.roundingmd {
+  border-radius: 12px;
+}
+
+.roundinglg {
+  border-radius: 16px;
+}
+
+.roundingxl {
+  border-radius: 32px;
+}
+
+.roundingfull {
+  border-radius: 999px;
+}


### PR DESCRIPTION
# Changes

Adds the `TapArea` component to Syntax

# Why?

We see more and more of a need of an accessible component which is clickable / tapable (to support mobile). Just grepping for `role="button"` in Cambly-Frontend shows 33 instances:
![image](https://github.com/Cambly/syntax/assets/127199/cc2f4613-82f7-41ff-90e7-caff3535458a)

# Notes

* The `compress` feature can happen in a follow up - I just added a base component that folks can start using today

# Screenshot

![image](https://github.com/Cambly/syntax/assets/127199/64985f7b-d657-46ac-9ca6-536ecf3a986d)

