### PR TITLE
[Box] add optional border

### DIFF
--- a/.changeset/plenty-days-travel.md
+++ b/.changeset/plenty-days-travel.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Box + Card: add border as a passthrough prop

--- a/.changeset/plenty-days-travel.md
+++ b/.changeset/plenty-days-travel.md
@@ -2,4 +2,4 @@
 "@cambly/syntax-core": minor
 ---
 
-Box + Card: add border as a passthrough prop
+Box: Add "primary" border as optional prop

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -68,6 +68,10 @@ export default {
       control: { type: "select" },
       options: allColors,
     },
+    border: {
+      control: { type: "radio" },
+      options: ["primary", "none"],
+    },
     dangerouslySetInlineStyle: {
       control: { type: "object" },
     },
@@ -171,7 +175,7 @@ export default {
       control: "text",
     },
     rounding: {
-      options: ["none", "sm", "md", "lg", "xl", "full"],
+      options: ["none", "sm", "md", "full"],
       control: { type: "select" },
     },
     children: {
@@ -406,7 +410,7 @@ const roundingLookup = {
 export const Rounding: StoryObj<typeof Box> = {
   render: () => (
     <Box display="flex" gap={4} flexWrap="wrap">
-      {(["sm", "md", "lg", "xl", "full"] as const).map((rounding) => (
+      {(["sm", "md", "full"] as const).map((rounding) => (
         <Box
           key={rounding}
           rounding={rounding}

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -248,9 +248,19 @@ export const BackgroundColor: StoryObj<typeof Box> = {
   ),
 };
 
+export const Border: StoryObj<typeof Box> = {
+  render: () => (
+    <Box display="flex" flexWrap="wrap" gap={4}>
+      <Box border="primary" width={240} padding={2}>
+        <Typography>Border Primary</Typography>
+      </Box>
+    </Box>
+  ),
+};
+
 export const Direction: StoryObj<typeof Box> = {
   render: () => (
-    <>
+    <Box display="flex" direction="column" gap={4}>
       <Typography weight="bold">Direction: row </Typography>
       <Box display="flex">
         <Box height={40} width={40}>
@@ -284,7 +294,7 @@ export const Direction: StoryObj<typeof Box> = {
           <Typography>4</Typography>
         </Box>
       </Box>
-    </>
+    </Box>
   ),
 };
 

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -99,6 +99,14 @@ type BoxProps = {
    */
   backgroundColor?: (typeof allColors)[number];
   /**
+   * The border color of the box.
+   * This is a passthrough prop directly to the Box component.
+   *
+   * Usage example: `border="1px solid var(--color-base-gray-300)"`
+   * @defaultValue `none`
+   */
+  border?: string;
+  /**
    * The children to be rendered inside the box.
    */
   children?: ReactNode;
@@ -441,6 +449,7 @@ const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
     lgAlignItems,
     alignSelf,
     backgroundColor,
+    border,
     direction,
     smDirection,
     lgDirection,
@@ -591,6 +600,7 @@ const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
       minHeight,
       minWidth,
       width,
+      border,
       ...(dangerouslySetInlineStyle?.__style ?? {}),
     },
   };

--- a/packages/syntax-core/src/Box/Box.tsx
+++ b/packages/syntax-core/src/Box/Box.tsx
@@ -4,6 +4,7 @@ import styles from "./Box.module.css";
 import marginStyles from "./margin.module.css";
 import paddingStyles from "./padding.module.css";
 import type allColors from "../colors/allColors";
+import borderStyles from "../border.module.css";
 import colorStyles from "../colors/colors.module.css";
 import roundingStyles from "../rounding.module.css";
 import { forwardRef } from "react";
@@ -99,13 +100,14 @@ type BoxProps = {
    */
   backgroundColor?: (typeof allColors)[number];
   /**
-   * The border color of the box.
-   * This is a passthrough prop directly to the Box component.
+   * The border styling of the box.
    *
-   * Usage example: `border="1px solid var(--color-base-gray-300)"`
+   * * `primary`: 1px solid var(--color-base-primary)
+   * * `none`: 0px
+   *
    * @defaultValue `none`
    */
-  border?: string;
+  border?: "primary" | "none";
   /**
    * The children to be rendered inside the box.
    */
@@ -589,6 +591,7 @@ const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
       lgJustifyContent && styles[`justifyContent${lgJustifyContent}Large`],
       position && position !== "static" && styles[position],
       rounding && rounding !== "none" && roundingStyles[`rounding${rounding}`],
+      border && borderStyles[`border${border}`],
       overflow && styles[`overflow${overflow}`],
       overflowX && styles[`overflowX${overflowX}`],
       overflowY && styles[`overflowY${overflowY}`],
@@ -600,7 +603,6 @@ const Box = forwardRef<HTMLDivElement, BoxProps>(function Box(
       minHeight,
       minWidth,
       width,
-      border,
       ...(dangerouslySetInlineStyle?.__style ?? {}),
     },
   };

--- a/packages/syntax-core/src/Card/Card.tsx
+++ b/packages/syntax-core/src/Card/Card.tsx
@@ -24,6 +24,14 @@ type CardType = {
    * @defaultValue `roomy`
    */
   size?: "compact" | "roomy";
+  /**
+   * The border color of the box.
+   * This is a passthrough prop directly to the Box component.
+   *
+   * Usage example: `border="1px solid var(--color-base-gray-300)"`
+   * * @defaultValue `none`
+   */
+  border?: string;
 };
 
 /**
@@ -33,6 +41,7 @@ export default function Card({
   backgroundColor = "white",
   children,
   size,
+  border = "none",
   "data-testid": dataTestId,
 }: CardType): JSX.Element {
   return (
@@ -42,6 +51,9 @@ export default function Card({
       width="100%"
       backgroundColor={backgroundColor}
       data-testid={dataTestId}
+      dangerouslySetInlineStyle={{
+        __style: { border: border ? border : "none" },
+      }}
     >
       {children}
     </Box>

--- a/packages/syntax-core/src/Card/Card.tsx
+++ b/packages/syntax-core/src/Card/Card.tsx
@@ -24,14 +24,6 @@ type CardType = {
    * @defaultValue `roomy`
    */
   size?: "compact" | "roomy";
-  /**
-   * The border color of the box.
-   * This is a passthrough prop directly to the Box component.
-   *
-   * Usage example: `border="1px solid var(--color-base-gray-300)"`
-   * * @defaultValue `none`
-   */
-  border?: string;
 };
 
 /**

--- a/packages/syntax-core/src/Card/Card.tsx
+++ b/packages/syntax-core/src/Card/Card.tsx
@@ -41,7 +41,6 @@ export default function Card({
   backgroundColor = "white",
   children,
   size,
-  border = "none",
   "data-testid": dataTestId,
 }: CardType): JSX.Element {
   return (
@@ -51,9 +50,6 @@ export default function Card({
       width="100%"
       backgroundColor={backgroundColor}
       data-testid={dataTestId}
-      dangerouslySetInlineStyle={{
-        __style: { border: border ? border : "none" },
-      }}
     >
       {children}
     </Box>

--- a/packages/syntax-core/src/border.module.css
+++ b/packages/syntax-core/src/border.module.css
@@ -1,0 +1,7 @@
+.borderprimary {
+  border: 1px solid var(--color-gray370);
+}
+
+.bordernone {
+  border: none;
+}

--- a/packages/syntax-core/src/border.module.css
+++ b/packages/syntax-core/src/border.module.css
@@ -1,5 +1,5 @@
 .borderprimary {
-  border: 1px solid var(--color-gray370);
+  border: 1px solid var(--color-cambio-gray-370);
 }
 
 .bordernone {


### PR DESCRIPTION
Note: since @christianvuerings is out for a week and he requested changes on my other PR (and so merging is blocked), I'm creating a new one so it isn't blocking my feature work. [original PR](https://github.com/Cambly/syntax/pull/381)

Talked with @christianvuerings + @ajmooo about how to handle this. we use this border prop fairly often. having a defined style makes it more consistent usage across the app. Also will eliminate usages of dangerouslySetInlineStyle just to set border

![image](https://github.com/Cambly/syntax/assets/15243713/f52cc29e-b93f-4e52-b78b-f5bd639a8785)
