### PR TITLE
Patch: `RichSelectList` type def for `selectTextValue` arg.  prevent innaccurate `selectTextValue(["a", "l", "l"])`

### DIFF
--- a/.changeset/tasty-trees-walk.md
+++ b/.changeset/tasty-trees-walk.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Patch: RichSelectList -- selectTextValue arg type: `"all" | string[] | undefined`

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -66,7 +66,7 @@ export type RichSelectListProps = Omit<
    */
   placeholderText?: string;
   /** Use to render (override) text shown in the select box */
-  selectTextValue?: (selectedValues?: string[]) => string | undefined;
+  selectTextValue?: (selectedValues?: "all" | string[]) => string | undefined;
   /**
    * Size of the select box
    *
@@ -143,8 +143,12 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
 
   const selectedTextValue = useMemo(() => {
     if (selectTextValue)
-      return selectTextValue([...selectedKeys].map(String)) ?? placeholderText;
-    if (selectedKeys === "all") return "all";
+      return (
+        selectTextValue(
+          selectedKeys === "all" ? "all" : [...selectedKeys].map(String),
+        ) ?? placeholderText
+      );
+    if (selectedKeys === "all") return "All selected";
     if (selectedKeys.size) return `${selectedKeys.size} selected`;
     return placeholderText;
   }, [selectTextValue, selectedKeys, placeholderText]);


### PR DESCRIPTION
[Patch: RichSelectList -- selectTextValue arg type](https://github.com/Cambly/syntax/commit/7cac4a9aad35165df55b165098f7c0cc446df595)

- selectedTextValues could === "all"
- previous implementation would have called `selectTextValue(["a", "l", "l"])` in that case, likely leading to innaccurate text being displayed in the select trigger