### PR TITLE
Add changeset for loading link button changes

### DIFF
--- a/.changeset/happy-bananas-switch.md
+++ b/.changeset/happy-bananas-switch.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add loading state for LinkButton


### PR DESCRIPTION
I forgot to commit the changeset to my LinkButton update PR, so it didn't trigger a version change