### PR TITLE
FIX: Checkbox: Fix input overlay rendering bug that forced way too much extra height in overflow containers

### DIFF
--- a/.changeset/eleven-bulldogs-reflect.md
+++ b/.changeset/eleven-bulldogs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Checkbox: Fix input overlay rendering bug that forced way too much extra height in overflow containers

--- a/packages/syntax-core/src/Checkbox/Checkbox.module.css
+++ b/packages/syntax-core/src/Checkbox/Checkbox.module.css
@@ -3,12 +3,15 @@
   flex-direction: row;
   gap: 8px;
   align-items: center;
+  position: relative;
 }
 
 .inputOverlay {
   opacity: 0;
   position: absolute;
   margin: 0;
+  top: 0;
+  left: 0;
 }
 
 .checkbox {

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -53,7 +53,7 @@ export const Interactive: StoryObj<typeof Checkbox> = {
 
 export const FixDoesNotBlowoutHeight: StoryObj<typeof Checkbox> = {
   render: () => (
-    <Box height="100px" overflowY="auto">
+    <Box height="100px" overflowY="auto" padding={3}>
       <CheckboxInteractive />
       <CheckboxInteractive />
       <CheckboxInteractive />

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import Checkbox from "./Checkbox";
 import React, { useState } from "react";
+import Box from "../Box/Box";
 
 export default {
   title: "Components/Checkbox",
@@ -48,4 +49,32 @@ const CheckboxInteractive = () => {
 
 export const Interactive: StoryObj<typeof Checkbox> = {
   render: () => <CheckboxInteractive />,
+};
+
+export const FixDoesNotBlowoutHeight: StoryObj<typeof Checkbox> = {
+  render: () => (
+    <Box height="100px" overflowY="auto">
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+      <CheckboxInteractive />
+    </Box>
+  ),
 };


### PR DESCRIPTION
Been looking into some tricky rendering issues with @kpatelPro over in our frontend repo.  after a long dive, we were able to trace the issue down to here.

Here's a video that of shows the issue with the storybook example I added with this PR, before the change in `Checkbox.module.css`

https://github.com/Cambly/syntax/assets/1890801/2896e7ba-f5a8-416f-85b3-7ad5a5f3f56c


I'm going to let @kpatelPro add more description in with this if he would like.
