### PR TITLE
add link to syntax usage guidelines doc to repo's root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ pnpm start
 1. Update newly generated files.
 1. (Don't forget to StartCase your ComponentName)
 
+## Usage guidelines
+https://docs.google.com/document/d/1zXAR4Lz0M_--SluTlEUpGUW16TpWWaZNh5h39cU3gQk/edit
+
 ## Contribute
 
 1. [Fork the syntax repository](https://github.com/Cambly/syntax/fork)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pnpm start
 1. (Don't forget to StartCase your ComponentName)
 
 ## Usage guidelines
+
 https://docs.google.com/document/d/1zXAR4Lz0M_--SluTlEUpGUW16TpWWaZNh5h39cU3gQk/edit
 
 ## Contribute


### PR DESCRIPTION
@ajmooo has created a document to act as a central source of truth for rules, dos/don'ts, and the status of implementations for different platforms.

This PR adds a link to that google doc to the README.md file at the root of this repo.