### PR TITLE
Add 'use client' to every Syntax component

### DIFF
--- a/.changeset/seven-oranges-punch.md
+++ b/.changeset/seven-oranges-punch.md
@@ -1,0 +1,7 @@
+---
+"@cambly/syntax-core": minor
+"@cambly/syntax-floating-components": minor
+"@cambly/syntax-utils": minor
+---
+
+Add 'use client' to every Syntax exported JS file

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
   skipNodeModulesBundle: true,
   esbuildOptions(options) {
     options.chunkNames = "__chunks/[hash]";
+    options.banner = {
+      js: '"use client"',
+    };
   },
   // ESBuild does not yet support CSS Modules
   // https://github.com/egoist/tsup/issues/536#issuecomment-1302012400


### PR DESCRIPTION
After adding hooks usage to `Typography` and `Heading` (because of Cambio theming), we see the following exception:

```
Error: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component
```

Fix is to add `use client` to every exported file:

![image](https://github.com/Cambly/syntax/assets/127199/2ec56e0f-5942-4106-8f1e-c9be0c93304c)


![image](https://github.com/Cambly/syntax/assets/127199/28a74f38-73b9-4059-a55d-4bca2f9a91bf)
