### PR TITLE
Button/LinkButton: remove startIcon & endIcon

### DIFF
--- a/.changeset/small-glasses-bake.md
+++ b/.changeset/small-glasses-bake.md
@@ -1,0 +1,15 @@
+---
+"@cambly/syntax-codemods": minor
+"@cambly/syntax-core": minor
+---
+
+Button/LinkButton: remove startIcon & endIcon props
+
+Codemod:
+
+```sh
+npx @cambly/syntax-codemods -c component-remove-prop -p ~/cambly/Cambly-Frontend/src/ --component=Button --prop=startIcon
+npx @cambly/syntax-codemods -c component-remove-prop -p ~/cambly/Cambly-Frontend/src/ --component=Button --prop=endIcon
+npx @cambly/syntax-codemods -c component-remove-prop -p ~/cambly/Cambly-Frontend/src/ --component=LinkButton --prop=startIcon
+npx @cambly/syntax-codemods -c component-remove-prop -p ~/cambly/Cambly-Frontend/src/ --component=LinkButton --prop=endIcon
+```

--- a/packages/syntax-codemods/src/index.ts
+++ b/packages/syntax-codemods/src/index.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 import runJscodeshift from "./run-js-codeshift";
 
 const {
-  values: { codemod, path: inputPath },
+  values: { codemod, path: inputPath, ...remainingArgs },
 } = parseArgs({
   options: {
     codemod: {
@@ -18,6 +18,7 @@ const {
       short: "p",
     },
   },
+  strict: false, // Allow additional arguments to be passed to the codemod
 });
 
 async function init() {
@@ -29,23 +30,27 @@ async function init() {
     .filter((dirent) => dirent.isFile() && dirent.name.endsWith(".js"))
     .map((dirent) => dirent.name.replace(".js", ""));
 
-  if (!codemod || !availableCodemods.includes(codemod)) {
+  if (
+    !codemod ||
+    typeof codemod !== "string" ||
+    !availableCodemods.includes(codemod)
+  ) {
     throw new Error(
       `Please provide a valid codemod to execute.
 
-Available codemods:
-${availableCodemods.join("\n")}`,
+  Available codemods:
+  ${availableCodemods.join("\n")}`,
     );
   }
 
-  if (!inputPath) {
+  if (!inputPath || typeof inputPath !== "string") {
     throw new Error(`Please provide a path to execute the codemod on.`);
   }
   const resolvedPath = path.resolve(inputPath);
 
   const response = await runJscodeshift(
     path.resolve(path.join(__dirname, "transforms", `${codemod}.js`)),
-    { silent: false, verbose: 2 },
+    { silent: false, verbose: 2, ...remainingArgs },
     [resolvedPath],
   );
 

--- a/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-end-icon.input.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-end-icon.input.tsx
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { Button } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
+import Icon from "./Icon";
+
+export default function Example(): ReactElement {
+  return (
+    <>
+      <Button text="Test 1" startIcon={<Icon />} />
+      <Button text="Test 2" endIcon={<Icon />} />
+      <Button text="Test 3" />
+    </>
+  );
+}

--- a/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-end-icon.output.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-end-icon.output.tsx
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { Button } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
+import Icon from "./Icon";
+
+export default function Example(): ReactElement {
+  return (
+    <>
+      <Button text="Test 1" startIcon={<Icon />} />
+      <Button text="Test 2" />
+      <Button text="Test 3" />
+    </>
+  );
+}

--- a/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-start-icon.input.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-start-icon.input.tsx
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { Button } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
+import Icon from "./Icon";
+
+export default function Example(): ReactElement {
+  return (
+    <>
+      <Button text="Test 1" startIcon={<Icon />} />
+      <Button text="Test 2" endIcon={<Icon />} />
+      <Button text="Test 3" />
+    </>
+  );
+}

--- a/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-start-icon.output.tsx
+++ b/packages/syntax-codemods/src/transforms/__fixtures__/component-remove-prop/button-start-icon.output.tsx
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { Button } from "@cambly/syntax-core";
+import { type ReactElement } from "react";
+import Icon from "./Icon";
+
+export default function Example(): ReactElement {
+  return (
+    <>
+      <Button text="Test 1" />
+      <Button text="Test 2" endIcon={<Icon />} />
+      <Button text="Test 3" />
+    </>
+  );
+}

--- a/packages/syntax-codemods/src/transforms/__tests__/component-remove-prop.test.ts
+++ b/packages/syntax-codemods/src/transforms/__tests__/component-remove-prop.test.ts
@@ -1,0 +1,76 @@
+import { join } from "path";
+import { readFile } from "fs/promises";
+
+import jscodeshift from "jscodeshift";
+import transform from "../component-remove-prop";
+import { format } from "prettier";
+
+const getTestMetadata = async (
+  dirPath: string,
+  filePrefix: string,
+  fileExtension: string,
+) => {
+  const inputPath = join(
+    dirPath,
+    [filePrefix, "input", fileExtension].join("."),
+  );
+  const outputPath = join(
+    dirPath,
+    [filePrefix, "output", fileExtension].join("."),
+  );
+  const inputCode = await readFile(inputPath, "utf8");
+  const outputCode = await readFile(outputPath, "utf8");
+
+  const input = { path: inputPath, source: inputCode };
+  return { input, outputCode };
+};
+
+const fixtureDir = join(__dirname, "..", "__fixtures__");
+const subDirPath = join(fixtureDir, "component-remove-prop");
+
+describe("component-remove-prop", () => {
+  it.each([
+    {
+      file: "button-start-icon",
+      component: "Button",
+      prop: "startIcon",
+    },
+    {
+      file: "button-end-icon",
+      component: "Button",
+      prop: "endIcon",
+    },
+  ])(`transforms correctly - %s`, async ({ file, component, prop }) => {
+    const { input, outputCode } = await getTestMetadata(
+      subDirPath,
+      file,
+      "tsx",
+    );
+
+    const jscodeshiftWithParser = jscodeshift.withParser("tsx");
+
+    const output = transform(
+      input,
+      {
+        j: jscodeshiftWithParser,
+        jscodeshift: jscodeshiftWithParser,
+        stats: () => undefined,
+        report: () => undefined,
+      },
+      {
+        component,
+        prop,
+      },
+    );
+
+    expect(
+      format(String(output), {
+        parser: "babel",
+      }),
+    ).toStrictEqual(
+      format(outputCode, {
+        parser: "babel",
+      }),
+    );
+  });
+});

--- a/packages/syntax-codemods/src/transforms/component-remove-prop.ts
+++ b/packages/syntax-codemods/src/transforms/component-remove-prop.ts
@@ -1,0 +1,101 @@
+// Codemod to remove a prop from a component.
+
+// Example with `component` set to "Button" and `prop` set to "startIcon":
+// <Button startIcon={<Icon />} text="Continue" />
+// to
+// <Button text="Continue" />
+
+import { type API, type FileInfo } from "jscodeshift";
+
+export const parser = "tsx";
+
+export default function transformer(
+  fileInfo: FileInfo,
+  api: API,
+  options: {
+    component: string;
+    prop: string;
+  },
+): string | null {
+  const { component, prop } = options;
+
+  if (!component || !prop) {
+    throw new Error("`component` and `prop` are required options");
+  }
+
+  const j = api.jscodeshift;
+  const src = j(fileInfo.source);
+
+  const syntaxImportCollection = src.find(j.ImportDeclaration, {
+    source: {
+      value: "@cambly/syntax-core",
+    },
+  });
+
+  if (syntaxImportCollection.size() === 0) return null;
+
+  const componentIdentifierCollection = syntaxImportCollection.find(
+    j.ImportSpecifier,
+    {
+      imported: {
+        type: "Identifier",
+        name: component,
+      },
+    },
+  );
+
+  if (componentIdentifierCollection.size() === 0) return null;
+
+  /**
+   * targetLocalName is the name of the variable that the Box component is imported as.
+   * E.g. import { Button } from '@cambly/syntax-core // Button
+   * E.g. import { Button as RenamedButton } from '@cambly/syntax-core // RenamedButton
+   */
+  const targetLocalName = String(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    componentIdentifierCollection.get(0).node.local?.name,
+  );
+
+  const jsxCollection = src.find(j.JSXElement, {
+    openingElement: { name: { name: targetLocalName } },
+  });
+
+  const spreadPropsCollection = jsxCollection.find(j.JSXSpreadAttribute).filter(
+    (nodepath) =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      nodepath.parentPath.parentPath.value.name?.name === targetLocalName,
+  );
+
+  if (spreadPropsCollection.size() > 0) {
+    throw new Error(
+      `Remove dynamic properties and rerun codemod.\n${spreadPropsCollection
+        .nodes()
+        .map(
+          (node) =>
+            `Location: ${fileInfo.path} @line: ${node.loc?.start.line ?? ""}`,
+        )
+        .join("\n")}`,
+    );
+  }
+
+  const jsxWithMatchingAttributesCollection = jsxCollection
+    .find(j.JSXAttribute, { name: { name: prop } })
+    .filter(
+      (nodepath) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        nodepath.parentPath?.parentPath.value.name?.name === targetLocalName,
+    );
+
+  if (jsxWithMatchingAttributesCollection.size() === 0) return null;
+
+  // Remove prop
+  jsxWithMatchingAttributesCollection.replaceWith((nodepath) => {
+    const node = nodepath.node;
+    if (node.name.name === prop) {
+      return null;
+    }
+    return node;
+  });
+
+  return src.toSource({ quote: "double" });
+}

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -72,31 +72,6 @@
   border-radius: 16px;
 }
 
-.icon {
-  color: inherit;
-}
-
-.smIcon {
-  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  width: 16px !important;
-  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  height: 16px !important;
-}
-
-.mdIcon {
-  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  width: 20px !important;
-  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  height: 20px !important;
-}
-
-.lgIcon {
-  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  width: 24px !important;
-  /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
-  height: 24px !important;
-}
-
 .secondaryBorder {
   border: 1px solid var(--color-base-primary-300);
 }

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -1,6 +1,5 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import Button from "./Button";
-import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 
 export default {
   title: "Components/Button",
@@ -79,10 +78,4 @@ export const Inverse: StoryObj<typeof Button> = {
 };
 export const Loading: StoryObj<typeof Button> = {
   args: { ...Default.args, loading: true, loadingText: "Connecting…" },
-};
-export const WithStartIcon: StoryObj<typeof Button> = {
-  args: { ...Default.args, startIcon: FavoriteBorder },
-};
-export const WithEndIcon: StoryObj<typeof Button> = {
-  args: { ...Default.args, endIcon: FavoriteBorder },
 };

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -8,7 +8,6 @@ import { type Size } from "../constants";
 import Typography from "../Typography/Typography";
 import Box from "../Box/Box";
 
-import iconSize from "./constants/iconSize";
 import textVariant from "./constants/textVariant";
 import loadingIconSize from "./constants/loadingIconSize";
 import styles from "./Button.module.css";
@@ -75,14 +74,6 @@ type ButtonProps = {
    */
   fullWidth?: boolean;
   /**
-   * The icon to be displayed at the start of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
-   */
-  startIcon?: React.ComponentType<{ className?: string }>;
-  /**
-   * The icon to be displayed at the end of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
-   */
-  endIcon?: React.ComponentType<{ className?: string }>;
-  /**
    * The callback to be called when the button is clicked
    */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -111,8 +102,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       disabled = false,
       loading = false,
       fullWidth = false,
-      startIcon: StartIcon,
-      endIcon: EndIcon,
       onClick,
       tooltip,
       type = "button",
@@ -144,9 +133,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           },
         )}
       >
-        {!loading && StartIcon && (
-          <StartIcon className={classNames(styles.icon, iconSize[size])} />
-        )}
         {((loading && loadingText) || (!loading && text)) && (
           <Box paddingX={1}>
             <Typography
@@ -158,9 +144,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
               </span>
             </Typography>
           </Box>
-        )}
-        {!loading && EndIcon && (
-          <EndIcon className={classNames(styles.icon, iconSize[size])} />
         )}
         {loading && (
           <svg

--- a/packages/syntax-core/src/Button/constants/iconSize.ts
+++ b/packages/syntax-core/src/Button/constants/iconSize.ts
@@ -1,9 +1,0 @@
-import styles from "../Button.module.css";
-
-const iconSize = {
-  ["sm"]: styles.smIcon,
-  ["md"]: styles.mdIcon,
-  ["lg"]: styles.lgIcon,
-};
-
-export default iconSize;

--- a/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
@@ -1,6 +1,5 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import LinkButton from "./LinkButton";
-import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 
 export default {
   title: "Components/LinkButton",
@@ -95,10 +94,4 @@ export const DestructiveTertiary: StoryObj<typeof LinkButton> = {
 };
 export const Branded: StoryObj<typeof LinkButton> = {
   args: { ...Default.args, color: "branded" },
-};
-export const WithStartIcon: StoryObj<typeof LinkButton> = {
-  args: { ...Default.args, startIcon: FavoriteBorder },
-};
-export const WithEndIcon: StoryObj<typeof LinkButton> = {
-  args: { ...Default.args, endIcon: FavoriteBorder },
 };

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -8,7 +8,6 @@ import { type Size } from "../constants";
 import Typography from "../Typography/Typography";
 
 import buttonStyles from "../Button/Button.module.css";
-import iconSize from "../Button/constants/iconSize";
 import textVariant from "../Button/constants/textVariant";
 
 import styles from "./LinkButton.module.css";
@@ -68,14 +67,6 @@ type LinkButtonProps = {
    */
   fullWidth?: boolean;
   /**
-   * The icon to be displayed at the start of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
-   */
-  startIcon?: React.ComponentType<{ className?: string }>;
-  /**
-   * The icon to be displayed at the end of the button. Please use a [Rounded Material Icon](https://material.io/resources/icons/?style=round)
-   */
-  endIcon?: React.ComponentType<{ className?: string }>;
-  /**
    * An optional onClick event. This is used for certain wrapper's support (such as react-router-dom).
    */
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
@@ -95,8 +86,6 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       color = "primary",
       size = "md",
       fullWidth = false,
-      startIcon: StartIcon,
-      endIcon: EndIcon,
       onClick,
     }: LinkButtonProps,
     ref,
@@ -125,30 +114,12 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
         )}
         onClick={onClick}
       >
-        {StartIcon && (
-          <StartIcon
-            className={classNames(
-              buttonStyles.icon,
-              iconSize[size],
-              foregroundColor(color),
-            )}
-          />
-        )}
         <Typography
           color={foregroundTypographyColor(color)}
           size={textVariant[size]}
         >
           <span style={{ fontWeight: 500 }}>{text}</span>
         </Typography>
-        {EndIcon && (
-          <EndIcon
-            className={classNames(
-              buttonStyles.icon,
-              iconSize[size],
-              foregroundColor(color),
-            )}
-          />
-        )}
       </a>
     );
   },


### PR DESCRIPTION
## Description

In order to get ready for Cambio, we are removing `startIcon` and `endIcon` as a prop from `Button` and `LinkButton`

Cambly-Frontend PR: https://github.com/Cambly/Cambly-Frontend/pull/8727

## Changes

* Codemod: Allow arguments
* Button / LinkButton: remove `startIcon` and `endIcon`