### PR TITLE
RadioButton/Checkbox: Add describedby as a prop

### DIFF
--- a/.changeset/curly-shrimps-buy.md
+++ b/.changeset/curly-shrimps-buy.md
@@ -2,4 +2,4 @@
 "@cambly/syntax-core": minor
 ---
 
-Aria Props - add ariaprops object to checkbox
+RadioButton/Checkbox: Add aria-describedby as a prop on both of those components for accessibility.

--- a/.changeset/curly-shrimps-buy.md
+++ b/.changeset/curly-shrimps-buy.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Aria Props - add ariaprops object to checkbox

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -2,6 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import Checkbox from "./Checkbox";
 import React, { useState } from "react";
 import Box from "../Box/Box";
+import Typography from "../Typography/Typography";
 
 export default {
   title: "Components/Checkbox",
@@ -19,6 +20,7 @@ export default {
     error: false,
     size: "md",
     "data-testid": "",
+    "aria-describedby": "",
   },
   argTypes: {
     checked: {
@@ -42,8 +44,10 @@ export const Default: StoryObj<typeof Checkbox> = {};
 
 const CheckboxInteractive = ({
   label = "checkbox label",
+  "aria-describedby": ariaDescribedby,
 }: {
   label?: string;
+  "aria-describedby"?: string;
 }) => {
   const [isChecked, setIsChecked] = useState(false);
   const handleChange = () => {
@@ -51,7 +55,7 @@ const CheckboxInteractive = ({
   };
   return (
     <Checkbox
-      ariaValues={{ "aria-describedby": "checkboxes" }}
+      aria-describedby={ariaDescribedby}
       checked={isChecked}
       onChange={handleChange}
       label={label}
@@ -94,6 +98,29 @@ export const FixDoesNotBlowoutHeight: StoryObj<typeof Checkbox> = {
       <CheckboxInteractive />
       <CheckboxInteractive />
       <CheckboxInteractive label="Checkbox with a long label to test the responsive behavior of Checkbox" />
+    </Box>
+  ),
+};
+
+export const Accessibility: StoryObj<typeof Checkbox> = {
+  render: () => (
+    <Box
+      display="flex"
+      direction="column"
+      height="100px"
+      overflowY="auto"
+      padding={3}
+      gap={3}
+    >
+      <CheckboxInteractive aria-describedby="checkboxes" />
+      <CheckboxInteractive aria-describedby="checkboxes" />
+      <CheckboxInteractive aria-describedby="checkboxes" />
+      <CheckboxInteractive aria-describedby="checkboxes" />
+      <CheckboxInteractive aria-describedby="checkboxes" />
+
+      <Box id="checkboxes">
+        <Typography>This is text that describes the checkbox above!</Typography>
+      </Box>
     </Box>
   ),
 };

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -49,7 +49,14 @@ const CheckboxInteractive = ({
   const handleChange = () => {
     setIsChecked(!isChecked);
   };
-  return <Checkbox checked={isChecked} onChange={handleChange} label={label} />;
+  return (
+    <Checkbox
+      ariaValues={{ "aria-describedby": "checkboxes" }}
+      checked={isChecked}
+      onChange={handleChange}
+      label={label}
+    />
+  );
 };
 
 export const Interactive: StoryObj<typeof Checkbox> = {

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -6,6 +6,7 @@ import focusStyles from "../Focus.module.css";
 import Typography from "../Typography/Typography";
 import useIsHydrated from "../useIsHydrated";
 import colorStyles from "../colors/colors.module.css";
+import { type ariaProps } from "../ariaProps";
 
 const typographySize = {
   sm: 100,
@@ -28,6 +29,7 @@ const Checkbox = ({
   label,
   error = false,
   onChange,
+  ariaValues,
 }: {
   /**
    * Whether or not the box has been clicked
@@ -68,6 +70,12 @@ const Checkbox = ({
    * @defaultValue false
    */
   error?: boolean;
+  /**
+   * Whether or not there is an error with the input
+   *
+   * @defaultValue false
+   */
+  ariaValues?: ariaProps;
 }): ReactElement => {
   const isHydrated = useIsHydrated();
   const disabled = !isHydrated || disabledProp;
@@ -107,6 +115,7 @@ const Checkbox = ({
         )}
       </div>
       <input
+        aria-describedby={ariaValues?.["aria-describedby"]}
         data-testid={dataTestId}
         type="checkbox"
         className={classNames(

--- a/packages/syntax-core/src/Checkbox/Checkbox.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.tsx
@@ -6,7 +6,6 @@ import focusStyles from "../Focus.module.css";
 import Typography from "../Typography/Typography";
 import useIsHydrated from "../useIsHydrated";
 import colorStyles from "../colors/colors.module.css";
-import { type ariaProps } from "../ariaProps";
 
 const typographySize = {
   sm: 100,
@@ -29,7 +28,7 @@ const Checkbox = ({
   label,
   error = false,
   onChange,
-  ariaValues,
+  "aria-describedby": ariaDescribedby,
 }: {
   /**
    * Whether or not the box has been clicked
@@ -71,11 +70,11 @@ const Checkbox = ({
    */
   error?: boolean;
   /**
-   * Whether or not there is an error with the input
+   * The aria-describedby attribute for the checkbox. This aria- prop identifies the element that describes the element on which the attribute is set.
    *
-   * @defaultValue false
+   * @defaultValue undefined
    */
-  ariaValues?: ariaProps;
+  "aria-describedby"?: string;
 }): ReactElement => {
   const isHydrated = useIsHydrated();
   const disabled = !isHydrated || disabledProp;
@@ -115,8 +114,8 @@ const Checkbox = ({
         )}
       </div>
       <input
-        aria-describedby={ariaValues?.["aria-describedby"]}
         data-testid={dataTestId}
+        aria-describedby={ariaDescribedby}
         type="checkbox"
         className={classNames(
           styles.inputOverlay,

--- a/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
@@ -2,6 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import RadioButton from "./RadioButton";
 import React, { useState } from "react";
 import Box from "../Box/Box";
+import Typography from "../Typography/Typography";
 
 export default {
   title: "Components/RadioButton",
@@ -23,6 +24,7 @@ export default {
     value: "value",
     id: "",
     dangerouslyForceFocusStyles: false,
+    "aria-describedby": "",
   },
   argTypes: {
     checked: {
@@ -43,7 +45,11 @@ export default {
 
 export const Default: StoryObj<typeof RadioButton> = {};
 
-const RadioButtonInteractive = () => {
+const RadioButtonInteractive = ({
+  "aria-describedby": ariaDescribedby,
+}: {
+  "aria-describedby"?: string;
+}) => {
   const [selectedOption, setSelectedOption] = useState("");
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedOption(event.target.value);
@@ -52,6 +58,7 @@ const RadioButtonInteractive = () => {
     <form>
       <Box display="flex" direction="column" gap={3}>
         <RadioButton
+          aria-describedby={ariaDescribedby}
           checked={selectedOption === "mage"}
           value="mage"
           onChange={handleChange}
@@ -59,6 +66,7 @@ const RadioButtonInteractive = () => {
           label="Label with a lot of text to test the responsive behavior of the component"
         />
         <RadioButton
+          aria-describedby={ariaDescribedby}
           checked={selectedOption === "warrior"}
           value="warrior"
           onChange={handleChange}
@@ -66,6 +74,7 @@ const RadioButtonInteractive = () => {
           label="Warrior"
         />
         <RadioButton
+          aria-describedby={ariaDescribedby}
           checked={selectedOption === "archer"}
           value="archer"
           onChange={handleChange}
@@ -79,4 +88,17 @@ const RadioButtonInteractive = () => {
 
 export const Interactive: StoryObj<typeof RadioButton> = {
   render: () => <RadioButtonInteractive />,
+};
+
+export const Accessibility: StoryObj<typeof RadioButton> = {
+  render: () => (
+    <Box display="flex" direction="column" gap={4}>
+      <RadioButtonInteractive aria-describedby="radio-buttons" />
+      <Box id="radio-buttons">
+        <Typography>
+          This is a description of the radio buttons above.
+        </Typography>
+      </Box>
+    </Box>
+  ),
 };

--- a/packages/syntax-core/src/RadioButton/RadioButton.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.tsx
@@ -24,6 +24,7 @@ const RadioButton = ({
   onChange,
   size = "md",
   value,
+  "aria-describedby": ariaDescribedby,
 }: {
   /**
    * Whether or not the radio button is checked
@@ -78,6 +79,12 @@ const RadioButton = ({
   value: string | number;
   /** forces focus ring styling */
   dangerouslyForceFocusStyles?: boolean;
+  /**
+   * The aria-describedby attribute for the RadioButton. This aria- prop identifies the element that describes the element on which the attribute is set.
+   *
+   * @defaultValue undefined
+   */
+  "aria-describedby"?: string;
 }): ReactElement => {
   const isHydrated = useIsHydrated();
   const disabled = !isHydrated || disabledProp;
@@ -122,6 +129,7 @@ const RadioButton = ({
         />
       )}
       <input
+        aria-describedby={ariaDescribedby}
         data-testid={dataTestId}
         type="radio"
         id={id}

--- a/packages/syntax-core/src/ariaProps.tsx
+++ b/packages/syntax-core/src/ariaProps.tsx
@@ -1,3 +1,0 @@
-export type ariaProps = {
-  "aria-describedby"?: string;
-};

--- a/packages/syntax-core/src/ariaProps.tsx
+++ b/packages/syntax-core/src/ariaProps.tsx
@@ -1,0 +1,3 @@
+export type ariaProps = {
+  "aria-describedby"?: string;
+};


### PR DESCRIPTION
for https://axeauditor.dequecloud.com/test-run/de95ac14-f88c-11ee-a30d-2b2389e5f0d8/issue/07ac1b62-fc82-11ee-a631-135645ea1d04?sortField=ordinal&sortDir=asc&page=0&issuesCount=&searchKeyword=1724726&searchOn=id&row=0

the fix that deque recommends are:
![image](https://github.com/Cambly/syntax/assets/15243713/0884ebf0-bfda-4689-91f2-7a10ddd74994)

I already recommended to @jennyhe1120 that she already do the second recommendation (add the fieldname to the error message), but since deque _strongly_ recommends the first option, i created this POC.


I created an ariaProps object that can be reused between the different inputs (checkbox/radio/textinput/etc), i only put `aria-describedby` for now, because that's the only one we need. other suggested ones are: `aria-label`, `aria-labelledby`, `aria-hidden` but concluded we didnt need them yet.

the other option was the just manually map the prop `aria-describedby` onto the the component, but that felt unwieldy if we ever added more (like in some places we already use `aria-label`) 