### PR TITLE
Icons: Add exports

### DIFF
--- a/.changeset/two-peas-sit.md
+++ b/.changeset/two-peas-sit.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-icons": minor
+---
+
+Syntax/Icons: update build for import

--- a/packages/syntax-icons/package.json
+++ b/packages/syntax-icons/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./dist/"
   }
 }


### PR DESCRIPTION
Current import has to be from the dist folder

`import Accent from "@cambly/syntax-icons/dist/Accent`

would love for us to be able to do it like 

`import Accent from "@cambly/syntax-icons/Accent"`