### PR TITLE
Fix pnpm deploy issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 # Install node
 nvm install
 # Install dependencies
-npm install -g pnpm@9.0.4
+npm install -g pnpm@9.2.0
 pnpm install
 # Run the dev server
 pnpm start

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "vite": "4.3.4",
     "vitest": "0.32.4"
   },
-  "packageManager": "pnpm@9.0.4",
+  "packageManager": "pnpm@9.2.0",
   "engines": {
     "npm": "please-use-pnpm",
-    "pnpm": "9.0.4"
+    "pnpm": "9.2.0"
   }
 }


### PR DESCRIPTION
Noticed vercel builds were failing due to the following issue:

![image](https://github.com/Cambly/syntax/assets/127199/0de6c239-1ebc-45be-8845-eae95595dcd9)

Fix by:

1. Upgrading to `pnpm@9.2.0`
2. Using corepack on vercel. More info at https://vercel.com/changelog/corepack-experimental-is-now-available