### PR TITLE
TapArea: add onMouseEnter and onMouseLeave events

### DIFF
--- a/.changeset/hungry-cups-warn.md
+++ b/.changeset/hungry-cups-warn.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+TapArea: add onMouseEnter and onMouseLeave events

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
     "eamodio.gitlens",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "ZixuanChen.vitest-explorer"
+    "vitest.explorer"
   ]
 }

--- a/packages/syntax-core/src/TapArea/TapArea.test.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.test.tsx
@@ -132,6 +132,74 @@ describe("tapArea", () => {
     expect(handleLinkClick).toHaveBeenCalledTimes(1);
   });
 
+  it("fires onMouseEnter when hovered over", async () => {
+    const handleMouseEnter = vi.fn();
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        onMouseEnter={handleMouseEnter}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    await userEvent.hover(tapArea);
+    expect(handleMouseEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onMouseEnter when hovered over and the TapArea is disabled", async () => {
+    const handleMouseEnter = vi.fn();
+    render(
+      <TapArea
+        disabled
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        onMouseEnter={handleMouseEnter}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    await userEvent.hover(tapArea);
+    expect(handleMouseEnter).toHaveBeenCalledTimes(0);
+  });
+
+  it("fires onMouseLeave when hovered out", async () => {
+    const handleMouseLeave = vi.fn();
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        onMouseLeave={handleMouseLeave}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    await userEvent.hover(tapArea);
+    await userEvent.unhover(tapArea);
+    expect(handleMouseLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onMouseLeave when hovered out and the TapArea is disabled", async () => {
+    const handleMouseLeave = vi.fn();
+    render(
+      <TapArea
+        disabled
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        onMouseLeave={handleMouseLeave}
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    await userEvent.hover(tapArea);
+    await userEvent.unhover(tapArea);
+    expect(handleMouseLeave).toHaveBeenCalledTimes(0);
+  });
+
   it("only opens link when link is clicked inside in TapArea and event.stopPropagation() is called", async () => {
     const handleTap = vi.fn();
     const handleLinkClick = vi.fn().mockImplementation((event: Event) => {

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -37,6 +37,14 @@ type TapAreaProps = AriaAttributes & {
    */
   onClick: (event: React.SyntheticEvent<HTMLDivElement>) => void;
   /**
+   * The callback to be called when the tap area is hovered
+   */
+  onMouseEnter?: (event: React.SyntheticEvent<HTMLDivElement>) => void;
+  /**
+   * The callback to be called when the tap area is no longer hovered
+   */
+  onMouseLeave?: (event: React.SyntheticEvent<HTMLDivElement>) => void;
+  /**
    * Border radius of the tap area.
    *
    * * `none`: 0px
@@ -90,6 +98,8 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
       disabled: disabledProp = false,
       fullWidth = true,
       onClick,
+      onMouseEnter,
+      onMouseLeave,
       rounding = "none",
       tabIndex = 0,
       ...accessibilityProps
@@ -122,6 +132,22 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
       }
     };
 
+    const handleOnMouseEnter: React.MouseEventHandler<HTMLDivElement> = (
+      event,
+    ) => {
+      if (disabled) return;
+      dispatch({ type: "MOUSE_ENTER" });
+      onMouseEnter?.(event);
+    };
+
+    const handleOnMouseLeave: React.MouseEventHandler<HTMLDivElement> = (
+      event,
+    ) => {
+      if (disabled) return;
+      dispatch({ type: "MOUSE_LEAVE" });
+      onMouseLeave?.(event);
+    };
+
     const isHoveredOrFocussed = !disabled && (hovered || focussed);
     const roundingClasses =
       rounding !== "none" && roundingStyles[`rounding${rounding}`];
@@ -141,8 +167,8 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
         data-testid={dataTestId}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
-        onMouseEnter={() => dispatch({ type: "MOUSE_ENTER" })}
-        onMouseLeave={() => dispatch({ type: "MOUSE_LEAVE" })}
+        onMouseEnter={handleOnMouseEnter}
+        onMouseLeave={handleOnMouseLeave}
         onFocus={() => dispatch({ type: "FOCUS" })}
         onBlur={() => dispatch({ type: "BLUR" })}
         ref={ref}


### PR DESCRIPTION
In order to build custom accessible components we need to be able to access `onMouseEnter` and `onMouseLeave` on `TapArea`