### PR TITLE
Icon: Update icon sizing

### DIFF
--- a/.changeset/brave-adults-carry.md
+++ b/.changeset/brave-adults-carry.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+Icon: change size values

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -78,7 +78,7 @@ const Badge = ({
         color={textColorForBackgroundColor(color)}
       >
         <Box display="flex" gap={1} alignItems="center" justifyContent="start">
-          {Icon && <Icon className={styles.icon} size="xs" />}
+          {Icon && <Icon className={styles.icon} size={100} />}
           <Typography
             color={textColorForBackgroundColor(color)}
             size={100}

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -127,10 +127,10 @@ export const WithEndIcon: StoryObj<typeof Button> = {
 };
 
 export const WithSyntaxIcons: StoryObj<typeof Button> = {
-  render: () => (
+  render: (args) => (
     <Box display="flex" gap={2}>
-      <Button text="Play" startIcon={Play} />
-      <Button text="Play" endIcon={Play} />
+      <Button {...args} text="Play" startIcon={Play} />
+      <Button {...args} text="Play" endIcon={Play} />
     </Box>
   ),
 };

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { type Size } from "../constants";
 import Typography from "../Typography/Typography";
 import Box from "../Box/Box";
-import iconSize from "./constants/iconSize";
+import { materialIconSize, internalIconSize } from "./constants/iconSize";
 import textVariant from "./constants/textVariant";
 import loadingIconSize from "./constants/loadingIconSize";
 import styles from "./Button.module.css";
@@ -163,10 +163,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <StartIcon
             className={classNames(
               styles.icon,
-              iconSize[size],
+              materialIconSize[size],
               disabledPrimary && styles.disabledPrimary,
             )}
-            size={iconSize[size]}
+            size={internalIconSize[size]}
           />
         )}
         {((loading && loadingText) || (!loading && text)) && (
@@ -187,10 +187,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <EndIcon
             className={classNames(
               styles.icon,
-              iconSize[size],
+              materialIconSize[size],
               disabledPrimary && styles.disabledPrimary,
             )}
-            size={iconSize[size]}
+            size={internalIconSize[size]}
           />
         )}
         {loading && (

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -163,10 +163,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <StartIcon
             className={classNames(
               styles.icon,
-              iconSize[size],
               disabledPrimary && styles.disabledPrimary,
             )}
-            size={size}
+            size={iconSize[size]}
           />
         )}
         {((loading && loadingText) || (!loading && text)) && (
@@ -187,10 +186,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <EndIcon
             className={classNames(
               styles.icon,
-              iconSize[size],
               disabledPrimary && styles.disabledPrimary,
             )}
-            size={size}
+            size={iconSize[size]}
           />
         )}
         {loading && (

--- a/packages/syntax-core/src/Button/Button.tsx
+++ b/packages/syntax-core/src/Button/Button.tsx
@@ -163,6 +163,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <StartIcon
             className={classNames(
               styles.icon,
+              iconSize[size],
               disabledPrimary && styles.disabledPrimary,
             )}
             size={iconSize[size]}
@@ -186,6 +187,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <EndIcon
             className={classNames(
               styles.icon,
+              iconSize[size],
               disabledPrimary && styles.disabledPrimary,
             )}
             size={iconSize[size]}

--- a/packages/syntax-core/src/Button/constants/iconSize.ts
+++ b/packages/syntax-core/src/Button/constants/iconSize.ts
@@ -1,7 +1,13 @@
-const iconSize = {
-  sm: 100,
-  md: 200,
-  lg: 300,
-} as const;
+import styles from "../Button.module.css";
 
-export default iconSize;
+export const materialIconSize = {
+  sm: styles.smIcon,
+  md: styles.mdIcon,
+  lg: styles.lgIcon,
+};
+
+export const internalIconSize = {
+  sm: 200,
+  md: 300,
+  lg: 400,
+} as const;

--- a/packages/syntax-core/src/Button/constants/iconSize.ts
+++ b/packages/syntax-core/src/Button/constants/iconSize.ts
@@ -1,9 +1,7 @@
-import styles from "../Button.module.css";
-
 const iconSize = {
-  sm: styles.smIcon,
-  md: styles.mdIcon,
-  lg: styles.lgIcon,
-};
+  sm: 100,
+  md: 200,
+  lg: 300,
+} as const;
 
 export default iconSize;

--- a/packages/syntax-core/src/Chip/Chip.tsx
+++ b/packages/syntax-core/src/Chip/Chip.tsx
@@ -123,7 +123,7 @@ const Chip = forwardRef<HTMLButtonElement, ChipProps>(
         aria-pressed={selected}
         onClick={onChange}
       >
-        {Icon && <Icon className={iconStyles} size="sm" />}
+        {Icon && <Icon className={iconStyles} size={100} />}
         <Box paddingX={Icon ? 1 : 0}>
           <Typography size={100} color={color} weight="medium">
             {text}

--- a/packages/syntax-core/src/Icon/Icon.module.css
+++ b/packages/syntax-core/src/Icon/Icon.module.css
@@ -5,22 +5,52 @@
   user-select: none;
 }
 
-.iconxs {
+.icon100 {
   width: 16px;
   height: 16px;
 }
 
-.iconsm {
+.icon200 {
   width: 20px;
   height: 20px;
 }
 
-.iconmd {
+.icon300 {
   width: 24px;
   height: 24px;
 }
 
-.iconlg {
+.icon400 {
   width: 32px;
   height: 32px;
+}
+
+.icon500 {
+  width: 48px;
+  height: 48px;
+}
+
+.icon600 {
+  width: 72px;
+  height: 72px;
+}
+
+.icon700 {
+  width: 100px;
+  height: 100px;
+}
+
+.icon800 {
+  width: 140px;
+  height: 140px;
+}
+
+.icon900 {
+  width: 200px;
+  height: 200px;
+}
+
+.icon1000 {
+  width: 280px;
+  height: 280px;
 }

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -1,0 +1,24 @@
+import { type StoryObj, type Meta } from "@storybook/react";
+import Icon from "./Icon";
+
+export default {
+  title: "Components/Icon",
+  component: Icon,
+  args: {
+    size: 200,
+  },
+  argTypes: {
+    size: {
+      options: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+      control: { type: "radio" },
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof Icon>;
+
+export const Default: StoryObj<typeof Icon> = {
+  args: {
+    size: 200,
+    path: "m22 11-.5-3.5h-6l-2-5.5h-3l-2 5.5h-6L2 11l4.5 3L4 20.5 7 22l5-4 5 4 3-1.5-2.5-6.5z",
+  },
+};

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -14,14 +14,20 @@ type IconProps = {
   color?: ComponentProps<typeof Typography>["color"];
   /**
    * The size of the Icon.
-   * * `xs`: 16px x 16px
-   * * `sm`: 20px x 20px
-   * * `md`: 24px x 24px
-   * * `lg`: 32px x 32px
+   * * 100: 16px x 16px
+   * * 200: 20px x 20px
+   * * 300: 24px x 24px
+   * * 400: 32px x 32px
+   * * 500: 48px x 48px
+   * * 600: 72px x 72px
+   * * 700: 100px x 100px
+   * * 800: 140px x 140px
+   * * 900: 200px x 200px
+   * * 1000: 280px x 280px
    *
-   * @defaultValue "md"
+   * @defaultValue 200
    */
-  size?: "xs" | "sm" | "md" | "lg";
+  size?: 0 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
   /**
    * The svg path of the icon. You should not use this prop directly, instead use the specific icon components.
    */
@@ -37,7 +43,7 @@ type IconProps = {
  * You can click on the icon to copy the import statement!
  */
 const Icon = forwardRef<SVGSVGElement, IconProps>(
-  ({ color = "inherit", path, size = "md" }: IconProps, ref) => (
+  ({ color = "inherit", path, size = 200 }: IconProps, ref) => (
     <svg
       className={classnames(
         styles.icon,

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -8,7 +8,7 @@ import { backgroundColor } from "../colors/backgroundColor";
 import { border } from "../colors/border";
 import type InternalIcon from "../Icon/Icon";
 
-const iconSize = {
+const materialIconSize = {
   sm: styles.smIcon,
   md: styles.mdIcon,
   lg: styles.lgIcon,
@@ -125,7 +125,10 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         )}
         ref={ref}
       >
-        <Icon className={iconSize[size]} size={internalIconSize[size]} />
+        <Icon
+          className={materialIconSize[size]}
+          size={internalIconSize[size]}
+        />
       </button>
     );
   },

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -6,13 +6,19 @@ import styles from "./IconButton.module.css";
 import useIsHydrated from "../useIsHydrated";
 import { backgroundColor } from "../colors/backgroundColor";
 import { border } from "../colors/border";
-import InternalIcon from "../Icon/Icon";
+import type InternalIcon from "../Icon/Icon";
 
 const iconSize = {
   sm: styles.smIcon,
   md: styles.mdIcon,
   lg: styles.lgIcon,
 };
+
+const internalIconSize = {
+  sm: 200,
+  md: 300,
+  lg: 400,
+} as const;
 
 type IconButtonProps = {
   /**
@@ -102,8 +108,6 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     const foregroundColorClass = foregroundColor(color, on);
     const backgroundColorClass = backgroundColor(color, on);
 
-    console.log(Icon === InternalIcon);
-
     return (
       <button
         aria-label={accessibilityLabel}
@@ -121,7 +125,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         )}
         ref={ref}
       >
-        <Icon className={iconSize[size]} size={size} />
+        <Icon className={iconSize[size]} size={internalIconSize[size]} />
       </button>
     );
   },

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -7,18 +7,10 @@ import useIsHydrated from "../useIsHydrated";
 import { backgroundColor } from "../colors/backgroundColor";
 import { border } from "../colors/border";
 import type InternalIcon from "../Icon/Icon";
-
-const materialIconSize = {
-  sm: styles.smIcon,
-  md: styles.mdIcon,
-  lg: styles.lgIcon,
-};
-
-const internalIconSize = {
-  sm: 200,
-  md: 300,
-  lg: 400,
-} as const;
+import {
+  materialIconSize,
+  internalIconSize,
+} from "../Button/constants/iconSize";
 
 type IconButtonProps = {
   /**

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -6,7 +6,7 @@ import styles from "./IconButton.module.css";
 import useIsHydrated from "../useIsHydrated";
 import { backgroundColor } from "../colors/backgroundColor";
 import { border } from "../colors/border";
-import type InternalIcon from "../Icon/Icon";
+import InternalIcon from "../Icon/Icon";
 
 const iconSize = {
   sm: styles.smIcon,
@@ -101,6 +101,8 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     const isHydrated = useIsHydrated();
     const foregroundColorClass = foregroundColor(color, on);
     const backgroundColorClass = backgroundColor(color, on);
+
+    console.log(Icon === InternalIcon);
 
     return (
       <button

--- a/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
@@ -141,10 +141,10 @@ export const WithEndIcon: StoryObj<typeof LinkButton> = {
 };
 
 export const WithSyntaxIcons: StoryObj<typeof LinkButton> = {
-  render: () => (
+  render: (args) => (
     <Box display="flex" gap={2}>
-      <LinkButton text="Pause" startIcon={Pause} />
-      <LinkButton text="Pause" endIcon={Pause} />
+      <LinkButton {...args} text="Pause" startIcon={Pause} />
+      <LinkButton {...args} text="Pause" endIcon={Pause} />
     </Box>
   ),
 };

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -152,12 +152,8 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       >
         {!loading && StartIcon && (
           <StartIcon
-            className={classNames(
-              buttonStyles.icon,
-              iconSize[size],
-              foregroundColorClass,
-            )}
-            size={size}
+            className={classNames(buttonStyles.icon, foregroundColorClass)}
+            size={iconSize[size]}
           />
         )}
         {!loading && text && (
@@ -172,12 +168,8 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
         )}
         {!loading && EndIcon && (
           <EndIcon
-            className={classNames(
-              buttonStyles.icon,
-              iconSize[size],
-              foregroundColorClass,
-            )}
-            size={size}
+            className={classNames(buttonStyles.icon, foregroundColorClass)}
+            size={iconSize[size]}
           />
         )}
         {loading && (

--- a/packages/syntax-core/src/LinkButton/LinkButton.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.tsx
@@ -8,7 +8,10 @@ import React from "react";
 import { type Size } from "../constants";
 import Typography from "../Typography/Typography";
 import buttonStyles from "../Button/Button.module.css";
-import iconSize from "../Button/constants/iconSize";
+import {
+  materialIconSize,
+  internalIconSize,
+} from "../Button/constants/iconSize";
 import textVariant from "../Button/constants/textVariant";
 import loadingIconSize from "../Button/constants/loadingIconSize";
 import styles from "./LinkButton.module.css";
@@ -152,8 +155,12 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       >
         {!loading && StartIcon && (
           <StartIcon
-            className={classNames(buttonStyles.icon, foregroundColorClass)}
-            size={iconSize[size]}
+            className={classNames(
+              buttonStyles.icon,
+              materialIconSize[size],
+              foregroundColorClass,
+            )}
+            size={internalIconSize[size]}
           />
         )}
         {!loading && text && (
@@ -168,8 +175,12 @@ const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
         )}
         {!loading && EndIcon && (
           <EndIcon
-            className={classNames(buttonStyles.icon, foregroundColorClass)}
-            size={iconSize[size]}
+            className={classNames(
+              buttonStyles.icon,
+              materialIconSize[size],
+              foregroundColorClass,
+            )}
+            size={internalIconSize[size]}
           />
         )}
         {loading && (


### PR DESCRIPTION
Per a request from Joey and AJ, we're updating `Icon` sizing to be more like `Typography`. Will run a codemod in Cambly-FE after this is merged to update the sizing of our syntax icons