### PR TITLE
Typography/Heading: add success/green color

### DIFF
--- a/.changeset/nine-apples-mate.md
+++ b/.changeset/nine-apples-mate.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-core": minor
+"@syntax/storybook": minor
+---
+
+Add green/success color to Text and Heading

--- a/packages/syntax-core/src/Heading/Heading.stories.tsx
+++ b/packages/syntax-core/src/Heading/Heading.stories.tsx
@@ -29,6 +29,7 @@ export default {
         "gray700",
         "gray900",
         "primary",
+        "success",
         "white",
       ],
       control: { type: "radio" },
@@ -80,6 +81,9 @@ export const Colors: StoryObj<typeof Heading> = {
       </Heading>
       <Heading {...args} color="primary">
         Color primary
+      </Heading>
+      <Heading {...args} color="success">
+        Color success
       </Heading>
       <div style={{ backgroundColor: "#000" }}>
         <Heading {...args} color="white">

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -26,6 +26,7 @@ export default {
         "gray700",
         "gray900",
         "primary",
+        "success",
         "white",
       ],
       control: { type: "radio" },
@@ -109,6 +110,9 @@ export const Colors: StoryObj<typeof Typography> = {
       </Typography>
       <Typography {...args} color="primary">
         Color primary
+      </Typography>
+      <Typography {...args} color="success">
+        Color success
       </Typography>
       <div style={{ backgroundColor: "#000" }}>
         <Typography {...args} color="white">

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -16,6 +16,8 @@ function textColor(color: (typeof Color)[number]): string {
       return colorStyles.primary700Color;
     case "destructive-primary":
       return colorStyles.destructive700Color;
+    case "success":
+      return colorStyles.success700Color;
     default:
       return colorStyles.gray900Color;
   }

--- a/packages/syntax-core/src/colors/colors.module.css
+++ b/packages/syntax-core/src/colors/colors.module.css
@@ -19,6 +19,10 @@
   color: var(--color-base-primary-700);
 }
 
+.success700Color {
+  color: var(--color-base-success-700);
+}
+
 .whiteColor {
   color: var(--color-base-white);
 }


### PR DESCRIPTION
# Changes

Adds the green / success color to `Typography` and `Heading`

![Screenshot 2023-09-20 at 2 29 25 PM](https://github.com/Cambly/syntax/assets/127199/6d903d85-8889-4a69-abb4-d7172d090b9a)
![Screenshot 2023-09-20 at 2 29 17 PM](https://github.com/Cambly/syntax/assets/127199/3facf4e8-ce85-4420-b851-f0a955941a85)

