### PR TITLE
LinkButton / IconButton: add success-tertiary as cambio options

### DIFF
--- a/.changeset/angry-guests-call.md
+++ b/.changeset/angry-guests-call.md
@@ -1,0 +1,9 @@
+---
+"@cambly/syntax-floating-components": patch
+"@cambly/syntax-design-tokens": patch
+"@cambly/syntax-tsconfig": patch
+"@cambly/syntax-core": patch
+"@syntax/storybook": patch
+---
+
+LinkButton / IconButton add missing success-tertiary color option

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -54,6 +54,7 @@ type IconButtonProps = {
     | "success"
     | "success-primary"
     | "success-secondary"
+    | "success-tertiary"
     | "inverse";
   /**
    * Test id for the button

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -68,6 +68,7 @@ type LinkButtonProps = {
     | "success"
     | "success-primary"
     | "success-secondary"
+    | "success-tertiary"
     | "inverse";
   /**
    * The size of the button


### PR DESCRIPTION
Follow up from #317 where I added `success-primary` and `success-secondary` but not `success-tertiary` to LinkButton and IconButton