### PR TITLE
TextArea/add-ability-to-not-resize

### DIFF
--- a/.changeset/two-lizards-drop.md
+++ b/.changeset/two-lizards-drop.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TextArea: Add optional resize prop to allow for no resizing

--- a/packages/syntax-core/src/TextArea/TextArea.module.css
+++ b/packages/syntax-core/src/TextArea/TextArea.module.css
@@ -2,3 +2,7 @@
   display: block; /* Fixes chrome bug https://stackoverflow.com/questions/63430767; */
   padding: 12px;
 }
+
+.resizeNone {
+  resize: none;
+}

--- a/packages/syntax-core/src/TextArea/TextArea.module.css
+++ b/packages/syntax-core/src/TextArea/TextArea.module.css
@@ -3,6 +3,18 @@
   padding: 12px;
 }
 
-.resizeNone {
+.resizenone {
   resize: none;
+}
+
+.resizehorizontal {
+  resize: horizontal;
+}
+
+.resizevertical {
+  resize: vertical;
+}
+
+.resizeboth {
+  resize: both;
 }

--- a/packages/syntax-core/src/TextArea/TextArea.stories.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.stories.tsx
@@ -22,6 +22,7 @@ export default {
     value: "",
     "data-testid": "",
     id: "",
+    resize: true,
   },
   argTypes: {
     disabled: {

--- a/packages/syntax-core/src/TextArea/TextArea.stories.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.stories.tsx
@@ -18,11 +18,11 @@ export default {
     errorText: "",
     helperText: "",
     maxLength: 1024,
+    resize: "none",
     rows: 3,
     value: "",
     "data-testid": "",
     id: "",
-    resize: "none",
   },
   argTypes: {
     disabled: {

--- a/packages/syntax-core/src/TextArea/TextArea.stories.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.stories.tsx
@@ -22,7 +22,7 @@ export default {
     value: "",
     "data-testid": "",
     id: "",
-    resize: true,
+    resize: "none",
   },
   argTypes: {
     disabled: {
@@ -30,6 +30,10 @@ export default {
     },
     placeholder: {
       control: "text",
+    },
+    resize: {
+      options: ["none", "horizontal", "vertical", "both"],
+      control: { type: "radio" },
     },
   },
   tags: ["autodocs"],

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -44,6 +44,16 @@ type TextAreaProps = {
    */
   placeholder?: string;
   /**
+   * Sets which part resizes when the user drags the resize handle.
+   * * `none`: TextArea can not be resized
+   * * `horizontal`: TextArea can only be resized horizontally
+   * * `vertical`: TextArea can only be resized vertically
+   * * `both`: TextArea can be resized horizontally and vertically
+   *
+   * @defaultvalue `none`
+   */
+  resize?: "none" | "horizontal" | "vertical" | "both";
+  /**
    * Number of rows to display
    */
   rows?: number;
@@ -51,16 +61,6 @@ type TextAreaProps = {
    * Value of the TextArea
    */
   value: string;
-  /**
-   * Sets which part resizes when the user drags the resize handle.
-   * "none" - The user cannot resize the element.
-   * "horizontal" - The user can only resize the element horizontally.
-   * "vertical" - The user can only resize the element vertically.
-   * "both" - The user can resize the element horizontally and vertically.
-   *
-   * @defaultvalue "none"
-   */
-  resize?: "none" | "horizontal" | "vertical" | "both";
 };
 
 /**

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -51,6 +51,12 @@ type TextAreaProps = {
    * Value of the TextArea
    */
   value: string;
+  /**
+   * Boolean of whether the TextArea should be resizable
+   *
+   * @default true
+   */
+  resize?: boolean;
 };
 
 /**
@@ -70,6 +76,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       rows = 3,
       value = "",
       onChange,
+      resize = true,
     }: TextAreaProps,
     forwardedRef,
   ): ReactElement {
@@ -104,6 +111,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             ref={forwardedRef}
             className={classNames(textFieldStyles.textfield, styles.textarea, {
               [textFieldStyles.inputError]: errorText,
+              [styles.resizeNone]: !resize,
             })}
             id={inputId}
             placeholder={placeholder}

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -52,11 +52,15 @@ type TextAreaProps = {
    */
   value: string;
   /**
-   * Boolean of whether the TextArea should be resizable
+   * Sets which part resizes when the user drags the resize handle.
+   * "none" - The user cannot resize the element.
+   * "horizontal" - The user can only resize the element horizontally.
+   * "vertical" - The user can only resize the element vertically.
+   * "both" - The user can resize the element horizontally and vertically.
    *
-   * @default true
+   * @defaultvalue "none"
    */
-  resize?: boolean;
+  resize?: "none" | "horizontal" | "vertical" | "both";
 };
 
 /**
@@ -76,7 +80,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       rows = 3,
       value = "",
       onChange,
-      resize = true,
+      resize = "none",
     }: TextAreaProps,
     forwardedRef,
   ): ReactElement {
@@ -109,10 +113,14 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <textarea
             data-testid={dataTestId}
             ref={forwardedRef}
-            className={classNames(textFieldStyles.textfield, styles.textarea, {
-              [textFieldStyles.inputError]: errorText,
-              [styles.resizeNone]: !resize,
-            })}
+            className={classNames(
+              textFieldStyles.textfield,
+              styles.textarea,
+              styles[`resize${resize}`],
+              {
+                [textFieldStyles.inputError]: errorText,
+              },
+            )}
             id={inputId}
             placeholder={placeholder}
             maxLength={maxLength}


### PR DESCRIPTION
Add optional resize prop to allow for disabling resize.

![image](https://github.com/Cambly/syntax/assets/15243713/6d0e42d9-ab8f-4819-85fa-d9233b177535)

![image](https://github.com/Cambly/syntax/assets/15243713/b347c1e2-a21c-4b63-a912-8769ff66eba7)


This prop was needed for ai assessments to not allow for text area resizing
