### PR TITLE
Fix Divider height zero within scrollable flex container

### DIFF
--- a/.changeset/tidy-kiwis-allow.md
+++ b/.changeset/tidy-kiwis-allow.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Divider: add style flex: 0 0 auto; this makes the height inflexible, preventing it from being squashed to height 0px when contained within a scrolling flex container

--- a/packages/syntax-core/src/Divider/Divider.module.css
+++ b/packages/syntax-core/src/Divider/Divider.module.css
@@ -2,6 +2,7 @@
   background-color: var(--color-base-gray-10);
   border-radius: 50px;
   border: none;
+  flex: 0 0 auto;
   height: 1px;
   margin: 0;
 }


### PR DESCRIPTION
`Divider`
 * Add style `flex: 0 0 auto`
 * This makes the height inflexible, fixing a bug wherein a Divider's height would be squashed to 0px when contained within a scrolling flex container