### PR TITLE
TextArea: add component & update props

### DIFF
--- a/.changeset/wise-apples-invite.md
+++ b/.changeset/wise-apples-invite.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TextArea: add component

--- a/packages/syntax-core/src/TextArea/TextArea.module.css
+++ b/packages/syntax-core/src/TextArea/TextArea.module.css
@@ -1,0 +1,18 @@
+.textarea {
+  border-radius: 12px;
+}
+
+.sm {
+  padding-bottom: 12px;
+  padding-top: 12px;
+}
+
+.md {
+  padding-bottom: 12px;
+  padding-top: 12px;
+}
+
+.lg {
+  padding-bottom: 16px;
+  padding-top: 16px;
+}

--- a/packages/syntax-core/src/TextArea/TextArea.server.test.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.server.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment node
+ */
+import TextArea from "./TextArea";
+import { renderToString } from "react-dom/server";
+
+describe("textArea - server", () => {
+  it("renders on the server without any errors & is disabled before hydration", () => {
+    const renderOnServer = () =>
+      renderToString(
+        <TextArea
+          label="Email"
+          value="arthur@gmail.com"
+          onChange={() => {
+            /* empty */
+          }}
+        ></TextArea>,
+      );
+
+    expect(renderOnServer).not.toThrow();
+    expect(renderOnServer()).toContain("disabled");
+    expect(renderOnServer()).toContain("Email");
+    expect(renderOnServer()).toContain("arthur@gmail.com");
+  });
+});

--- a/packages/syntax-core/src/TextArea/TextArea.stories.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.stories.tsx
@@ -1,0 +1,71 @@
+import { type StoryObj, type Meta } from "@storybook/react";
+import TextArea from "./TextArea";
+import React, { useState } from "react";
+
+export default {
+  title: "Components/TextArea",
+  component: TextArea,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/p7LKna9JMU0JEkcKamzs53/%F0%9F%93%90-Syntax?node-id=1007%3A4103",
+    },
+  },
+  argTypes: {
+    disabled: {
+      control: "boolean",
+    },
+    placeholder: {
+      control: "text",
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof TextArea>;
+
+function TextAreaDefault({
+  label = "Label",
+  placeholder = "Placeholder",
+  value: initialValue = "",
+  ...rest
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <TextArea
+      label={label}
+      placeholder={placeholder}
+      onChange={(event) => {
+        setValue(event.target.value);
+      }}
+      value={initialValue || value}
+      {...rest}
+    />
+  );
+}
+
+export const Default: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault {...args} />,
+};
+
+export const SizeSm: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault size="sm" {...args} />,
+};
+
+export const SizeMd: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault size="md" {...args} />,
+};
+
+export const SizeLg: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault size="lg" {...args} />,
+};
+
+export const helperText: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault helperText="Helper text" {...args} />,
+};
+
+export const ErrorText: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault errorText="This is an error" {...args} />,
+};
+
+export const TypeNumber: StoryObj<typeof TextArea> = {
+  render: (args) => <TextAreaDefault type="number" {...args} />,
+};

--- a/packages/syntax-core/src/TextArea/TextArea.test.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import TextArea from "./TextArea";
+import { expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+describe("textArea", () => {
+  it("renders successfully", () => {
+    const { baseElement } = render(
+      <TextArea label="TextArea label" value="" onChange={() => undefined} />,
+    );
+    expect(baseElement).toBeTruthy();
+  });
+
+  it("displays the label", () => {
+    render(
+      <TextArea label="TextArea label" value="" onChange={() => undefined} />,
+    );
+    expect(screen.getByText("TextArea label")).toBeInTheDocument();
+  });
+
+  it("displays the placeholder", () => {
+    render(
+      <TextArea
+        label="TextArea label"
+        placeholder="Placeholder"
+        value=""
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByPlaceholderText("Placeholder")).toBeInTheDocument();
+  });
+
+  it("displays the value", () => {
+    render(
+      <TextArea
+        label="TextArea label"
+        value="Value"
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByDisplayValue("Value")).toBeInTheDocument();
+  });
+
+  it("displays the error", () => {
+    render(
+      <TextArea
+        label="TextArea label"
+        value=""
+        onChange={() => undefined}
+        errorText="Error"
+      />,
+    );
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("displays the helper text", () => {
+    render(
+      <TextArea
+        label="TextArea label"
+        value=""
+        onChange={() => undefined}
+        helperText="Helper text"
+      />,
+    );
+    expect(screen.getByText("Helper text")).toBeInTheDocument();
+  });
+
+  it("displays the disabled state", () => {
+    render(
+      <TextArea
+        label="TextArea label"
+        value=""
+        onChange={() => undefined}
+        disabled
+      />,
+    );
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("fires the onChange event", async () => {
+    const handleChange = vi.fn();
+    render(
+      <TextArea
+        label="TextArea label"
+        value=""
+        onChange={handleChange}
+        data-testid="syntax-TextArea"
+      />,
+    );
+    const textArea = screen.getByTestId("syntax-TextArea");
+    await userEvent.type(textArea, "test");
+    expect(handleChange).toHaveBeenCalledTimes(4);
+  });
+
+  it("successfully grabs input value when changed", async () => {
+    function TextAreaWithState() {
+      const [value, setValue] = useState("");
+      return (
+        <TextArea
+          label="TextArea label"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+          }}
+          data-testid="syntax-TextArea"
+        />
+      );
+    }
+
+    render(<TextAreaWithState />);
+    const textArea = screen.getByTestId("syntax-TextArea");
+    await userEvent.type(textArea, "test");
+    expect(textArea).toHaveValue("test");
+  });
+
+  it("sets the data-testid correctly", () => {
+    render(
+      <TextArea
+        data-testid="TextArea-test-id"
+        label="TextArea label"
+        value=""
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("TextArea-test-id")).toBeInTheDocument();
+  });
+});

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -1,0 +1,144 @@
+import Box from "../Box/Box";
+import Typography from "../Typography/Typography";
+import React, { type ReactElement, useId, forwardRef } from "react";
+import styles from "./TextArea.module.css";
+import textFieldStyles from "../TextField/TextField.module.css";
+import classNames from "classnames";
+import useIsHydrated from "../useIsHydrated";
+
+type TextAreaProps = {
+  /**
+   * A data-testid to make querying for the TextArea easier.
+   */
+  "data-testid"?: string;
+  /**
+   * If true, the TextArea will be disabled.
+   */
+  disabled?: boolean;
+  /**
+   * Text shown below TextArea if there is an input error.
+   */
+  errorText?: string;
+  /**
+   * Informative helper text shown below TextArea
+   */
+  helperText?: string;
+  /**
+   * TextField id, if not provided, a unique id will be generated
+   */
+  id?: string;
+  /**
+   * TextArea visible label
+   */
+  label: string;
+  /**
+   * Maximum number of characters allowed in the TextArea
+   */
+  maxLength?: number;
+  /**
+   * Callback fired when the value is changed.
+   */
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Placeholder text to display when TextArea is empty
+   */
+  placeholder?: string;
+  /**
+   * Size of the TextArea. Defines the font size and padding.
+   *
+   * @defaultValue "md"
+   */
+  size?: "sm" | "md" | "lg";
+  /**
+   * Number of rows to display
+   */
+  rows?: number;
+  /**
+   * Value of the TextArea
+   */
+  value: string;
+};
+
+/**
+ * [TextArea](https://cambly-syntax.vercel.app/?path=/docs/components-textarea--docs) allows users to enter multiple lines of text.
+ */
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  function TextArea(
+    {
+      "data-testid": dataTestId,
+      disabled: disabledProp = false,
+      errorText = "",
+      helperText = "",
+      id,
+      label,
+      maxLength = 1024,
+      placeholder = "",
+      rows = 3,
+      size = "md",
+      value = "",
+      onChange,
+    }: TextAreaProps,
+    forwardedRef,
+  ): ReactElement {
+    const isHydrated = useIsHydrated();
+    const disabled = !isHydrated || disabledProp;
+    const reactId = useId();
+    const inputId = id ?? reactId;
+
+    return (
+      <Box
+        display="flex"
+        direction="column"
+        gap={2}
+        width="100%"
+        dangerouslySetInlineStyle={{
+          __style: {
+            opacity: disabled ? 0.5 : 1,
+          },
+        }}
+      >
+        <label className={textFieldStyles.label} htmlFor={inputId}>
+          <Box paddingX={1}>
+            <Typography size={100} color="gray700">
+              {label}
+            </Typography>
+          </Box>
+        </label>
+        <Typography size={200}>
+          <textarea
+            data-testid={dataTestId}
+            ref={forwardedRef}
+            className={classNames(
+              textFieldStyles.textfield,
+              textFieldStyles[size],
+              styles.textarea,
+              styles[size],
+              {
+                [textFieldStyles.inputError]: errorText,
+              },
+            )}
+            id={inputId}
+            placeholder={placeholder}
+            maxLength={maxLength}
+            onChange={onChange}
+            rows={rows}
+            value={value}
+            disabled={disabled}
+          />
+        </Typography>
+        {(helperText || errorText) && (
+          <Box paddingX={1}>
+            <Typography
+              size={100}
+              color={errorText ? "destructive-primary" : "gray700"}
+            >
+              {errorText || helperText}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
+
+export default TextArea;

--- a/packages/syntax-core/src/TextField/TextField.module.css
+++ b/packages/syntax-core/src/TextField/TextField.module.css
@@ -5,7 +5,6 @@
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
     Helvetica, Arial, sans-serif;
   margin: 0;
-  padding: 0 12px;
   width: 100%;
 }
 
@@ -23,18 +22,36 @@
 }
 
 .sm {
-  height: 32px;
   border-radius: 12px;
+  font-size: 12px;
+  padding-inline-start: 12px;
+  padding-inline-end: 12px;
+}
+
+.smHeight {
+  height: 32px;
 }
 
 .md {
-  height: 40px;
   border-radius: 12px;
+  font-size: 14px;
+  padding-inline-start: 12px;
+  padding-inline-end: 12px;
+}
+
+.mdHeight {
+  height: 40px;
 }
 
 .lg {
-  height: 48px;
   border-radius: 16px;
+  font-size: 16px;
+  padding-inline-start: 16px;
+  padding-inline-end: 16px;
+}
+
+.lgHeight {
+  height: 48px;
 }
 
 .inputError {

--- a/packages/syntax-core/src/TextField/TextField.stories.tsx
+++ b/packages/syntax-core/src/TextField/TextField.stories.tsx
@@ -58,7 +58,7 @@ export default {
 } as Meta<typeof TextField>;
 
 function TextFieldDefault({
-  label = "TextField label",
+  label = "Label",
   placeholder = "Placeholder",
   value: initialValue = "",
   ...rest
@@ -79,4 +79,28 @@ function TextFieldDefault({
 
 export const Default: StoryObj<typeof TextField> = {
   render: (args) => <TextFieldDefault {...args} />,
+};
+
+export const SizeSm: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault size="sm" {...args} />,
+};
+
+export const SizeMd: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault size="md" {...args} />,
+};
+
+export const SizeLg: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault size="lg" {...args} />,
+};
+
+export const helperText: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault helperText="Helper text" {...args} />,
+};
+
+export const ErrorText: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault errorText="This is an error" {...args} />,
+};
+
+export const TypeNumber: StoryObj<typeof TextField> = {
+  render: (args) => <TextFieldDefault type="number" {...args} />,
 };

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -114,9 +114,14 @@ export default function TextField({
       )}
       <input
         autoComplete={autoComplete}
-        className={classNames(styles.textfield, styles[size], {
-          [styles.inputError]: errorText,
-        })}
+        className={classNames(
+          styles.textfield,
+          styles[size],
+          styles[`${size}Height`],
+          {
+            [styles.inputError]: errorText,
+          },
+        )}
         data-testid={dataTestId}
         disabled={disabled}
         id={inputId}

--- a/packages/syntax-core/src/index.tsx
+++ b/packages/syntax-core/src/index.tsx
@@ -15,6 +15,7 @@ import Modal from "./Modal/Modal";
 import RadioButton from "./RadioButton/RadioButton";
 import SelectList from "./SelectList/SelectList";
 import TapArea from "./TapArea/TapArea";
+import TextArea from "./TextArea/TextArea";
 import TextField from "./TextField/TextField";
 import Typography from "./Typography/Typography";
 
@@ -36,6 +37,7 @@ export {
   RadioButton,
   SelectList,
   TapArea,
+  TextArea,
   TextField,
   Typography,
 };


### PR DESCRIPTION
# Description

Adds `TextArea` component which previously lived in `Cambly-Frontend`

# Changes

- Props: Add `data-testid`, `errorText`, `helperText`, `size` and `id` props
- Props: Make `maxLength` configurable and set default to 1024; 
- Props: Make `placeholder` optional, just as with `TextField`
- Test: Add client and server tests
- Documentation: Document each prop
- SSR support: Support Server Side Rendering by disabling the element before hydration

Also updated `TextField` so the font size + padding changes depending on the `size` - as defined in Figma.

# Screenshots

![Screenshot 2024-01-10 at 5 08 09 AM](https://github.com/Cambly/syntax/assets/127199/93fc6da5-3d59-4153-99a5-e16c15443949)
![Screenshot 2024-01-10 at 5 08 02 AM](https://github.com/Cambly/syntax/assets/127199/d3a88b7b-8f65-4cf4-a32b-cc79888e02b0)
