### PR TITLE
Fix: TapArea - keyboard interaction when focused

### DIFF
--- a/.changeset/mean-seas-bake.md
+++ b/.changeset/mean-seas-bake.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Fix: TapArea - handle keyboard interaction when focused

--- a/packages/syntax-core/src/TapArea/TapArea.test.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.test.tsx
@@ -167,4 +167,20 @@ describe("tapArea", () => {
       "tap-area-testid",
     );
   });
+
+  it("when focused it is keyboard interactable", async () => {
+    const spy = vi.fn();
+    render(<TapArea data-testid="tap-area-testid" onClick={spy} />);
+
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    // tab to focus on the tapArea
+    await userEvent.tab();
+    expect(tapArea).toHaveFocus();
+    await userEvent.keyboard("{Enter}");
+    expect(spy).toHaveBeenCalledTimes(1);
+    await userEvent.keyboard("{Space}");
+    expect(spy).toHaveBeenCalledTimes(2);
+    await userEvent.keyboard(" ");
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -29,7 +29,7 @@ type TapAreaProps = {
   /**
    * The callback to be called when the tap area is clicked
    */
-  onClick: React.MouseEventHandler<HTMLDivElement>;
+  onClick: (event: React.SyntheticEvent<HTMLDivElement>) => void;
   /**
    * Border radius of the tap area.
    *
@@ -69,6 +69,13 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
     const handleClick: React.MouseEventHandler<HTMLDivElement> = (event) =>
       !disabled ? onClick(event) : undefined;
 
+    const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+      if (disabled) return;
+      if (event.key !== "Enter" && event.key !== " " && event.key !== "Space") return;
+      event.preventDefault();
+      onClick(event);
+    }
+
     return (
       <div
         aria-disabled={disabled}
@@ -81,6 +88,7 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
         )}
         data-testid={dataTestId}
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
         ref={ref}
         role="button"
         tabIndex={disabled ? undefined : tabIndex}

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -69,12 +69,15 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
     const handleClick: React.MouseEventHandler<HTMLDivElement> = (event) =>
       !disabled ? onClick(event) : undefined;
 
-    const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+    const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (
+      event,
+    ) => {
       if (disabled) return;
-      if (event.key !== "Enter" && event.key !== " " && event.key !== "Space") return;
-      event.preventDefault();
-      onClick(event);
-    }
+      if (event.key === "Enter" || event.key === " " || event.key === "Space") {
+        event.preventDefault();
+        onClick(event);
+      }
+    };
 
     return (
       <div


### PR DESCRIPTION
## What

Followup to https://github.com/Cambly/syntax/pull/246#discussion_r1329086735 because I need this behavior already.

## Why

We don't have this lint rule turned on to enforce this like we do in our frontend app, but as per accessibility specs, if it is visible and not a natively-interactable element type, it needs to handle keyboard events:

```
Visible, non-interactive elements with click handlers must have at least one keyboard listener.eslint[jsx-a11y/click-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/click-events-have-key-events.md)
```

<img width="505" alt="image" src="https://github.com/Cambly/syntax/assets/1890801/14b0a668-2e64-460b-851a-02bf73d57909">


Since we don't render this through a `<button />`, we need to handle keypress ourselves