### PR TITLE
TextField: Add step param

### DIFF
--- a/.changeset/funny-peas-learn.md
+++ b/.changeset/funny-peas-learn.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TextField: Add optional step param for input

--- a/packages/syntax-core/src/TextField/TextField.stories.tsx
+++ b/packages/syntax-core/src/TextField/TextField.stories.tsx
@@ -21,7 +21,7 @@ export default {
     "data-testid": "",
     id: "",
     value: "",
-    step: 0,
+    step: 1,
   },
   argTypes: {
     autoComplete: {

--- a/packages/syntax-core/src/TextField/TextField.stories.tsx
+++ b/packages/syntax-core/src/TextField/TextField.stories.tsx
@@ -21,6 +21,7 @@ export default {
     "data-testid": "",
     id: "",
     value: "",
+    step: 0,
   },
   argTypes: {
     autoComplete: {
@@ -89,13 +90,21 @@ export const Default: StoryObj<typeof TextField> = {
 };
 
 export const helperText: StoryObj<typeof TextField> = {
-  render: (args) => <TextFieldDefault helperText="Helper text" {...args} />,
+  args: { helperText: "Helper text" },
+  render: (args) => <TextFieldDefault {...args} />,
 };
 
 export const ErrorText: StoryObj<typeof TextField> = {
-  render: (args) => <TextFieldDefault errorText="This is an error" {...args} />,
+  args: { errorText: "This is an error" },
+  render: (args) => <TextFieldDefault {...args} />,
 };
 
 export const TypeNumber: StoryObj<typeof TextField> = {
-  render: (args) => <TextFieldDefault type="number" {...args} />,
+  args: { type: "number" },
+  render: (args) => <TextFieldDefault {...args} />,
+};
+
+export const TimeWithStep: StoryObj<typeof TextField> = {
+  args: { step: 900, type: "time" },
+  render: (args) => <TextFieldDefault {...args} />,
 };

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -90,7 +90,6 @@ export default function TextField({
   const disabled = !isHydrated || disabledProp;
   const reactId = useId();
   const inputId = id ?? reactId;
-  console.log(type, step);
 
   return (
     <Box

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -82,7 +82,7 @@ export default function TextField({
    */
   value: string;
   /**
-   * Specified legal number intervals for an input field. Specifically for time or number. If for time specify for milliseconds.
+   * Specified legal number intervals for an input field. Specifically for time or number. If for time specify for milliseconds. Must be a positive value.
    */
   step?: number;
 }): ReactElement {

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -25,6 +25,7 @@ export default function TextField({
   placeholder = "",
   type = "text",
   value = "",
+  step,
 }: {
   /**
    * The autocomplete attribute specifies whether or not an input field should have autocomplete enabled.
@@ -80,11 +81,16 @@ export default function TextField({
    * Value of the TextField
    */
   value: string;
+  /**
+   * Specified legal number intervals for an input field. Specifically for time or number. If for time specify for milliseconds.
+   */
+  step?: number;
 }): ReactElement {
   const isHydrated = useIsHydrated();
   const disabled = !isHydrated || disabledProp;
   const reactId = useId();
   const inputId = id ?? reactId;
+  console.log(type, step);
 
   return (
     <Box
@@ -120,6 +126,7 @@ export default function TextField({
         onChange={onChange}
         placeholder={placeholder}
         value={value}
+        step={step}
       />
       {(helperText || errorText) && (
         <Box paddingX={1}>


### PR DESCRIPTION
Need step for this: https://www.figma.com/design/FDcPtWKnUQWY8VjVFhpjxe/Availability-filter?node-id=10699-17858&m=dev. So I added it.

Official documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step

I also fixed the other stories so they actually work:
Before:
<img width="1190" alt="Screenshot 2024-05-22 at 5 33 06 PM" src="https://github.com/Cambly/syntax/assets/60896115/d2442b9b-661d-4eb7-99de-04337a7b91cb">

After:
<img width="640" alt="Screenshot 2024-05-22 at 5 32 38 PM" src="https://github.com/Cambly/syntax/assets/60896115/ffa87476-e1ba-4c34-a7b4-67ee33f6e78e">
