### PR TITLE
RichSelectList: update color and make label optional

### DIFF
--- a/.changeset/seven-candles-cry.md
+++ b/.changeset/seven-candles-cry.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+RichSelectList: color and label updates

--- a/packages/syntax-core/src/RichSelect/RichSelect.module.css
+++ b/packages/syntax-core/src/RichSelect/RichSelect.module.css
@@ -2,3 +2,7 @@
 .richSelectBox:focus-visible {
   outline: none;
 }
+
+.label {
+  cursor: pointer;
+}

--- a/packages/syntax-core/src/RichSelect/RichSelectBox.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectBox.tsx
@@ -148,7 +148,7 @@ const RichSelectBox = forwardRef<HTMLDivElement, RichSelectBoxProps>(
     );
 
     const saveChanges = () => setSelectedKeys(stagedKeys);
-    const clearChanges = () => setStagedKeys(new Set());
+    const clearChanges = () => setSelectedKeys(new Set());
     const stageChanges = (selectedValues: Selection) => {
       setStagedKeys(selectedValues);
       if (autosave) setSelectedKeys(selectedValues);

--- a/packages/syntax-core/src/RichSelect/RichSelectBox.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectBox.tsx
@@ -148,7 +148,7 @@ const RichSelectBox = forwardRef<HTMLDivElement, RichSelectBoxProps>(
     );
 
     const saveChanges = () => setSelectedKeys(stagedKeys);
-    const clearChanges = () => setSelectedKeys(new Set());
+    const clearChanges = () => setStagedKeys(new Set());
     const stageChanges = (selectedValues: Selection) => {
       setStagedKeys(selectedValues);
       if (autosave) setSelectedKeys(selectedValues);

--- a/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
@@ -207,7 +207,6 @@ export const Default: StoryObj<typeof RichSelectList> = {
   args: {
     children: renderOptions(),
     helperText: "Helper text",
-    accessibilityLabel: "Label",
     placeholderText: "Placeholder",
     selectedValues: ["opt1"],
   },

--- a/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
@@ -45,6 +45,7 @@ export const WhatIfItLookedLikeThis = (): ReactElement => {
     <Box display="flex" gap={2} alignItems="center" flexWrap="wrap">
       <RichSelectList
         label="Label"
+        accessibilityLabel="Label"
         helperText="Helper text"
         multiple
         placeholderText="Placeholder"
@@ -136,6 +137,7 @@ export const VeryLongContent = (): ReactElement => {
     >
       <RichSelectList
         label="Label"
+        accessibilityLabel="Label"
         helperText="Helper text"
         placeholderText="Placeholder"
         onChange={() => undefined}
@@ -205,7 +207,7 @@ export const Default: StoryObj<typeof RichSelectList> = {
   args: {
     children: renderOptions(),
     helperText: "Helper text",
-    label: "Label",
+    accessibilityLabel: "Label",
     placeholderText: "Placeholder",
     selectedValues: ["opt1"],
   },
@@ -226,6 +228,7 @@ const RichSelectListInteractive = (): ReactElement => {
   return (
     <RichSelectList
       label="Label"
+      accessibilityLabel="Label"
       helperText="Helper text"
       multiple
       selectedValues={selectionValue}
@@ -255,6 +258,7 @@ export const RadioButtons: StoryObj<typeof RichSelectList> = {
     <RichSelectList
       multiple={false}
       label="Label"
+      accessibilityLabel="Label"
       selectedValues={["opt1"]}
       placeholderText="Placeholder"
       onChange={() => undefined}
@@ -277,6 +281,7 @@ export const NoAutosaveControlled: StoryObj<typeof RichSelectList> = {
       <RichSelectList
         multiple
         label="Label"
+        accessibilityLabel="Label"
         selectedValues={["sf"]}
         placeholderText="Placeholder"
         helperText="When `autosave` is false, the user must click the button to save their changes"
@@ -337,6 +342,7 @@ export const NoAutosaveControlledMultipleSelect: StoryObj<
         <ControlledRichSelectList
           multiple
           label="Multiple select"
+          accessibilityLabel="Label"
           helperText="When `autosave` is false, the user must click the button to save their changes"
           autosave={false}
         >
@@ -348,6 +354,7 @@ export const NoAutosaveControlledMultipleSelect: StoryObj<
         </ControlledRichSelectList>
 
         <ControlledRichSelectList
+          accessibilityLabel="Label"
           multiple={false}
           label="Single select"
           helperText="When `autosave` is false, the user must click the button to save their changes"
@@ -368,6 +375,7 @@ export const Autosave: StoryObj<typeof RichSelectList> = {
   render: () => (
     <RichSelectList
       label="Label"
+      accessibilityLabel="Label"
       helperText="When `autosave` is true, the user's changes are automatically saveted"
       autosave
       onChange={() => undefined}
@@ -389,6 +397,7 @@ export const ItemAttributeComposition: StoryObj<typeof RichSelectList> = {
   render: () => (
     <RichSelectList
       label="Label"
+      accessibilityLabel="Label"
       multiple
       autosave
       onChange={() => undefined}

--- a/packages/syntax-core/src/RichSelect/RichSelectList.test.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.test.tsx
@@ -275,7 +275,7 @@ describe("richSelectList", () => {
     opt1 = screen.getByTestId("opt1"); // opt1 was re-created when overlay re-opened. must get new reference
     expect(opt1).toHaveAttribute("aria-selected", "true");
     await user.click(screen.getByTestId("secondary-button"));
-    expect(spy).toHaveBeenCalledTimes(2); // clearing only stages, does not commit yet
+    expect(spy).toHaveBeenCalledTimes(1); // clearing only stages, does not commit yet
     expect(opt1).toHaveAttribute("aria-selected", "false");
   });
 

--- a/packages/syntax-core/src/RichSelect/RichSelectList.test.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.test.tsx
@@ -257,7 +257,7 @@ describe("richSelectList", () => {
     expect(opt1).toHaveAttribute("aria-selected", "true");
   });
 
-  it.only("can clear a saved selection", async () => {
+  it("can clear a saved selection", async () => {
     const spy = vi.fn();
     render(
       simpleRichSelectList({
@@ -267,7 +267,6 @@ describe("richSelectList", () => {
     );
     await user.click(screen.getByTestId("trigger"));
     let opt1 = screen.getByTestId("opt1");
-    console.log("opt1", opt1);
     await user.click(opt1);
     await user.click(screen.getByTestId("primary-button"));
     expect(spy).toHaveBeenCalledTimes(1);

--- a/packages/syntax-core/src/RichSelect/RichSelectList.test.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.test.tsx
@@ -20,6 +20,7 @@ const user = userEvent.setup({
 const defaultRequiredProps = {
   onChange: () => undefined,
   label: "x",
+  accessibilityLabel: "label",
   primaryButtonText: "Save",
   primaryButtonAccessibilityLabel: "Save",
   secondaryButtonText: "Clear",
@@ -256,7 +257,7 @@ describe("richSelectList", () => {
     expect(opt1).toHaveAttribute("aria-selected", "true");
   });
 
-  it("can clear a saved selection", async () => {
+  it.only("can clear a saved selection", async () => {
     const spy = vi.fn();
     render(
       simpleRichSelectList({
@@ -266,6 +267,7 @@ describe("richSelectList", () => {
     );
     await user.click(screen.getByTestId("trigger"));
     let opt1 = screen.getByTestId("opt1");
+    console.log("opt1", opt1);
     await user.click(opt1);
     await user.click(screen.getByTestId("primary-button"));
     expect(spy).toHaveBeenCalledTimes(1);
@@ -274,7 +276,7 @@ describe("richSelectList", () => {
     opt1 = screen.getByTestId("opt1"); // opt1 was re-created when overlay re-opened. must get new reference
     expect(opt1).toHaveAttribute("aria-selected", "true");
     await user.click(screen.getByTestId("secondary-button"));
-    expect(spy).toHaveBeenCalledTimes(1); // clearing only stages, does not commit yet
+    expect(spy).toHaveBeenCalledTimes(2); // clearing only stages, does not commit yet
     expect(opt1).toHaveAttribute("aria-selected", "false");
   });
 

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -42,10 +42,7 @@ const iconSize = {
   lg: 24,
 } as const;
 
-export type RichSelectListProps = Omit<
-  RichSelectBoxProps,
-  "accessibilityLabel"
-> & {
+export type RichSelectListProps = Omit<RichSelectBoxProps, "id"> & {
   /** Test id for the select element */
   "data-testid"?: string;
   /**
@@ -59,10 +56,12 @@ export type RichSelectListProps = Omit<
   errorText?: string;
   /** Text shown below select box */
   helperText?: string;
+  /**
+   * RichSelectList id, if not provided, a unique id will be generated
+   */
+  id?: string;
   /** Text shown above select box */
   label?: string;
-  //** */
-  accessibilityLabel: string;
   /**
    * Text showing in select box if no option has been chosen.
    * There should always have a placeholder unless there is a default option selected
@@ -110,7 +109,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
     errorText,
     helperText,
     label,
-    accessibilityLabel,
+    id,
     onChange,
     onClick = NOOP,
     placeholderText,
@@ -121,7 +120,8 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
     ...richSelectBoxProps
   } = props;
 
-  const id = useId();
+  const reactId = useId();
+  const inputId = id ?? reactId;
   const isHydrated = useIsHydrated();
   const disabled = !isHydrated || disabledProp;
 
@@ -202,9 +202,9 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
           )}
         </ReactAriaLabel>
         <Popover
+          accessibilityLabel={inputId}
           ref={overlayHandlerRef}
           disabled={disabled}
-          accessibilityLabel={accessibilityLabel}
           content={
             // this Box wrapper is to reapply the padding that was stripped from popover's dialog to show the sticky save/close buttons. Ideally this could be avoided
             <Box
@@ -218,7 +218,6 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
                 selectedValues={selectedKeys}
                 defaultSelectedValues={defaultSelectedKeys}
                 onChange={(selected) => setSelectedKeys(new Set(selected))}
-                accessibilityLabel={accessibilityLabel}
                 {...richSelectBoxProps}
               >
                 {children}

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -3,6 +3,7 @@ import React, {
   useMemo,
   type SyntheticEvent,
   useRef,
+  useId,
 } from "react";
 import classNames from "classnames";
 import {
@@ -59,7 +60,9 @@ export type RichSelectListProps = Omit<
   /** Text shown below select box */
   helperText?: string;
   /** Text shown above select box */
-  label: string;
+  label?: string;
+  //** */
+  accessibilityLabel: string;
   /**
    * Text showing in select box if no option has been chosen.
    * There should always have a placeholder unless there is a default option selected
@@ -107,6 +110,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
     errorText,
     helperText,
     label,
+    accessibilityLabel,
     onChange,
     onClick = NOOP,
     placeholderText,
@@ -117,6 +121,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
     ...richSelectBoxProps
   } = props;
 
+  const id = useId();
   const isHydrated = useIsHydrated();
   const disabled = !isHydrated || disabledProp;
 
@@ -186,14 +191,20 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
             setInteractionModality("keyboard"); // Show the focus ring so the user knows where focus went
           }}
         >
-          <Typography size={100} color="gray700">
-            {label}
-          </Typography>
+          {label && (
+            <label className={styles.label} htmlFor={id}>
+              <Box paddingX={1}>
+                <Typography size={100} color="gray700">
+                  {label}
+                </Typography>
+              </Box>
+            </label>
+          )}
         </ReactAriaLabel>
         <Popover
           ref={overlayHandlerRef}
           disabled={disabled}
-          accessibilityLabel={label}
+          accessibilityLabel={accessibilityLabel}
           content={
             // this Box wrapper is to reapply the padding that was stripped from popover's dialog to show the sticky save/close buttons. Ideally this could be avoided
             <Box
@@ -207,7 +218,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
                 selectedValues={selectedKeys}
                 defaultSelectedValues={defaultSelectedKeys}
                 onChange={(selected) => setSelectedKeys(new Set(selected))}
-                accessibilityLabel={label}
+                accessibilityLabel={accessibilityLabel}
                 {...richSelectBoxProps}
               >
                 {children}

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -42,7 +42,7 @@ const iconSize = {
   lg: 24,
 } as const;
 
-export type RichSelectListProps = Omit<RichSelectBoxProps, "id"> & {
+export type RichSelectListProps = RichSelectBoxProps & {
   /** Test id for the select element */
   "data-testid"?: string;
   /**
@@ -202,7 +202,6 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
           )}
         </ReactAriaLabel>
         <Popover
-          accessibilityLabel={inputId}
           ref={overlayHandlerRef}
           disabled={disabled}
           content={
@@ -219,6 +218,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
                 defaultSelectedValues={defaultSelectedKeys}
                 onChange={(selected) => setSelectedKeys(new Set(selected))}
                 {...richSelectBoxProps}
+                accessibilityLabel={inputId}
               >
                 {children}
               </RichSelectBox>

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -21,6 +21,7 @@
 .selectBox {
   align-items: center;
   appearance: none;
+  background-color: var(--color-base-white);
   border: 1px solid var(--color-base-gray-700);
   cursor: pointer;
   display: flex;
@@ -32,7 +33,6 @@
   outline: 0;
   padding: 0 36px 0 12px;
   width: 100%;
-  background-color: var(--color-base-white);
 }
 
 .selectMouseFocusStyling {

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -32,6 +32,7 @@
   outline: 0;
   padding: 0 36px 0 12px;
   width: 100%;
+  background-color: var(--color-base-white);
 }
 
 .selectMouseFocusStyling {


### PR DESCRIPTION
This PR adds the following updates for RichSelectList:
- Make the `label` prop optional (similar to what we do for TextField
- Because the label is now optional, I've added a required `accessibilityLabel` prop
- Make the default color for the select box white

Changes needed for [Shoppable Group Lessons](https://www.figma.com/file/e0BhCuouCduwIhnB3D7NQc/Shoppable-Group-Lessons?node-id=170%3A35748&mode=dev) which is the first use case of RichSelectList