### PR TITLE
Typography: only use GT Super on supported languages

### DIFF
--- a/.changeset/tough-cameras-grab.md
+++ b/.changeset/tough-cameras-grab.md
@@ -1,0 +1,7 @@
+---
+"@cambly/syntax-design-tokens": minor
+"@cambly/syntax-core": minor
+"@cambly/syntax-floating-components": minor
+---
+
+Typography: only use GT Super on supported languages

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -8,8 +8,7 @@
   font-style: normal;
   font-weight: 510;
   src: local("GT-Super-Text-Medium"),
-    url("https://static.cambly.com/fonts/gt-super-medium.woff2");
-  font-display: optional;
+    url("https://static.cambly.com/fonts/gt-super-text-medium-converted.woff2");
 }
 
 @font-face {
@@ -17,19 +16,54 @@
   font-style: normal;
   font-weight: 700;
   src: local("GT-Super-Text-Bold"),
-    url("https://static.cambly.com/fonts/gt-super-bold.woff2");
-  font-display: optional;
+    url("https://static.cambly.com/fonts/gt-super-text-bold-converted.woff2");
 }
 
 .sansSerif {
-  font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Helvetica, Arial, sans-serif;
+  font-family: var(--syntax-font-sans-serif);
   margin: 0;
 }
 
 .serif {
-  font-family: "GT Super", -apple-system, system-ui, BlinkMacSystemFont,
-    "Segoe UI", Roboto, Helvetica, Arial, serif;
+  font-family: var(
+    --syntax-font-sans-serif
+  ); /* Intentional, the default is still to use sans-serif, we only use serif for certain languages */
+}
+
+/* GT Super only supports certain languages: https://www.grillitype.com/typeface/gt-super */
+
+/* List of languages we use on Cambly and their support for GT Super
+
+* English: ✅
+* Arabic: ❌
+* Azerbaijani: ✅
+* German: ✅
+* Spanish: ✅
+* French: ✅
+* Italian: ✅
+* Japanese: ❌
+* Korean: ❌
+* Polish: ✅
+* Portuguese: ✅
+* Russian: ❌
+* Thai: ❌
+* Turkish: ✅
+* Vietnamese: ❌
+* Simplified Chinese: ❌
+* Traditional Chinese: ❌
+*/
+
+/* stylelint-disable-next-line selector-max-compound-selectors -- only render serif font for certain languages */
+:lang(en) .serif,
+:lang(az) .serif,
+:lang(fr) .serif,
+:lang(de) .serif,
+:lang(es) .serif,
+:lang(it) .serif,
+:lang(pl) .serif,
+:lang(pt) .serif,
+:lang(tr) .serif {
+  font-family: "GT Super", var(--syntax-font-sans-serif);
   -webkit-font-smoothing: antialiased;
 }
 

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -1,5 +1,6 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import Typography from "./Typography";
+import Box from "../Box/Box";
 
 export default {
   title: "Components/Typography",
@@ -160,6 +161,44 @@ export const colors: StoryObj<typeof Typography> = {
       </Typography>
     </>
   ),
+};
+
+function SerifCharacterSupportExample() {
+  return (
+    <Box display="flex" gap={3} direction="column">
+      <Typography size={200} fontStyle="serif">
+        English: à, é, ñ
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        Azerbaijani: ə, ı, ş, ü
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        French: à, â, é, è, ê, ë, î, ï, ô, ö, ù, û, ü, ÿ, ç
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        German: ä, ö, ü, ß
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        Spanish: á, é, í, ó, ú, ü, ñ
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        Italian: à, è, é, ì, ò, ó, ù
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        Polish: ą, ć, ę, ł, ń, ó, ś, ź, ż
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        Portuguese: á, â, ã, à, é, ê, í, ó, ô, õ, ú
+      </Typography>
+      <Typography size={200} fontStyle="serif">
+        Turkish: ç, ğ, ı, ö, ş, ü
+      </Typography>
+    </Box>
+  );
+}
+
+export const SerifCharacterSupport: StoryObj<typeof Typography> = {
+  render: () => <SerifCharacterSupportExample />,
 };
 
 export const Inline: StoryObj<typeof Typography> = {

--- a/packages/syntax-design-tokens/tokens/font/base.json
+++ b/packages/syntax-design-tokens/tokens/font/base.json
@@ -1,0 +1,9 @@
+{
+  "syntax": {
+    "font": {
+      "sans-serif": {
+        "value": "-apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Background

We currently use a trial version of the GT Super font which only supports a limited set of characters. That causes issues for our users and we should fix it.

# Changes

* Use full version of GT super font (converted OTF => WOFF2 with https://cloudconvert.com/otf-to-woff2)
* Only use GT Super on supported languages
* Add Storybook example to show before / after

## Before

![Screenshot 2024-03-27 at 11 29 16 AM](https://github.com/Cambly/syntax/assets/127199/a014222b-41c8-4081-bbb0-28c6a62a25a0)

## After

![Screenshot 2024-03-27 at 11 30 43 AM](https://github.com/Cambly/syntax/assets/127199/92c83615-4311-4946-9793-6a3fb737e04d)
