### PR TITLE
LinkButton: show icons in Cambio

### DIFF
--- a/.changeset/poor-maps-yawn.md
+++ b/.changeset/poor-maps-yawn.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+LinkButton: show icons in Cambio

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -181,8 +181,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           themeName === "classic" ? styles[size] : styles[`${size}Cambio`],
           {
             [styles.fullWidth]: fullWidth,
-            [styles.buttonGap]:
-              themeName === "classic" && (size === "lg" || size === "md"),
+            [styles.buttonGap]: size === "lg" || size === "md",
             [styles.secondaryBorder]:
               themeName === "classic" && color === "secondary",
             [styles.secondaryDestructiveBorder]:

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -165,8 +165,7 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
           {
             [buttonStyles.fullWidth]: fullWidth,
             [styles.fitContent]: !fullWidth,
-            [buttonStyles.buttonGap]:
-              themeName === "classic" && (size === "lg" || size === "md"),
+            [buttonStyles.buttonGap]: size === "lg" || size === "md",
             [buttonStyles.secondaryBorder]:
               themeName === "classic" && color === "secondary",
             [buttonStyles.secondaryDestructiveBorder]:
@@ -175,7 +174,7 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
         )}
         onClick={onClick}
       >
-        {StartIcon && themeName === "classic" && (
+        {StartIcon && (
           <StartIcon
             className={classNames(
               buttonStyles.icon,
@@ -195,7 +194,7 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
             {text}
           </span>
         </Typography>
-        {EndIcon && themeName === "classic" && (
+        {EndIcon && (
           <EndIcon
             className={classNames(
               buttonStyles.icon,

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -178,7 +178,6 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
       <div
         className={classNames(styles.selectContainer, {
           [styles.opacityOverlay]: disabled,
-          [styles.selectContainerCambio]: themeName === "cambio",
         })}
         onClick={onClick}
       >
@@ -186,9 +185,6 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
           <>
             <ReactAriaLabel
               data-testid={[dataTestId, "label"].filter(Boolean).join("-")}
-              className={classNames(
-                themeName === "cambio" && styles.labelCambio,
-              )}
               {...labelProps}
               onClick={() => {
                 if (disabled) return;
@@ -196,7 +192,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
                 setInteractionModality("keyboard"); // Show the focus ring so the user knows where focus went
               }}
             >
-              <Box paddingX={themeName === "classic" ? 1 : 3}>
+              <Box paddingX={1}>
                 <Typography size={100} color="gray700">
                   {label}
                 </Typography>
@@ -279,7 +275,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
           </TapArea>
         </Popover>
         {(helperText || errorText) && (
-          <Box paddingX={themeName === "classic" ? 1 : 0}>
+          <Box paddingX={1}>
             <Typography
               size={100}
               color={errorText ? "destructive-primary" : "gray700"}

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -4,10 +4,6 @@
   gap: 8px;
 }
 
-.selectContainerCambio {
-  position: relative;
-}
-
 .opacityOverlay {
   opacity: 0.5;
 }

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -109,7 +109,6 @@ export default function SelectList({
     <div
       className={classNames(styles.selectContainer, {
         [styles.opacityOverlay]: disabled,
-        [styles.selectContainerCambio]: themeName === "cambio",
       })}
     >
       {label && (


### PR DESCRIPTION
## LinkButton Before: no icons show in Cambio

![Screenshot 2024-03-25 at 6 15 46 AM](https://github.com/Cambly/syntax/assets/127199/b0729b5c-13c1-4192-8a6f-a0dab7ab0456)

## LinkButton After: icons show in Cambio
![Screenshot 2024-03-25 at 6 17 05 AM](https://github.com/Cambly/syntax/assets/127199/a2dee1bf-f774-4dde-8018-49724304f416)

## RichSelectList before: label is not aligned
![Screenshot 2024-03-25 at 6 26 36 AM](https://github.com/Cambly/syntax/assets/127199/9153c5dd-7169-472c-81f2-2e1d3148faab)

## RichSelectList after: label is aligned
![Screenshot 2024-03-25 at 6 32 57 AM](https://github.com/Cambly/syntax/assets/127199/082d523a-1ad5-41d3-b70a-43a4cc624b50)
