### PR TITLE
Interactive components: enable after hydration completes

### DIFF
--- a/.changeset/cold-bobcats-chew.md
+++ b/.changeset/cold-bobcats-chew.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Interactive elements: only enable after hydration

--- a/packages/syntax-core/src/Button/Button.server.test.tsx
+++ b/packages/syntax-core/src/Button/Button.server.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @vitest-environment node
+ */
+import Button from "./Button";
+import { renderToString } from "react-dom/server";
+
+describe("button - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <Button
+          accessibilityLabel="Continue to the next step"
+          text="Continue"
+        ></Button>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("Continue to the next step");
+  });
+});

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -12,6 +12,7 @@ import iconSize from "./constants/iconSize";
 import textVariant from "./constants/textVariant";
 import loadingIconSize from "./constants/loadingIconSize";
 import styles from "./Button.module.css";
+import useIsHydrated from "../useIsHydrated";
 
 type ButtonProps = {
   /**
@@ -117,6 +118,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     }: ButtonProps,
     ref,
   ) => {
+    const isHydrated = useIsHydrated();
+
     return (
       <button
         data-testid={dataTestId}
@@ -124,7 +127,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         aria-label={accessibilityLabel}
         type={type}
         title={tooltip}
-        disabled={disabled || loading}
+        disabled={!isHydrated || disabled || loading}
         onClick={onClick}
         className={classNames(
           styles.button,

--- a/packages/syntax-core/src/Checkbox/Checkbox.server.test.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.server.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @vitest-environment node
+ */
+import Checkbox from "./Checkbox";
+import { renderToString } from "react-dom/server";
+
+describe("checkbox - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <Checkbox
+          checked
+          label="Checkbox label"
+          onChange={() => {
+            /* empty */
+          }}
+        />,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("Checkbox label");
+  });
+});

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import useFocusVisible from "../useFocusVisible";
 import styles from "./Checkbox.module.css";
 import focusStyles from "../Focus.module.css";
 import Typography from "../Typography/Typography";
+import useIsHydrated from "../useIsHydrated";
 
 const typographySize = {
   sm: 100,
@@ -21,7 +22,7 @@ const iconWidth = {
 const Checkbox = ({
   checked = false,
   "data-testid": dataTestId,
-  disabled = false,
+  disabled: disabledProp = false,
   size = "md",
   label,
   error = false,
@@ -67,6 +68,8 @@ const Checkbox = ({
    */
   error?: boolean;
 }): ReactElement => {
+  const isHydrated = useIsHydrated();
+  const disabled = !isHydrated || disabledProp;
   const [isFocused, setIsFocused] = useState(false);
   const { isFocusVisible } = useFocusVisible();
 

--- a/packages/syntax-core/src/Chip/Chip.module.css
+++ b/packages/syntax-core/src/Chip/Chip.module.css
@@ -9,6 +9,11 @@
   cursor: pointer;
 }
 
+.disabled {
+  filter: opacity(50%);
+  cursor: auto;
+}
+
 .selectedChip {
   background-color: var(--color-base-primary-800);
   border: 1px solid var(--color-base-primary-800);

--- a/packages/syntax-core/src/Chip/Chip.server.test.tsx
+++ b/packages/syntax-core/src/Chip/Chip.server.test.tsx
@@ -1,0 +1,17 @@
+/**
+ * @vitest-environment node
+ */
+import { vi } from "vitest";
+import Chip from "./Chip";
+import { renderToString } from "react-dom/server";
+
+describe("chip - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(<Chip onChange={vi.fn()} text="Text on chip" />);
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("Text on chip");
+  });
+});

--- a/packages/syntax-core/src/Chip/Chip.tsx
+++ b/packages/syntax-core/src/Chip/Chip.tsx
@@ -3,6 +3,7 @@ import classnames from "classnames";
 import Typography from "../Typography/Typography";
 import Box from "../Box/Box";
 import styles from "./Chip.module.css";
+import useIsHydrated from "../useIsHydrated";
 
 type ChipProps = {
   /**
@@ -54,8 +55,12 @@ const Chip = forwardRef<HTMLButtonElement, ChipProps>(
     }: ChipProps,
     ref,
   ) => {
+    const isHydrated = useIsHydrated();
+    const disabled = !isHydrated;
+
     const chipStyles = classnames(styles.chip, styles[size], {
       [styles.selectedChip]: selected,
+      [styles.disabled]: disabled,
     });
     const iconStyles = classnames(styles.icon, {
       [styles.selectedIcon]: selected,
@@ -67,6 +72,7 @@ const Chip = forwardRef<HTMLButtonElement, ChipProps>(
     return (
       <button
         className={chipStyles}
+        disabled={disabled}
         data-testid={dataTestId}
         ref={ref}
         type="button"

--- a/packages/syntax-core/src/IconButton/IconButton.server.test.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.server.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @vitest-environment node
+ */
+import IconButton from "./IconButton";
+import { renderToString } from "react-dom/server";
+import Star from "@mui/icons-material/Star";
+
+describe("iconButton - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <IconButton
+          icon={Star}
+          accessibilityLabel="Continue to the next step"
+        ></IconButton>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("Continue to the next step");
+  });
+});

--- a/packages/syntax-core/src/IconButton/IconButton.test.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.test.tsx
@@ -8,6 +8,7 @@ describe("iconButton", () => {
   it("renders successfully", () => {
     const { baseElement } = render(
       <IconButton
+        accessibilityLabel="Star"
         onClick={() => {
           /* empty */
         }}
@@ -20,6 +21,7 @@ describe("iconButton", () => {
   it("renders an role=IconButton element", async () => {
     render(
       <IconButton
+        accessibilityLabel="Star"
         onClick={() => {
           /* empty */
         }}

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import classNames from "classnames";
 import backgroundColor from "../colors//backgroundColor";
 import foregroundColor from "../colors/foregroundColor";
 import React, { forwardRef } from "react";
 import { type Color, type Size } from "../constants";
 import styles from "./IconButton.module.css";
+import useIsHydrated from "../useIsHydrated";
 
 const iconSize = {
   ["sm"]: styles.smIcon,
@@ -73,13 +76,15 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     }: IconButtonProps,
     ref,
   ) => {
+    const isHydrated = useIsHydrated();
+
     return (
       <button
         aria-label={accessibilityLabel}
         data-testid={dataTestId}
         type="button"
         title={tooltip}
-        disabled={disabled}
+        disabled={!isHydrated || disabled}
         onClick={onClick}
         className={classNames(
           styles.iconButton,

--- a/packages/syntax-core/src/RadioButton/RadioButton.server.test.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.server.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment node
+ */
+import RadioButton from "./RadioButton";
+import { renderToString } from "react-dom/server";
+
+describe("radioButton - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <RadioButton
+          label="RadioButton label"
+          name="radio-button"
+          value="radio-button-value"
+          onChange={() => {
+            /* empty */
+          }}
+        />,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("RadioButton label");
+  });
+});

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -5,6 +5,7 @@ import styles from "./RadioButton.module.css";
 import focusStyles from "../Focus.module.css";
 import Typography from "../Typography/Typography";
 import useFocusVisible from "../useFocusVisible";
+import useIsHydrated from "../useIsHydrated";
 
 /**
  * [RadioButton](https://cambly-syntax.vercel.app/?path=/docs/components-radiobutton--docs) is a radio button with accompanying text
@@ -12,7 +13,7 @@ import useFocusVisible from "../useFocusVisible";
 const RadioButton = ({
   checked = false,
   "data-testid": dataTestId,
-  disabled = false,
+  disabled: disabledProp = false,
   error = false,
   id,
   label,
@@ -73,6 +74,8 @@ const RadioButton = ({
    */
   value: string | number;
 }): ReactElement => {
+  const isHydrated = useIsHydrated();
+  const disabled = !isHydrated || disabledProp;
   const [isFocused, setIsFocused] = useState(false);
   const { isFocusVisible } = useFocusVisible();
 

--- a/packages/syntax-core/src/SelectList/SelectList.server.test.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.server.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment node
+ */
+import { vi } from "vitest";
+import SelectList from "./SelectList";
+import { renderToString } from "react-dom/server";
+
+describe("selectList - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <SelectList
+          data-testid="syntax-select"
+          selectedValue=""
+          onChange={vi.fn()}
+          helperText="helper text"
+          errorText={"error text"}
+          label="SelectList label"
+        >
+          <SelectList.Option
+            key={"key"}
+            value={"value"}
+            label={"SelectList.Option label"}
+            data-testid={`syntax-select-label`}
+          />
+        </SelectList>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("SelectList label");
+    expect(renderOnServer()).toContain("SelectList.Option label");
+  });
+});

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -14,6 +14,7 @@ import styles from "./SelectList.module.css";
 import focusStyles from "../Focus.module.css";
 import SelectOption from "./SelectOption";
 import useFocusVisible from "../useFocusVisible";
+import useIsHydrated from "../useIsHydrated";
 
 const iconSize = {
   sm: 20,
@@ -27,7 +28,7 @@ const iconSize = {
 export default function SelectList({
   children,
   "data-testid": dataTestId,
-  disabled = false,
+  disabled: disabledProp = false,
   errorText,
   helperText,
   id,
@@ -95,6 +96,8 @@ export default function SelectList({
   size?: "sm" | "md" | "lg";
 }): ReactElement {
   const reactId = useId();
+  const isHydrated = useIsHydrated();
+  const disabled = !isHydrated || disabledProp;
   const selectId = id ?? reactId;
   const { isFocusVisible } = useFocusVisible();
   const [isFocused, setIsFocused] = useState(false);

--- a/packages/syntax-core/src/TapArea/TapArea.server.test.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.server.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @vitest-environment node
+ */
+import TapArea from "./TapArea";
+import { renderToString } from "react-dom/server";
+
+describe("tapArea - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <TapArea
+          onClick={() => {
+            /* empty */
+          }}
+        >
+          <div>TapArea children</div>
+        </TapArea>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("TapArea children");
+  });
+});

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -2,6 +2,7 @@ import React, { type ReactNode, forwardRef } from "react";
 import classNames from "classnames";
 import styles from "./TapArea.module.css";
 import roundingStyles from "../rounding.module.css";
+import useIsHydrated from "../useIsHydrated";
 
 type TapAreaProps = {
   /**
@@ -58,7 +59,7 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
       children,
       accessibilityLabel,
       "data-testid": dataTestId,
-      disabled = false,
+      disabled: disabledProp = false,
       fullWidth = true,
       onClick,
       rounding = "none",
@@ -66,6 +67,9 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
     }: TapAreaProps,
     ref,
   ) => {
+    const isHydrated = useIsHydrated();
+    const disabled = !isHydrated || disabledProp;
+
     const handleClick: React.MouseEventHandler<HTMLDivElement> = (event) =>
       !disabled ? onClick(event) : undefined;
 

--- a/packages/syntax-core/src/TextField/TextField.server.test.tsx
+++ b/packages/syntax-core/src/TextField/TextField.server.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment node
+ */
+import TextField from "./TextField";
+import { renderToString } from "react-dom/server";
+
+describe("textField - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <TextField
+          label="Email"
+          value="arthur@gmail.com"
+          onChange={() => {
+            /* empty */
+          }}
+        ></TextField>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("Email");
+    expect(renderOnServer()).toContain("arthur@gmail.com");
+  });
+});

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -7,6 +7,7 @@ import classNames from "classnames";
 import styles from "./TextField.module.css";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
+import useIsHydrated from "../useIsHydrated";
 
 /**
  * [TextField](https://cambly-syntax.vercel.app/?path=/docs/components-textfield--docs) is a component that allows users to enter text.
@@ -14,7 +15,7 @@ import Typography from "../Typography/Typography";
 export default function TextField({
   autoComplete,
   "data-testid": dataTestId,
-  disabled = false,
+  disabled: disabledProp = false,
   errorText = "",
   helperText = "",
   id,
@@ -85,6 +86,8 @@ export default function TextField({
    */
   value: string;
 }): ReactElement {
+  const isHydrated = useIsHydrated();
+  const disabled = !isHydrated || disabledProp;
   const reactId = useId();
   const inputId = id ?? reactId;
 

--- a/packages/syntax-core/src/useIsHydrated.test.tsx
+++ b/packages/syntax-core/src/useIsHydrated.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import useIsHydrated from "./useIsHydrated";
+import { vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+describe("useIsHydrated", () => {
+  it("correctly sets the hydration", () => {
+    const callback = vi.fn();
+
+    function MyComponent() {
+      const isMounted = useIsHydrated();
+      callback(isMounted);
+      return (
+        <div data-testid="hydration-test-element" data-is-hydrated={true}>
+          Hey
+        </div>
+      );
+    }
+
+    render(<MyComponent />);
+    expect(callback.mock.calls).toStrictEqual([
+      // Not hydrated yet
+      [false],
+      // Hydrated after the useEffect fires
+      [true],
+    ]);
+    expect(screen.getByTestId("hydration-test-element")).toHaveAttribute(
+      "data-is-hydrated",
+      "true",
+    );
+  });
+});

--- a/packages/syntax-core/src/useIsHydrated.tsx
+++ b/packages/syntax-core/src/useIsHydrated.tsx
@@ -1,0 +1,9 @@
+import { useEffect, useState } from "react";
+
+export default function useIsHydrated(): boolean {
+  const [isHydrated, setIsHydrated] = useState(false);
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+  return isHydrated;
+}


### PR DESCRIPTION
# Context

When any of our interactive elements render it seems like they are immediately intractable, however since hydration hasn't happened yet, the initial state might get lost.

# Current solution

We toggle the hydration state globally and use that in our tests
https://github.com/Cambly/Cambly-Frontend/pull/6943

## Downsides of current solutions

1. Doesn't solve the underlying issue - if a user immediately interacts without hydration being completed, we'll lose the initial state.
2. Requires extra hydration checks in all of our integration tests:
    ```tsx
    await page.waitForSelector("[data-hydrated]");
    await page.getByTestId("subscribe-button").click();
    ```

# Design impact

1. first render a disabled interactive element
2. load all the JavaScript
3. enable the interactive element once the JavaScript finished loading & running

# Resources

## Playwright docs

https://playwright.dev/docs/navigations#hydration

> At some point in time, you'll stumble upon a use case where Playwright performs an action, but nothing seemingly happens. Or you enter some text into the input field and it will disappear. The most probable reason behind that is a poor page [hydration](https://en.wikipedia.org/wiki/Hydration_(web_development)).

> When page is hydrated, first, a static version of the page is sent to the browser. Then the dynamic part is sent and the page becomes "live". As a very fast user, Playwright will start interacting with the page the moment it sees it. And if the button on a page is enabled, but the listeners have not yet been added, Playwright will do its job, but the click won't have any effect.

> A simple way to verify if your page suffers from a poor hydration is to open Chrome DevTools, pick "Slow 3G" network emulation in the Network panel and reload the page. Once you see the element of interest, interact with it. You'll see that the button clicks will be ignored and the entered text will be reset by the subsequent page load code. The right fix for this issue is to make sure that all the interactive controls are disabled until after the hydration, when the page is fully functional.


## React docs
https://react.dev/reference/react/useLayoutEffect#im-getting-an-error-uselayouteffect-does-nothing-on-the-server

> Alternatively, you can render a component with useLayoutEffect only after hydration. Keep a boolean isMounted state that’s initialized to false, and set it to true inside a useEffect call. Your rendering logic can then be like return isMounted ? <RealContent /> : <FallbackContent />. On the server and during the hydration, the user will see FallbackContent which should not call useLayoutEffect. Then React will replace it with RealContent which runs on the client only and can include useLayoutEffect calls.