### PR TITLE
Feat: IconButton - color="black"

### DIFF
--- a/.changeset/gold-knives-live.md
+++ b/.changeset/gold-knives-live.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+IconButton: add "black" as valid color prop value

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -2,7 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import IconButton from "./IconButton";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import Star from "@mui/icons-material/Star";
-import { Color, type Size } from "../constants";
+import { Color } from "../constants";
 import Box from "../Box/Box";
 
 export default {

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -75,5 +75,5 @@ export const Colors: StoryObj<typeof IconButton> = {
         />
       ))}
     </Box>
-    )
+  ),
 };

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -2,6 +2,8 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import IconButton from "./IconButton";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import Star from "@mui/icons-material/Star";
+import { Color, type Size } from "../constants";
+import Box from "../Box/Box";
 
 export default {
   title: "Components/IconButton",
@@ -14,14 +16,7 @@ export default {
   },
   argTypes: {
     color: {
-      options: [
-        "primary",
-        "secondary",
-        "tertiary",
-        "destructive-primary",
-        "destructive-secondary",
-        "success",
-      ],
+      options: Color,
       control: { type: "radio" },
     },
     size: {
@@ -67,4 +62,18 @@ export const Success: StoryObj<typeof IconButton> = {
 };
 export const DifferentIcon: StoryObj<typeof IconButton> = {
   args: { ...Default.args, icon: FavoriteBorder },
+};
+export const Colors: StoryObj<typeof IconButton> = {
+  render: () => (
+    <Box display="flex" gap={3}>
+      {Color.map((color) => (
+        <IconButton
+          key={color}
+          color={color}
+          icon={Star}
+          accessibilityLabel={color}
+        />
+      ))}
+    </Box>
+    )
 };

--- a/packages/syntax-core/src/IconButton/IconButton.test.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.test.tsx
@@ -12,18 +12,20 @@ describe("iconButton", () => {
           /* empty */
         }}
         icon={Star}
+        accessibilityLabel="My accessibility label"
       />,
     );
     expect(baseElement).toBeTruthy();
   });
 
-  it("renders an role=IconButton element", async () => {
+  it("renders an role=button element", async () => {
     render(
       <IconButton
         onClick={() => {
           /* empty */
         }}
         icon={Star}
+        accessibilityLabel="My accessibility label"
       />,
     );
     const button = await screen.findAllByRole("button");

--- a/packages/syntax-core/src/colors/backgroundColor.ts
+++ b/packages/syntax-core/src/colors/backgroundColor.ts
@@ -16,6 +16,8 @@ export default function backgroundColor(color: (typeof Color)[number]): string {
       return styles.whiteBackgroundColor;
     case "branded":
       return styles.yellow700BackgroundColor;
+    case "black":
+      return styles.blackBackgroundColor;
     default:
       return styles.primary700BackgroundColor;
   }

--- a/packages/syntax-core/src/constants.ts
+++ b/packages/syntax-core/src/constants.ts
@@ -12,6 +12,7 @@ export const Color = [
   "gray800",
   "gray900",
   "white",
+  "black",
   "inherit",
 ] as const;
 


### PR DESCRIPTION
## What

This adds `"black"` as a valid `Color` and wires it in so that `IconButton` can display a black button

## Why

A design I am working from is wanting to use a round button that is black:

<img width="442" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/baa5ec20-20e0-4ae3-8aec-da5dd5ef25e1">

### Story

There is a new story in this PR that renders `IconButton` using all `color` prop values that it accepts:  As of now that looks like this:

![image](https://github.com/Cambly/syntax/assets/1890801/7e96d02e-76bc-4c3f-943b-f81abad409c7)


### Notes

`IconButton` isn't the exact component I need to implement that design (locall in my feature branch I have a very ugly hack that is passing in a fake `icon` componenttype that can render text `1`,`2`,`3`,`4`, etc... inside instead of an Icon

In a separate PR I am going to be proposing a new `RoundButton` component (I will take absolutely any and all suggestions for naming it!) that will allow the round button design used in IconButton to be used to render a button of fixed size with text children.  That is not this PR.