### PR TITLE
Typography: use final font + Modal: fix image size

### DIFF
--- a/.changeset/blue-laws-lie.md
+++ b/.changeset/blue-laws-lie.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Typography: use final font + Modal: fix image size

--- a/packages/syntax-core/src/Modal/Modal.stories.tsx
+++ b/packages/syntax-core/src/Modal/Modal.stories.tsx
@@ -99,7 +99,13 @@ export const WithImage: StoryObj<typeof Modal> = {
   args: {
     ...Default.args,
     header: "With Image",
-    image: <img src="https://placehold.co/400x200" alt="placeholder image" />,
+    image: (
+      <img
+        src="https://placehold.co/600x200"
+        alt="placeholder image"
+        style={{ width: "100%" }}
+      />
+    ),
   },
   render: function WithImageExample({ ...args }): JSX.Element {
     const [isOpen, setIsOpen] = useState(false);

--- a/packages/syntax-core/src/Modal/Modal.tsx
+++ b/packages/syntax-core/src/Modal/Modal.tsx
@@ -102,7 +102,9 @@ export default function Modal({
   onDismiss: () => void;
   /**
    * The optional image rendered above the Modal.
-   * Image size should be 400w x 200h.
+   * Image
+   *  * Size should be 600w x 200h
+   *  * Be sure to set width="100%" on the image
    * If images aren't that sized, should ask design to give another image.
    */
   image?: JSX.Element;
@@ -222,7 +224,7 @@ export default function Modal({
                   </Box>
                 )}
               </Box>
-              {image && <Box maxHeight={200}>{image}</Box>}
+              {image && <Box>{image}</Box>}
               <Box
                 display="flex"
                 gap={themeName === "classic" ? 3 : 4}

--- a/packages/syntax-core/src/Typography/Typography.module.css
+++ b/packages/syntax-core/src/Typography/Typography.module.css
@@ -8,7 +8,7 @@
   font-style: normal;
   font-weight: 510;
   src: local("GT-Super-Text-Medium"),
-    url("https://static.cambly.com/fonts/gt-super-text-medium-converted.woff2");
+    url("https://static.cambly.com/fonts/gt-super-text-medium-final.woff2");
 }
 
 @font-face {
@@ -16,7 +16,7 @@
   font-style: normal;
   font-weight: 700;
   src: local("GT-Super-Text-Bold"),
-    url("https://static.cambly.com/fonts/gt-super-text-bold-converted.woff2");
+    url("https://static.cambly.com/fonts/gt-super-text-bold-final.woff2");
 }
 
 .sansSerif {


### PR DESCRIPTION
## Typography

Updated so we use the font given to us by the foundry

### Before

![Screenshot 2024-03-27 at 2 55 17 PM](https://github.com/Cambly/syntax/assets/127199/a873eacb-2bb5-42a2-ac5b-301001051d1f)


### After

![Screenshot 2024-03-27 at 2 55 40 PM](https://github.com/Cambly/syntax/assets/127199/289233e0-86e1-4ff4-aa50-55cd7f3ee62c)


## Modal

### Before

![Screenshot 2024-03-27 at 2 33 43 PM](https://github.com/Cambly/syntax/assets/127199/615680c6-7bab-4c83-afdc-ea87beaf57c2)

### After

![Screenshot 2024-03-27 at 2 48 49 PM](https://github.com/Cambly/syntax/assets/127199/0dca230f-eca1-4ad0-b49e-6075d05d1e4d)
