### PR TITLE
TapArea: support hover on children with color

### DIFF
--- a/.changeset/pretty-moose-punch.md
+++ b/.changeset/pretty-moose-punch.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TapArea: support hover on children with color

--- a/packages/syntax-core/src/TapArea/TapArea.module.css
+++ b/packages/syntax-core/src/TapArea/TapArea.module.css
@@ -18,21 +18,23 @@
 }
 
 .enabled:hover {
-  background-image: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.1) 0%,
-    rgba(0, 0, 0, 0.1) 100%
-  );
-  transition-duration: 0.2s;
   cursor: pointer;
 }
 
 .enabled:focus-visible {
-  background-image: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.2) 0%,
-    rgba(0, 0, 0, 0.2) 100%
-  );
   box-shadow: 0 0 0 4px #000;
   outline: solid 2px #fff;
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.1);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.hoveredOrFocussed {
+  position: relative;
 }

--- a/packages/syntax-core/src/TapArea/TapArea.stories.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.stories.tsx
@@ -82,3 +82,30 @@ export const Rounding: StoryObj<typeof Box> = {
     </>
   ),
 };
+
+export const Colored: StoryObj<typeof Box> = {
+  render: () => (
+    <>
+      <Box display="flex" direction="column" gap={4}>
+        <Typography>Hover to see the overlay</Typography>
+
+        <TapArea
+          fullWidth={false}
+          onClick={() => {
+            /* empty */
+          }}
+        >
+          <Box
+            display="flex"
+            alignItems="center"
+            gap={2}
+            padding={2}
+            backgroundColor="purple300"
+          >
+            <Typography>Colored</Typography>
+          </Box>
+        </TapArea>
+      </Box>
+    </>
+  ),
+};


### PR DESCRIPTION
# Context

https://cambly.slack.com/archives/C033ZPY5M46/p1700070891891909?thread_ts=1699987244.953739&cid=C033ZPY5M46

Previously, when we hovered a TapArea which had a child with color, it would not show the TapArea hover style `rgba(0,0,0,0.1)`. The issue is that both the `Box` and `TapArea` components are trying to set the background.

Fixed it by adding a conditional child element which has the overlay style.

## Before

https://github.com/Cambly/syntax/assets/127199/a3eae106-ebbe-441b-add4-c1dd93acda43

## After

https://github.com/Cambly/syntax/assets/127199/01f7fad9-4520-4999-b3e5-c536caf5fcab



