### PR TITLE
Modal/FocusTrap: useLayoutEffect

### DIFF
--- a/.changeset/tasty-clocks-rule.md
+++ b/.changeset/tasty-clocks-rule.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-core": minor
+"@syntax/storybook": minor
+---
+
+Modal/FocusTrap: useLayoutEffect

--- a/packages/syntax-core/src/Modal/FocusTrap.tsx
+++ b/packages/syntax-core/src/Modal/FocusTrap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, type ReactElement } from "react";
+import React, { useRef, type ReactElement, useLayoutEffect } from "react";
 
 function queryFocusableAll(el: HTMLDivElement): NodeListOf<HTMLElement> {
   // Focusable, interactive elements that could possibly be in children
@@ -39,7 +39,7 @@ export default function FocusTrap({
   const elRef = useRef<HTMLDivElement | null>(null);
   const previouslyFocusedElRef = useRef<HTMLElement | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const { current: element } = elRef;
 
     // Focus the first child element among all the focusable, interactive elements within `children`


### PR DESCRIPTION
Better fix than https://github.com/Cambly/syntax/pull/355

In Cambio we use a Cambly Syntax IconButton instead of a custom `button` component. An `IconButton` is only enabled after hydration / first render so focus on the first element is not possible which caused the previous `.focus` failure.

How is this better?
Still sets the `focus` on the close icon button

![image](https://github.com/Cambly/syntax/assets/127199/22c55b30-24d1-47e1-8f31-9d864d2b642c)
