### PR TITLE
Button/IconButton: add "inverse" color option to Button and IconButton

### DIFF
--- a/.changeset/neat-rats-deliver.md
+++ b/.changeset/neat-rats-deliver.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add "Inverse" color option to Button and IconButton

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -22,6 +22,7 @@ export default {
         "destructive-tertiary",
         "success",
         "branded",
+        "inverse",
       ],
       control: { type: "radio" },
     },
@@ -72,6 +73,9 @@ export const DestructiveTertiary: StoryObj<typeof Button> = {
 };
 export const Branded: StoryObj<typeof Button> = {
   args: { ...Default.args, color: "branded" },
+};
+export const Inverse: StoryObj<typeof Button> = {
+  args: { ...Default.args, color: "inverse" },
 };
 export const Loading: StoryObj<typeof Button> = {
   args: { ...Default.args, loading: true, loadingText: "Connecting…" },

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -40,7 +40,8 @@ type ButtonProps = {
     | "destructive-secondary"
     | "destructive-tertiary"
     | "branded"
-    | "success";
+    | "success"
+    | "inverse";
   /**
    * The size of the button
    *

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -21,6 +21,7 @@ export default {
         "destructive-primary",
         "destructive-secondary",
         "success",
+        "inverse",
       ],
       control: { type: "radio" },
     },
@@ -64,6 +65,9 @@ export const DestructiveTertiary: StoryObj<typeof IconButton> = {
 };
 export const Success: StoryObj<typeof IconButton> = {
   args: { ...Default.args, color: "success" },
+};
+export const Inverse: StoryObj<typeof IconButton> = {
+  args: { ...Default.args, color: "inverse" },
 };
 export const DifferentIcon: StoryObj<typeof IconButton> = {
   args: { ...Default.args, icon: FavoriteBorder },

--- a/packages/syntax-core/src/colors/backgroundColor.ts
+++ b/packages/syntax-core/src/colors/backgroundColor.ts
@@ -16,6 +16,8 @@ export default function backgroundColor(color: (typeof Color)[number]): string {
       return styles.whiteBackgroundColor;
     case "branded":
       return styles.yellow700BackgroundColor;
+    case "inverse":
+      return styles.gray60BackgroundColor;
     default:
       return styles.primary700BackgroundColor;
   }

--- a/packages/syntax-core/src/colors/foregroundColor.ts
+++ b/packages/syntax-core/src/colors/foregroundColor.ts
@@ -11,6 +11,8 @@ export default function foregroundColor(color: (typeof Color)[number]): string {
       return styles.destructive700Color;
     case "branded":
       return styles.gray900Color;
+    case "inverse":
+      return styles.whiteColor;
     default:
       return styles.whiteColor;
   }

--- a/packages/syntax-core/src/colors/foregroundTypographyColor.ts
+++ b/packages/syntax-core/src/colors/foregroundTypographyColor.ts
@@ -12,6 +12,8 @@ export default function foregroundTypographyColor(
       return "destructive-primary";
     case "branded":
       return "gray900";
+    case "inverse":
+      return "white";
     default:
       return "white";
   }

--- a/packages/syntax-core/src/constants.ts
+++ b/packages/syntax-core/src/constants.ts
@@ -3,6 +3,7 @@ export const Color = [
   "secondary",
   "tertiary",
   "branded",
+  "inverse",
   "destructive-primary",
   "destructive-secondary",
   "destructive-tertiary",


### PR DESCRIPTION
As addressed in [this slack thread](https://cambly.slack.com/archives/C033ZPY5M46/p1700503376307279), we would like to add a "dark" IconButton. To expand that further from today's Syntax meeting, we should have this for Button as well.

<img width="649" alt="image" src="https://github.com/Cambly/syntax/assets/36240753/bd5beba0-4db6-43c7-899f-7d23759b4b15">

<img width="584" alt="image" src="https://github.com/Cambly/syntax/assets/36240753/bd87b85c-80b2-45d7-b92a-fc84e5547ccd">
