### PR TITLE
RichSelectList: add menu role

### DIFF
--- a/.changeset/rare-rocks-play.md
+++ b/.changeset/rare-rocks-play.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add menu role to RichSelectList popover

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -195,6 +195,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
               dangerouslySetInlineStyle={
                 autosave ? undefined : { __style: { paddingBottom: 0 } }
               }
+              role="menu"
             >
               <RichSelectBox
                 autosave={autosave}


### PR DESCRIPTION
It's an [accessibility issue](https://axeauditor.dequecloud.com/test-run/de95ac14-f88c-11ee-a30d-2b2389e5f0d8/issue/612cdcd0-faf2-11ee-9650-4bcbd7c29630?sortField=ordinal&sortDir=asc&page=0&issuesCount=&searchKeyword=1722391&searchOn=id&row=0) that we don't flag the popover as a "menu" role. 

I believe adding `role="menu"` to the box within the Popover should solve this issue

<img width="655" alt="image" src="https://github.com/Cambly/syntax/assets/36240753/a76ce040-e746-4bf7-bc81-dce841c3a9de">
