### PR TITLE
[SYN-13] Card styling updates + Box rounding change

### DIFF
--- a/.changeset/famous-lizards-melt.md
+++ b/.changeset/famous-lizards-melt.md
@@ -1,0 +1,12 @@
+---
+"@cambly/syntax-core": minor
+---
+
+## Card
+
+- update padding from 36px -> 28px on md + lg breakpoints
+- update padding from 28px -> 20px on sm breakpoint
+
+## Box
+
+- update `xl` rounding from 32px to 24px

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -357,7 +357,7 @@ type BoxProps = {
    * * `sm`: 8px
    * * `md`: 12px
    * * `lg`: 16px
-   * * `xl`: 32px
+   * * `xl`: 24px
    * * `full`: 999px
    *
    * @defaultValue "none"

--- a/packages/syntax-core/src/Card/Card.tsx
+++ b/packages/syntax-core/src/Card/Card.tsx
@@ -38,9 +38,10 @@ export default function Card({
 
   return (
     <Box
-      rounding="xl"
-      padding={7}
-      smPadding={9}
+      rounding="lg"
+      padding={5}
+      smPadding={7}
+      lgPadding={7}
       maxWidth={size && sizeWidth[size]}
       width="100%"
       backgroundColor="white"

--- a/packages/syntax-core/src/rounding.module.css
+++ b/packages/syntax-core/src/rounding.module.css
@@ -12,7 +12,7 @@
 }
 
 .roundingxl {
-  border-radius: 32px;
+  border-radius: 24px;
 }
 
 .roundingfull {


### PR DESCRIPTION
Also manually showed this to @ajmooo and he signed off on all of these

## Card

- update padding from 36px -> 28px on md + lg breakpoints
- update padding from 28px -> 20px on sm breakpoint

## Box

- update `xl` rounding from 32px to 24px

![image](https://github.com/Cambly/syntax/assets/15243713/be3824a0-c70b-4003-85f9-57d9a4b4c5c7)
![image](https://github.com/Cambly/syntax/assets/15243713/665dcc39-ab64-4656-ad27-ad990b83881a)

