### PR TITLE
TextArea: conditionally render label

### DIFF
--- a/.changeset/itchy-cups-sparkle.md
+++ b/.changeset/itchy-cups-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TextArea: conditionally render label

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -102,13 +102,15 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         }}
         position="relative"
       >
-        <label className={textFieldStyles.label} htmlFor={inputId}>
-          <Box paddingX={1}>
-            <Typography size={100} color="gray700">
-              {label}
-            </Typography>
-          </Box>
-        </label>
+        {label && (
+          <label className={textFieldStyles.label} htmlFor={inputId}>
+            <Box paddingX={1}>
+              <Typography size={100} color="gray700">
+                {label}
+              </Typography>
+            </Box>
+          </label>
+        )}
         <Typography size={100}>
           <textarea
             data-testid={dataTestId}


### PR DESCRIPTION
Noticed extra spacing above a `TextArea` when setting a custom label

![image](https://github.com/Cambly/syntax/assets/127199/5425af63-9823-473b-98d3-4c44d907f05d)
