### PR TITLE
tooltip: update stylings to center trigger

### DIFF
--- a/.changeset/heavy-cougars-kick.md
+++ b/.changeset/heavy-cougars-kick.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Tooltip: trigger isn't centered. apply new stylings to make it centered

--- a/packages/syntax-core/src/react-aria-utils/Triggerable.tsx
+++ b/packages/syntax-core/src/react-aria-utils/Triggerable.tsx
@@ -73,8 +73,9 @@ const Triggerable = forwardRef<
         {
           className: styles.trigger,
           style: {
-            display: "inline-block",
-            verticalAlign: "text-top",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
           },
         },
       )}


### PR DESCRIPTION
before: 
![image](https://github.com/Cambly/syntax/assets/15243713/628f96e0-5063-41dc-a0ea-98ffd9608add)


after:
![image](https://github.com/Cambly/syntax/assets/15243713/7bef1129-fe09-4948-be2f-7e822eaa8ff5)
