### PR TITLE
Icon: Update sizing to match Typography scale

### DIFF
--- a/.changeset/four-grapes-protect.md
+++ b/.changeset/four-grapes-protect.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Icon: update sizes to match Typography scale

--- a/packages/syntax-core/src/Button/constants/iconSize.ts
+++ b/packages/syntax-core/src/Button/constants/iconSize.ts
@@ -7,7 +7,7 @@ export const materialIconSize = {
 };
 
 export const internalIconSize = {
-  sm: 200,
-  md: 300,
-  lg: 400,
+  sm: 100,
+  md: 200,
+  lg: 300,
 } as const;

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -9,7 +9,7 @@ export default {
   },
   argTypes: {
     size: {
-      options: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+      options: [0, 100, 200, 300, 400, 500, 600, 700, 800, 900],
       control: { type: "radio" },
     },
   },

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -14,16 +14,16 @@ type IconProps = {
   color?: ComponentProps<typeof Typography>["color"];
   /**
    * The size of the Icon.
-   * * 100: 16px x 16px
-   * * 200: 20px x 20px
-   * * 300: 24px x 24px
-   * * 400: 32px x 32px
-   * * 500: 48px x 48px
-   * * 600: 72px x 72px
-   * * 700: 100px x 100px
-   * * 800: 140px x 140px
-   * * 900: 200px x 200px
-   * * 1000: 280px x 280px
+   * * 0: 16px x 16px
+   * * 100: 20px x 20px
+   * * 200: 24px x 24px
+   * * 300: 28px x 28px
+   * * 400: 48px x 48px
+   * * 500: 72px x 72px
+   * * 600: 100px x 100px
+   * * 700: 140px x 140px
+   * * 800: 200px x 200px
+   * * 9000: 280px x 280px
    *
    * @defaultValue 200
    */


### PR DESCRIPTION
Small follow-up to the previous update. Noticed that the Icon scale as speced didnt exactly match the one with Typography (no size 0, default 300 instead of 200). Confirmed with design that we should update it to this.