### PR TITLE
LinkButton: update color on LinkButton

### DIFF
--- a/.changeset/cold-ads-love.md
+++ b/.changeset/cold-ads-love.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+LinkButton: add color to Icon to fix hover styles

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -127,7 +127,11 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       >
         {StartIcon && (
           <StartIcon
-            className={classNames(buttonStyles.icon, iconSize[size])}
+            className={classNames(
+              buttonStyles.icon,
+              iconSize[size],
+              foregroundColor(color),
+            )}
           />
         )}
         <Typography
@@ -137,7 +141,13 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
           <span style={{ fontWeight: 500 }}>{text}</span>
         </Typography>
         {EndIcon && (
-          <EndIcon className={classNames(buttonStyles.icon, iconSize[size])} />
+          <EndIcon
+            className={classNames(
+              buttonStyles.icon,
+              iconSize[size],
+              foregroundColor(color),
+            )}
+          />
         )}
       </a>
     );


### PR DESCRIPTION
![image](https://github.com/Cambly/syntax/assets/15243713/fa7a90bb-6d26-4778-9bfd-449450cae7b0)

Hover styles are happening because theres no color set. This should fix that.