### PR TITLE
[gp-3127] add in floating portal so styles don't overlap the tooltip content box

### DIFF
--- a/.changeset/soft-rabbits-suffer.md
+++ b/.changeset/soft-rabbits-suffer.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-floating-components": patch
+---
+
+Add floating portal to tooltip content so styles don't overlap it

--- a/packages/syntax-floating-components/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/syntax-floating-components/src/Tooltip/Tooltip.stories.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, type ReactElement } from "react";
 import type { StoryObj, Meta } from "@storybook/react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 import Button from "../../../syntax-core/src/Button/Button";
+import IconButton from "../../../syntax-core/src/IconButton/IconButton";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Box from "../../../syntax-core/src/Box/Box";
 import RadioButton from "../../../syntax-core/src/RadioButton/RadioButton";
@@ -55,65 +56,34 @@ export default {
   tags: ["autodocs"],
 } as Meta<typeof Tooltip>;
 
-const proficiencyChoices = [
-  {
-    text: "Beginner",
-  },
-  {
-    text: "Intermediate",
-  },
-  {
-    text: "Advanced",
-  },
-];
-
 export const Default: StoryObj<typeof Tooltip> = {
   args: {
     delay: 0,
-    placement: "left",
-    initialOpen: false,
+    placement: "right",
+    initialOpen: true,
     strategy: "absolute",
-    children:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam",
+    children: "This is a tooltip",
   },
   render: ({ delay, placement, initialOpen, strategy, children }) => (
-    <Box paddingY={8} paddingX={4} backgroundColor="gray200">
-      <Box display="flex" alignItems="center" direction="column">
-        <Box padding={7} rounding="xl" backgroundColor="white" width="100%">
-          <Box
-            display="flex"
-            direction="column"
-            justifyContent="center"
-            alignItems="center"
-          >
-            <Box role="radiogroup">
-              {proficiencyChoices.map(({ text }) => (
-                <Box key={text} display="flex" alignItems="center" gap={1}>
-                  <RadioButton
-                    key={text}
-                    label={text}
-                    value={text}
-                    name="proficiency"
-                    onChange={(e) => alert(`${e.target.value} button pressed`)}
-                  />
-                  <Tooltip
-                    delay={delay}
-                    placement={placement}
-                    initialOpen={initialOpen}
-                    strategy={strategy}
-                  >
-                    <TooltipTrigger>
-                      <InfoOutlinedIcon width={20} height={20} />
-                    </TooltipTrigger>
-                    <TooltipContent>{children}</TooltipContent>
-                  </Tooltip>
-                </Box>
-              ))}
-            </Box>
-          </Box>
-        </Box>
-      </Box>
-    </Box>
+    <div style={{ margin: "240px" }}>
+      <Tooltip
+        delay={delay}
+        placement={placement}
+        initialOpen={initialOpen}
+        strategy={strategy}
+      >
+        <TooltipTrigger>
+          <IconButton
+            accessibilityLabel="Info Icon Button"
+            icon={InfoOutlinedIcon}
+            onClick={() => alert("Default button pressed")}
+            color="tertiary"
+            size="lg"
+          />
+        </TooltipTrigger>
+        <TooltipContent>{children}</TooltipContent>
+      </Tooltip>
+    </div>
   ),
 };
 
@@ -187,5 +157,66 @@ export const ControlledTooltip = (): ReactElement => {
         </Tooltip>
       </div>
     </div>
+  );
+};
+
+export const RadioButtonGroupWithTooltips = (): ReactElement => {
+  const [choice, setChoice] = useState(0);
+
+  const proficiencyChoices = [
+    {
+      text: "Beginner",
+      value: 0,
+      content:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam",
+    },
+    {
+      text: "Intermediate",
+      value: 1,
+      content:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam",
+    },
+    {
+      text: "Advanced",
+      value: 2,
+      content:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam",
+    },
+  ];
+
+  return (
+    <Box paddingY={8} paddingX={4} backgroundColor="gray200">
+      <Box display="flex" alignItems="center" direction="column">
+        <Box padding={7} rounding="xl" backgroundColor="white" width="100%">
+          <Box
+            display="flex"
+            direction="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Box role="radiogroup">
+              {proficiencyChoices.map(({ text, value, content }) => (
+                <Box key={value} display="flex" alignItems="center" gap={1}>
+                  <RadioButton
+                    key={value}
+                    label={text}
+                    value={value}
+                    name="proficiency"
+                    onChange={(e) => setChoice(Number(e.target.value))}
+                    checked={choice === value}
+                  />
+                  <Tooltip placement="left">
+                    <TooltipTrigger>
+                      <InfoOutlinedIcon width={20} height={20} />
+                    </TooltipTrigger>
+                    <TooltipContent>{content}</TooltipContent>
+                  </Tooltip>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
   );
 };

--- a/packages/syntax-floating-components/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/syntax-floating-components/src/Tooltip/Tooltip.stories.tsx
@@ -2,8 +2,9 @@ import { useState, useRef, useEffect, type ReactElement } from "react";
 import type { StoryObj, Meta } from "@storybook/react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 import Button from "../../../syntax-core/src/Button/Button";
-import IconButton from "../../../syntax-core/src/IconButton/IconButton";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import Box from "../../../syntax-core/src/Box/Box";
+import RadioButton from "../../../syntax-core/src/RadioButton/RadioButton";
 
 export default {
   title: "Floating-Components/Tooltip",
@@ -54,34 +55,65 @@ export default {
   tags: ["autodocs"],
 } as Meta<typeof Tooltip>;
 
+const proficiencyChoices = [
+  {
+    text: "Beginner",
+  },
+  {
+    text: "Intermediate",
+  },
+  {
+    text: "Advanced",
+  },
+];
+
 export const Default: StoryObj<typeof Tooltip> = {
   args: {
     delay: 0,
-    placement: "right",
-    initialOpen: true,
+    placement: "left",
+    initialOpen: false,
     strategy: "absolute",
-    children: "This is a tooltip",
+    children:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam",
   },
   render: ({ delay, placement, initialOpen, strategy, children }) => (
-    <div style={{ margin: "240px" }}>
-      <Tooltip
-        delay={delay}
-        placement={placement}
-        initialOpen={initialOpen}
-        strategy={strategy}
-      >
-        <TooltipTrigger>
-          <IconButton
-            accessibilityLabel="Info Icon Button"
-            icon={InfoOutlinedIcon}
-            onClick={() => alert("Default button pressed")}
-            color="tertiary"
-            size="lg"
-          />
-        </TooltipTrigger>
-        <TooltipContent>{children}</TooltipContent>
-      </Tooltip>
-    </div>
+    <Box paddingY={8} paddingX={4} backgroundColor="gray200">
+      <Box display="flex" alignItems="center" direction="column">
+        <Box padding={7} rounding="xl" backgroundColor="white" width="100%">
+          <Box
+            display="flex"
+            direction="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Box role="radiogroup">
+              {proficiencyChoices.map(({ text }) => (
+                <Box key={text} display="flex" alignItems="center" gap={1}>
+                  <RadioButton
+                    key={text}
+                    label={text}
+                    value={text}
+                    name="proficiency"
+                    onChange={(e) => alert(`${e.target.value} button pressed`)}
+                  />
+                  <Tooltip
+                    delay={delay}
+                    placement={placement}
+                    initialOpen={initialOpen}
+                    strategy={strategy}
+                  >
+                    <TooltipTrigger>
+                      <InfoOutlinedIcon width={20} height={20} />
+                    </TooltipTrigger>
+                    <TooltipContent>{children}</TooltipContent>
+                  </Tooltip>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
   ),
 };
 

--- a/packages/syntax-floating-components/src/Tooltip/Tooltip.tsx
+++ b/packages/syntax-floating-components/src/Tooltip/Tooltip.tsx
@@ -14,6 +14,7 @@ import {
   FloatingArrow,
   arrow,
   size,
+  FloatingPortal,
 } from "@floating-ui/react";
 import type { Side, Strategy, UseFloatingReturn } from "@floating-ui/react";
 import Typography from "../../../syntax-core/src/Typography/Typography";
@@ -216,18 +217,20 @@ export const TooltipContent = React.forwardRef<
   if (!context.open) return null;
 
   return (
-    <div
-      {...context.getFloatingProps(props)}
-      ref={ref}
-      className={styles.tooltipContent}
-      style={{
-        ...context.floatingStyles,
-      }}
-    >
-      <Typography size={100} color="white">
-        {props.children}
-      </Typography>
-      <FloatingArrow ref={context.arrowRef} context={floatingContext} />
-    </div>
+    <FloatingPortal>
+      <div
+        {...context.getFloatingProps(props)}
+        ref={ref}
+        className={styles.tooltipContent}
+        style={{
+          ...context.floatingStyles,
+        }}
+      >
+        <Typography size={100} color="white">
+          {props.children}
+        </Typography>
+        <FloatingArrow ref={context.arrowRef} context={floatingContext} />
+      </div>
+    </FloatingPortal>
   );
 });


### PR DESCRIPTION
https://cambly.atlassian.net/browse/GP-3127


Before: 
![IMG_6719](https://github.com/Cambly/syntax/assets/31363881/ab90b1c6-1e60-4d04-97e1-58ff9a17fc9f)


After:
<img width="1312" alt="Screenshot 2023-10-16 at 4 46 00 PM" src="https://github.com/Cambly/syntax/assets/31363881/91340fb6-c091-4b5c-805e-b181ae090be8">


I just added a floating portal to surround the tooltip dialogue box. 

I updated the default example to be a bit more complex and more similar to real world use case. 
A developer can look at the example and still be able to parse out the "copy pastable" code for tooltip