### PR TITLE
[SYN-62] Add 2 colors + fix typography 

### DIFF
--- a/packages/syntax-core/src/Divider/Divider.tsx
+++ b/packages/syntax-core/src/Divider/Divider.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from "react";
 import styles from "./Divider.module.css";
 import classNames from "classnames";
 import colorStyles from "../colors/colors.module.css";
@@ -5,15 +6,27 @@ import colorStyles from "../colors/colors.module.css";
 /**
  * [Divider](https://cambly-syntax.vercel.app/?path=/docs/components-divider--docs) is a thin horizontal line to group content in lists and layouts.
  */
-export default function Divider(): React.ReactElement {
+function Divider({
+  on = "lightBackground",
+}: {
+  /**
+   * Indicate whether the divider renders on a light or dark background. Changes the color of the divider.
+   *
+   * @defaulValue `lightBackground`
+   */
+  on?: "lightBackground" | "darkBackground";
+}): ReactElement {
   return (
     <hr
       className={classNames(
         styles.divider,
-        colorStyles.cambioGray370BackgroundColor,
+        {
+          [colorStyles.cambioGray370BackgroundColor]: on === "lightBackground",
+          [colorStyles.cambioWhite40BackgroundColor]: on === "darkBackground",
+        }
       )}
     />
   );
 }
 
-Divider.displayName = "Divider";
+export default Divider;

--- a/packages/syntax-core/src/colors/allColors.ts
+++ b/packages/syntax-core/src/colors/allColors.ts
@@ -41,6 +41,8 @@ const colors = [
   "success800",
   "success900",
   "white",
+  "white40",
+  "white70",
   "yellow100",
   "yellow200",
   "yellow300",

--- a/packages/syntax-core/src/colors/colors.module.css
+++ b/packages/syntax-core/src/colors/colors.module.css
@@ -260,7 +260,15 @@
 }
 
 .cambioWhiteColor {
-  color: var(--color-cambio-white);
+  color: var(--color-cambio-white-100);
+}
+
+.cambioWhite40Color {
+  color: var(--color-cambio-white-40);
+}
+
+.cambioWhite70Color {
+  color: var(--color-cambio-white-70);
 }
 
 .cambioGray100Color {
@@ -404,7 +412,15 @@
 }
 
 .cambioWhiteBackgroundColor {
-  background-color: var(--color-cambio-white);
+  background-color: var(--color-cambio-white-100);
+}
+
+.cambioWhite40BackgroundColor {
+  background-color: var(--color-cambio-white-40);
+}
+
+.cambioWhite70BackgroundColor {
+  background-color: var(--color-cambio-white-70);
 }
 
 .cambioGray100BackgroundColor {

--- a/packages/syntax-core/src/colors/textColors.ts
+++ b/packages/syntax-core/src/colors/textColors.ts
@@ -10,6 +10,7 @@ export default function textColor(
     | "success"
     | "success-darkBackground"
     | "white"
+    | "white-secondary"
     | "inherit",
 ): string {
   switch (color) {
@@ -17,6 +18,8 @@ export default function textColor(
       return colorStyles.cambioGray800Color;
     case "white":
       return colorStyles.cambioWhiteColor;
+    case "white-secondary":
+      return colorStyles.cambioWhite70Color;
     case "inherit":
       return colorStyles.inheritColor;
     case "destructive-primary":

--- a/packages/syntax-core/src/colors/textColors.ts
+++ b/packages/syntax-core/src/colors/textColors.ts
@@ -3,7 +3,7 @@ import colorStyles from "../colors/colors.module.css";
 export default function textColor(
   color:
     | "gray900"
-    | "gray700"
+    | "gray800"
     | "primary"
     | "destructive-primary"
     | "destructive-darkBackground"
@@ -14,7 +14,7 @@ export default function textColor(
     | "inherit",
 ): string {
   switch (color) {
-    case "gray700":
+    case "gray800":
       return colorStyles.cambioGray800Color;
     case "white":
       return colorStyles.cambioWhiteColor;

--- a/packages/syntax-design-tokens/tokens/color/base.json
+++ b/packages/syntax-design-tokens/tokens/color/base.json
@@ -86,11 +86,15 @@
         "800": { "value": "#765F1C" },
         "900": { "value": "#3B3009" }
       },
-      "white": { "value": "#ffffff" }
+      "white": { "value": "#ffffff" },
     },
     "cambio": {
       "black": { "value": "#050500" },
-      "white": { "value": "#ffffff" },
+      "white": {
+        "40" : { "value": "rgba(255, 255, 255, 0.4)" },
+        "70": { "value": "rgba(255, 255, 255, 0.7)" },
+        "100" : { "value": "#ffffff" }
+      },
       "gray": {
         "100": { "value": "#faf4eb" },
         "200": { "value": "#e4dbd3" },


### PR DESCRIPTION
1. Add white40 #FFFFFF @ 40% opacity
3. Add white70: #FFFFFF @ 70% opacity
5. Add text color white-secondary which uses white70
7. Add option to divider that allows for on=darkBackground to use white40
9. add gray800 to typography