### PR TITLE
Layer: fix document is not defined on SSR

### DIFF
--- a/.changeset/funny-dolls-know.md
+++ b/.changeset/funny-dolls-know.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Layer: fix document is not defined issue

--- a/packages/syntax-core/src/Modal/Layer.server.test.tsx
+++ b/packages/syntax-core/src/Modal/Layer.server.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * @vitest-environment node
+ */
+import Layer from "./Layer";
+import { renderToString } from "react-dom/server";
+
+describe("layer - server", () => {
+  it("renders on the server without any errors", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <Layer>
+          <div data-testid="child">Content</div>
+        </Layer>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toStrictEqual("");
+  });
+});

--- a/packages/syntax-core/src/Modal/Layer.test.tsx
+++ b/packages/syntax-core/src/Modal/Layer.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import Layer from "./Layer";
+
+describe("layer", () => {
+  it("should render a Layer", () => {
+    render(
+      <Layer>
+        <div data-testid="child">Content</div>
+      </Layer>,
+    );
+    expect(screen.getByTestId("syntax-layer")).toBeInTheDocument();
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+});

--- a/packages/syntax-core/src/Modal/Layer.tsx
+++ b/packages/syntax-core/src/Modal/Layer.tsx
@@ -8,17 +8,19 @@ export default function Layer({
 }: {
   children: ReactElement;
   zIndex?: number;
-}): ReactPortal {
-  return createPortal(
-    <Box
-      data-testid="syntax-layer"
-      position="fixed"
-      dangerouslySetInlineStyle={{
-        __style: { zIndex, inset: 0 },
-      }}
-    >
-      {children}
-    </Box>,
-    document.body,
-  );
+}): ReactPortal | null {
+  return typeof document !== "undefined"
+    ? createPortal(
+        <Box
+          data-testid="syntax-layer"
+          position="fixed"
+          dangerouslySetInlineStyle={{
+            __style: { zIndex, inset: 0 },
+          }}
+        >
+          {children}
+        </Box>,
+        document.body,
+      )
+    : null;
 }


### PR DESCRIPTION
# Changes

* Fixes `document is not defined` when server rendering `Layer`
* Add tests

# Why

@emmanuelgamboa09 raised the issue:
![image](https://github.com/Cambly/syntax/assets/127199/7ad25e81-50b1-4c81-af87-67c9c9353cf9)
https://cambly.slack.com/archives/C04QEEZMSLF/p1695327506767059

# Test

First time we add a server test in Syntax, we should probably do this for other components as well

Failure in the test if we don't fix the issue:
![Screenshot 2023-09-21 at 4 50 57 PM](https://github.com/Cambly/syntax/assets/127199/370b8780-a2e6-42dc-87ca-01fb145ba5b5)

