### PR TITLE
Typography: set line-height to initial

### DIFF
--- a/.changeset/stupid-tips-decide.md
+++ b/.changeset/stupid-tips-decide.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-core": minor
+"@syntax/storybook": minor
+---
+
+Typography: set line-height to initial

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -1,5 +1,5 @@
 .typography {
-  line-height: normal;
+  line-height: initial;
   margin: 0;
 }
 


### PR DESCRIPTION
We should use `line-height: initial` for all of our Syntax text https://developer.mozilla.org/en-US/docs/Web/CSS/initial_value

Noticed that we had a global line-height setting in Camblystrap.css which was setting this for all text on Cambly.com

![image](https://github.com/Cambly/syntax/assets/127199/278f8023-bddb-4fbf-aa1b-0d2b7a7ebd06)
