### PR TITLE
[NOJIRA] Add vertical padding to badge

### DIFF
--- a/.changeset/breezy-singers-drop.md
+++ b/.changeset/breezy-singers-drop.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Added vertical padding to Badge

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -65,6 +65,7 @@ const Badge = ({
     <Box
       display="inlineFlex"
       paddingX={2}
+      paddingY={1}
       rounding={"sm"}
       backgroundColor={color}
       alignItems="center"


### PR DESCRIPTION
Add vertical padding to badge, so it looks better when mutiline

Before:
<img width="131" alt="Screenshot 2024-05-20 at 10 42 08 AM" src="https://github.com/Cambly/syntax/assets/114436044/6c7a3ded-1194-48b2-a24b-c07d775dd32d">
<img width="112" alt="Screenshot 2024-05-20 at 10 42 37 AM" src="https://github.com/Cambly/syntax/assets/114436044/8ae9daf1-99d4-42f1-9663-add048309168">

After:
<img width="131" alt="Screenshot 2024-05-20 at 10 42 08 AM" src="https://github.com/Cambly/syntax/assets/114436044/a8fe36eb-841a-432d-984e-0ed2887da1b8">
<img width="119" alt="Screenshot 2024-05-20 at 10 41 49 AM" src="https://github.com/Cambly/syntax/assets/114436044/8949486e-ee74-4f1d-8ea2-e8587bc4b212">