### PR TITLE
Checkbox / RadioButton: fix responsiveness + TextField: add maxLength

### DIFF
--- a/.changeset/hot-boxes-happen.md
+++ b/.changeset/hot-boxes-happen.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Checkbox / RadioButton: fix responsiveness + TextField: add maxLength

--- a/packages/syntax-core/src/Checkbox/Checkbox.module.css
+++ b/packages/syntax-core/src/Checkbox/Checkbox.module.css
@@ -16,6 +16,7 @@
 
 .checkbox {
   border-radius: 4px;
+  flex: none;
   position: relative;
   display: flex;
   justify-content: center;

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -40,18 +40,16 @@ export default {
 
 export const Default: StoryObj<typeof Checkbox> = {};
 
-const CheckboxInteractive = () => {
+const CheckboxInteractive = ({
+  label = "checkbox label",
+}: {
+  label?: string;
+}) => {
   const [isChecked, setIsChecked] = useState(false);
   const handleChange = () => {
     setIsChecked(!isChecked);
   };
-  return (
-    <Checkbox
-      checked={isChecked}
-      onChange={handleChange}
-      label="checkbox label"
-    />
-  );
+  return <Checkbox checked={isChecked} onChange={handleChange} label={label} />;
 };
 
 export const Interactive: StoryObj<typeof Checkbox> = {
@@ -60,7 +58,14 @@ export const Interactive: StoryObj<typeof Checkbox> = {
 
 export const FixDoesNotBlowoutHeight: StoryObj<typeof Checkbox> = {
   render: () => (
-    <Box height="100px" overflowY="auto" padding={3}>
+    <Box
+      display="flex"
+      direction="column"
+      height="100px"
+      overflowY="auto"
+      padding={3}
+      gap={3}
+    >
       <CheckboxInteractive />
       <CheckboxInteractive />
       <CheckboxInteractive />
@@ -81,7 +86,7 @@ export const FixDoesNotBlowoutHeight: StoryObj<typeof Checkbox> = {
       <CheckboxInteractive />
       <CheckboxInteractive />
       <CheckboxInteractive />
-      <CheckboxInteractive />
+      <CheckboxInteractive label="Checkbox with a long label to test the responsive behavior of Checkbox" />
     </Box>
   ),
 };

--- a/packages/syntax-core/src/RadioButton/RadioButton.module.css
+++ b/packages/syntax-core/src/RadioButton/RadioButton.module.css
@@ -28,6 +28,7 @@
 
 .radioStyleOverride {
   margin: 0;
+  flex: none;
   opacity: 0;
 }
 

--- a/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
@@ -1,6 +1,7 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import RadioButton from "./RadioButton";
 import React, { useState } from "react";
+import Box from "../Box/Box";
 
 export default {
   title: "Components/RadioButton",
@@ -48,28 +49,30 @@ const RadioButtonInteractive = () => {
     setSelectedOption(event.target.value);
   };
   return (
-    <form style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-      <RadioButton
-        checked={selectedOption === "mage"}
-        value="mage"
-        onChange={handleChange}
-        name="rpg_class"
-        label="Mage"
-      />
-      <RadioButton
-        checked={selectedOption === "warrior"}
-        value="warrior"
-        onChange={handleChange}
-        name="rpg_class"
-        label="Warrior"
-      />
-      <RadioButton
-        checked={selectedOption === "archer"}
-        value="archer"
-        onChange={handleChange}
-        name="rpg_class"
-        label="Archer"
-      />
+    <form>
+      <Box display="flex" direction="column" gap={3}>
+        <RadioButton
+          checked={selectedOption === "mage"}
+          value="mage"
+          onChange={handleChange}
+          name="rpg_class"
+          label="Label with a lot of text to test the responsive behavior of the component"
+        />
+        <RadioButton
+          checked={selectedOption === "warrior"}
+          value="warrior"
+          onChange={handleChange}
+          name="rpg_class"
+          label="Warrior"
+        />
+        <RadioButton
+          checked={selectedOption === "archer"}
+          value="archer"
+          onChange={handleChange}
+          name="rpg_class"
+          label="Archer"
+        />
+      </Box>
     </form>
   );
 };

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -91,8 +91,6 @@ const RadioButton = ({
         styles[`cursor${disabled ? "Disabled" : "Enabled"}`],
         {
           [styles.disabled]: disabled,
-          [styles.smBase]: size === "sm",
-          [styles.mdBase]: size === "md",
         },
       )}
     >

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -20,6 +20,7 @@ export default function TextField({
   helperText = "",
   id,
   label,
+  maxLength,
   onChange,
   placeholder = "",
   type = "text",
@@ -57,6 +58,10 @@ export default function TextField({
    * TextField visible label
    */
   label: string;
+  /**
+   * Maximum length of the TextField
+   */
+  maxLength?: number;
   /**
    * The callback to be called the input changes
    */
@@ -110,6 +115,7 @@ export default function TextField({
         data-testid={dataTestId}
         disabled={disabled}
         id={inputId}
+        maxLength={maxLength}
         type={type}
         onChange={onChange}
         placeholder={placeholder}


### PR DESCRIPTION
# Description

After we used Syntax on our Cambly settings page, we noticed a few missing props & bugs with responsive behavior

# Changes

* `TextField`: add `maxLength`
* Checkbox: fix responsive behavior
* RadioButton: avoid setting a height + fix responsive behavior

# Screenshots

## RadioButton: before / after
![Screenshot 2024-05-10 at 8 24 08 AM](https://github.com/Cambly/syntax/assets/127199/e14a702a-22f1-4ecb-a9a8-4660ce58f338) ![Screenshot 2024-05-10 at 8 27 37 AM](https://github.com/Cambly/syntax/assets/127199/b1c01a2f-18fe-44fe-a68c-7e1c11af4fba)

## Checkbox: before / after
![Screenshot 2024-05-10 at 8 30 27 AM](https://github.com/Cambly/syntax/assets/127199/df5d1626-4d61-4bce-94c6-a0590ed922e2) ![Screenshot 2024-05-10 at 8 30 52 AM](https://github.com/Cambly/syntax/assets/127199/2c061c4d-51d9-4547-95b4-3adbf8a624fc)

# Notes

Would be good to add e.g. a `CheckboxGroup` or `RadioButonGroup` in the future to make e.g. the spacing between items more consistent