### PR TITLE
Modal: add extra focus element check

### DIFF
--- a/.changeset/soft-melons-yell.md
+++ b/.changeset/soft-melons-yell.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Modal: add extra focus element check

--- a/packages/syntax-core/src/Modal/FocusTrap.tsx
+++ b/packages/syntax-core/src/Modal/FocusTrap.tsx
@@ -22,8 +22,8 @@ function queryFocusableAll(el: HTMLDivElement): NodeListOf<HTMLElement> {
   return el.querySelectorAll(selector);
 }
 
-const focusElement = (el: HTMLElement) => {
-  if (typeof el.focus === "function") {
+const focusElement = (el?: HTMLElement) => {
+  if (el && typeof el.focus === "function") {
     el.focus();
   }
 };


### PR DESCRIPTION
Noticed the following issue when using the Cambio theme: 

`Cannot read properties of undefined (reading 'focus')`


```tsx
var focusElement = (el) => {
  if (typeof el.focus === "function") {
    el.focus();
  }
};
```

https://cambly-inc.sentry.io/issues/5098994999/?alert_rule_id=14792676&alert_type=issue&environment=production&notification_uuid=75afccdd-1d2a-42ce-97ea-d90d6d12c677&project=234235&referrer=slack