### PR TITLE
Add dependency review GitHub action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: "Dependency Review"
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v3


### PR DESCRIPTION
Enables https://github.com/actions/dependency-review-action to ensure we don't add new security vulnerabilities or packages with invalid licenses

Note that we will only be able to enable this on our private repos once we have [GitHub advanced security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security) enabled
> [$49 per month per active committer.](https://resources.github.com/contact/security)