### PR TITLE
RichSelectList: Update onClick call

### DIFF
--- a/.changeset/serious-trees-yell.md
+++ b/.changeset/serious-trees-yell.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+RichSelectList: Update onClick

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -180,6 +180,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
           [styles.opacityOverlay]: disabled,
           [styles.selectContainerCambio]: themeName === "cambio",
         })}
+        onClick={onClick}
       >
         {label && (
           <>


### PR DESCRIPTION
Passing in the onClick prop to the TapArea of RichSelectList never actually gets called since the mouse isn't clicking on that element. To trigger the onClick, it has to be passed into the div at the parent level.