### PR TITLE
TapArea: fix issue with link nested in TapArea

### DIFF
--- a/.changeset/mean-rats-love.md
+++ b/.changeset/mean-rats-love.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TapArea: fix issue with link nested in TapArea

--- a/packages/syntax-core/src/TapArea/TapArea.module.css
+++ b/packages/syntax-core/src/TapArea/TapArea.module.css
@@ -33,6 +33,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  pointer-events: none;
 }
 
 .hoveredOrFocussed {

--- a/packages/syntax-core/src/TapArea/TapArea.stories.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.stories.tsx
@@ -109,3 +109,33 @@ export const Colored: StoryObj<typeof Box> = {
     </>
   ),
 };
+
+export const NestedLink: StoryObj<typeof Box> = {
+  render: () => (
+    <>
+      <Box display="flex" direction="column" gap={4}>
+        <TapArea
+          fullWidth={false}
+          onClick={() => {
+            /* empty */
+          }}
+        >
+          <Box
+            display="flex"
+            alignItems="center"
+            gap={2}
+            padding={2}
+            backgroundColor="purple200"
+          >
+            <Typography>
+              Link:{" "}
+              <a href="https://www.cambly.com" target="_blank">
+                Cambly
+              </a>
+            </Typography>
+          </Box>
+        </TapArea>
+      </Box>
+    </>
+  ),
+};

--- a/packages/syntax-core/src/TapArea/TapArea.test.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.test.tsx
@@ -106,6 +106,60 @@ describe("tapArea", () => {
     expect(handleTap).toHaveBeenCalledTimes(0);
   });
 
+  it("fires onClick & opens link when link is clicked inside in TapArea", async () => {
+    const handleTap = vi.fn();
+    const handleLinkClick = vi.fn();
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={handleTap}
+        accessibilityLabel="Continue to the next step"
+      >
+        <a
+          href="https://www.cambly.com"
+          data-testid="link-in-tap-area"
+          onClick={handleLinkClick}
+        >
+          Cambly
+        </a>
+      </TapArea>,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    const linkInTapArea = await screen.findByTestId("link-in-tap-area");
+    await userEvent.hover(tapArea);
+    await userEvent.click(linkInTapArea);
+    expect(handleTap).toHaveBeenCalledTimes(1);
+    expect(handleLinkClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("only opens link when link is clicked inside in TapArea and event.stopPropagation() is called", async () => {
+    const handleTap = vi.fn();
+    const handleLinkClick = vi.fn().mockImplementation((event: Event) => {
+      event.stopPropagation();
+    });
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={handleTap}
+        accessibilityLabel="Continue to the next step"
+      >
+        <a
+          href="https://www.cambly.com"
+          data-testid="link-in-tap-area"
+          onClick={handleLinkClick}
+        >
+          Cambly
+        </a>
+      </TapArea>,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    const linkInTapArea = await screen.findByTestId("link-in-tap-area");
+    await userEvent.hover(tapArea);
+    await userEvent.click(linkInTapArea);
+    expect(handleTap).toHaveBeenCalledTimes(0);
+    expect(handleLinkClick).toHaveBeenCalledTimes(1);
+  });
+
   it("allows us to focus the TapArea", async () => {
     render(
       <TapArea


### PR DESCRIPTION
# To repro

Nest a link inside a `TapArea` and click it

Expected: link works as expected
Actual: link doesn't work

Root cause: [276](https://github.com/Cambly/syntax/pull/276) by @christianvuerings - we added an overlay which gets hit but none of the items inside the TapArea actually gets hit

# Fix

Add `pointer-events: none` to the `TapArea`

# Before

https://github.com/Cambly/syntax/assets/127199/ca076b9f-2a3b-41f7-8552-cea29b31b7a7



# After

https://github.com/Cambly/syntax/assets/127199/a9d0ba77-0718-49aa-8424-e206c57aff05

