### PR TITLE
Box/Avatar/TapArea: remove deprecated props

### DIFF
--- a/.changeset/serious-games-worry.md
+++ b/.changeset/serious-games-worry.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-core": minor
+"@syntax/storybook": minor
+---
+
+Box/Avatar/TapArea: remove deprecated props

--- a/packages/syntax-core/src/Avatar/Avatar.module.css
+++ b/packages/syntax-core/src/Avatar/Avatar.module.css
@@ -33,8 +33,3 @@
   width: 64px;
   height: 64px;
 }
-
-.xl {
-  width: 64px;
-  height: 64px;
-}

--- a/packages/syntax-core/src/Avatar/Avatar.stories.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
   argTypes: {
     size: {
-      options: ["xs", "sm", "md", "lg", "xl"],
+      options: ["xs", "sm", "md", "lg"],
       control: { type: "radio" },
     },
   },
@@ -39,9 +39,6 @@ export const Small: StoryObj<typeof Avatar> = {
 };
 export const Large: StoryObj<typeof Avatar> = {
   args: { ...Default.args, size: "lg" },
-};
-export const ExtraLarge: StoryObj<typeof Avatar> = {
-  args: { ...Default.args, size: "xl" },
 };
 
 export const IconAvatar: StoryObj<typeof Avatar> = {

--- a/packages/syntax-core/src/Avatar/Avatar.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.tsx
@@ -9,7 +9,6 @@ const sizeToIconStyles = {
   sm: { bottom: 6, marginInlineEnd: 2, height: 4, width: 4 },
   md: { bottom: 6, marginInlineEnd: 2, height: 8, width: 8 },
   lg: { bottom: 6, marginInlineEnd: 6, height: 12, width: 12 },
-  xl: { bottom: 12, marginInlineEnd: 12, height: 16, width: 16 },
 } as const;
 
 const sizeToMargin = {
@@ -17,7 +16,6 @@ const sizeToMargin = {
   sm: -14,
   md: -22,
   lg: -28,
-  xl: -28,
 } as const;
 
 function AvatarInternal({
@@ -30,7 +28,7 @@ function AvatarInternal({
   accessibilityLabel: string;
   icon?: React.ReactElement;
   outline?: boolean;
-  size?: "xs" | "sm" | "md" | "lg" | "xl";
+  size?: "xs" | "sm" | "md" | "lg";
   src: string;
 }): ReactElement {
   return (
@@ -93,11 +91,10 @@ const Avatar = ({
    * * `sm`: 32px
    * * `md`: 48px
    * * `lg`: 64px
-   * * `xl`: 64px (deprecated)
    *
    * @defaultValue `md`
    */
-  size?: "xs" | "sm" | "md" | "lg" | "xl";
+  size?: "xs" | "sm" | "md" | "lg";
   /**
    * URL of the image to display as the avatar.
    */

--- a/packages/syntax-core/src/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/syntax-core/src/AvatarGroup/AvatarGroup.stories.tsx
@@ -18,7 +18,7 @@ export default {
   },
   argTypes: {
     size: {
-      options: ["xs", "sm", "md", "lg", "xl"],
+      options: ["xs", "sm", "md", "lg"],
       control: { type: "radio" },
     },
     orientation: {
@@ -80,7 +80,7 @@ export const Standard: StoryObj<
     size: ComponentProps<typeof Avatar>["size"];
   }
 > = {
-  args: { size: "xl", orientation: "standard" },
+  args: { size: "lg", orientation: "standard" },
   render: (args) => {
     const { size, orientation } = args;
     return (
@@ -118,7 +118,7 @@ export const Reverse: StoryObj<
     size: ComponentProps<typeof Avatar>["size"];
   }
 > = {
-  args: { size: "xl", orientation: "reverse" },
+  args: { size: "lg", orientation: "reverse" },
   render: (args) => {
     const { size, orientation } = args;
     return (

--- a/packages/syntax-core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/syntax-core/src/AvatarGroup/AvatarGroup.tsx
@@ -6,13 +6,7 @@ import {
 } from "react";
 import Box from "../Box/Box";
 
-type Size =
-  | "xs"
-  | "sm"
-  | "md"
-  | "lg"
-  /* `xl` is deprecated */
-  | "xl";
+type Size = "xs" | "sm" | "md" | "lg";
 type Orientation = "standard" | "reverse";
 
 type AvatarGroupContextType = {
@@ -34,7 +28,7 @@ export function useAvatarGroup(): AvatarGroupContextType | null {
  *
  * Usage:
  *
- * <AvatarGroup size="xl" orientation="standard">
+ * <AvatarGroup size="md" orientation="standard">
  *   <Avatar accessibilityLabel="Joseph Liotta" src="image.png" />
  *   <Avatar accessibilityLabel="Joseph Liotta" src="image.png" />
  *   <Avatar accessibilityLabel="Joseph Liotta" src="image.png" />
@@ -53,7 +47,6 @@ export default function AvatarGroup({
    * * `sm`: 32px
    * * `md`: 48px
    * * `lg`: 64px
-   * * `xl`: 64px (deprecated)
    *
    * @defaultValue `md`
    */
@@ -72,10 +65,8 @@ export default function AvatarGroup({
    */
   children: ReactNode;
 }): ReactElement {
-  const parsedSize = size === "xl" ? "lg" : size;
-
   return (
-    <AvatarGroupContext.Provider value={{ size: parsedSize, orientation }}>
+    <AvatarGroupContext.Provider value={{ size, orientation }}>
       <Box
         display="flex"
         justifyContent={orientation === "standard" ? "start" : "end"}

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -362,13 +362,11 @@ type BoxProps = {
    * * `none`: 0px
    * * `sm`: 4px
    * * `md`: 8px
-   * * `lg`: 8px (maps to `md`)
-   * * `xl`: 8px (maps to `md`)
    * * `full`: 999px
    *
    * @defaultValue "none"
    */
-  rounding?: "xl" | "lg" | "md" | "sm" | "full" | "none";
+  rounding?: "md" | "sm" | "full" | "none";
   /**
    * The alignment of the box on the cross axis on sm (480px) or larger viewports.
    */
@@ -422,15 +420,6 @@ type BoxProps = {
    */
   width?: Dimension;
 };
-
-export function roundingCambio(
-  rounding: "sm" | "md" | "lg" | "xl" | "full",
-): "sm" | "md" | "full" {
-  if (rounding === "lg" || rounding === "xl") {
-    return "md";
-  }
-  return rounding;
-}
 
 /**
  * [Box](https://cambly-syntax.vercel.app/?path=/docs/components-box--docs) is primitive design component and is used by lots of other components. It keeps details like spacing, borders and colors consistent across all of Syntax.
@@ -590,9 +579,7 @@ const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
       smJustifyContent && styles[`justifyContent${smJustifyContent}Small`],
       lgJustifyContent && styles[`justifyContent${lgJustifyContent}Large`],
       position && position !== "static" && styles[position],
-      rounding &&
-        rounding !== "none" &&
-        roundingStyles[`rounding${roundingCambio(rounding)}`],
+      rounding && rounding !== "none" && roundingStyles[`rounding${rounding}`],
       overflow && styles[`overflow${overflow}`],
       overflowX && styles[`overflowX${overflowX}`],
       overflowY && styles[`overflowY${overflowY}`],

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -8,7 +8,6 @@ import classNames from "classnames";
 import styles from "./TapArea.module.css";
 import roundingStyles from "../rounding.module.css";
 import useIsHydrated from "../useIsHydrated";
-import { roundingCambio } from "../Box/Box";
 
 type TapAreaProps = AriaAttributes & {
   /**
@@ -51,13 +50,11 @@ type TapAreaProps = AriaAttributes & {
    * * `none`: 0px
    * * `sm`: 8px
    * * `md`: 12px
-   * * `lg`: 16px
-   * * `xl`: 32px
    * * `full`: 999px
    *
    * @defaultValue "none"
    */
-  rounding?: "xl" | "lg" | "md" | "sm" | "full" | "none";
+  rounding?: "md" | "sm" | "full" | "none";
   /**
    * The tab index of the tap area
    */
@@ -151,8 +148,7 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
 
     const isHoveredOrFocussed = !disabled && (hovered || focussed);
     const roundingClasses =
-      rounding !== "none" &&
-      roundingStyles[`rounding${roundingCambio(rounding)}`];
+      rounding !== "none" && roundingStyles[`rounding${rounding}`];
 
     return (
       <div


### PR DESCRIPTION
Changes to `Box` / `TapArea` / `Avatar` & `AvatarGroup` to remove / replace deprecated props

- [ ] Avatar / AvatarGroup: remove deprecated xl size
- [ ] Box/TapArea: remove lg and xl rounding => md

Related PR: https://github.com/Cambly/Cambly-Frontend/pull/9298