### PR TITLE
Tabs.Link: fix selected state on=darkBackground

### DIFF
--- a/.changeset/cold-wolves-play.md
+++ b/.changeset/cold-wolves-play.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Tabs.Link: fix selected state on=darkBackground

--- a/packages/syntax-core/src/Tabs/TabLink.tsx
+++ b/packages/syntax-core/src/Tabs/TabLink.tsx
@@ -57,7 +57,7 @@ const TabLink = forwardRef<HTMLAnchorElement, TabLinkProps>(
           [styles.unselectedTab]: !selected,
           [styles.selectedTabOnLightBackground]:
             selected && on === "lightBackground",
-          [styles.selectedTabDarkBackground]:
+          [styles.selectedTabOnDarkBackground]:
             selected && on === "darkBackground",
         })}
         style={{

--- a/packages/syntax-core/src/Tabs/Tabs.stories.tsx
+++ b/packages/syntax-core/src/Tabs/Tabs.stories.tsx
@@ -3,6 +3,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import Tabs from "./Tabs";
 import Badge from "../Badge/Badge";
 import Box from "../Box/Box";
+import SelectList from "../SelectList/SelectList";
 
 export default {
   title: "Components/Tabs",
@@ -29,7 +30,7 @@ export default {
 const TabsButtonInteractive = ({
   on,
 }: {
-  on: "lightBackground" | "darkBackground";
+  on?: "lightBackground" | "darkBackground";
 }) => {
   const [selected, setSelected] = useState<
     "Achievements" | "History" | "Quizzes" | "Levels" | "Tabatha" | "Tabathy"
@@ -81,45 +82,77 @@ const TabsButtonInteractive = ({
   );
 };
 
-const TabsLinkInteractive = ({
-  on,
-}: {
-  on: "lightBackground" | "darkBackground";
-}) => {
+const TabsLinkInteractive = () => {
   const [selected, setSelected] = useState<"Tabrell" | "Tabara" | "Tabson">(
     "Tabrell",
   );
+  const [on, setOn] = useState<"lightBackground" | "darkBackground">(
+    "lightBackground",
+  );
 
   return (
-    <Tabs accessibilityLabel="My custom tabs" on={on}>
-      <Tabs.Link
-        href="https://cambly-syntax.vercel.app/?path=/docs/components-tabs--docs"
-        text="Tabrell"
-        onClick={() => setSelected("Tabrell")}
-        selected={selected === "Tabrell"}
-        on={on}
-      />
-      <Tabs.Link
-        href="https://cambly-syntax.vercel.app/?path=/docs/components-tabs--docs"
-        text="Tabara"
-        onClick={() => setSelected("Tabara")}
-        selected={selected === "Tabara"}
-        on={on}
-      />
-      <Tabs.Link
-        href="https://cambly-syntax.vercel.app/?path=/docs/components-tabs--docs"
-        text="Tabson"
-        onClick={() => setSelected("Tabson")}
-        selected={selected === "Tabson"}
-        on={on}
-      />
-    </Tabs>
+    <Box display="flex" direction="column" gap={2}>
+      <SelectList
+        id="on"
+        label="Background"
+        selectedValue={on}
+        onChange={(event) =>
+          setOn(
+            event.target.value === "lightBackground"
+              ? "lightBackground"
+              : "darkBackground",
+          )
+        }
+      >
+        <SelectList.Option
+          value="lightBackground"
+          label="Light"
+        ></SelectList.Option>
+        <SelectList.Option
+          value="darkBackground"
+          label="Dark"
+        ></SelectList.Option>
+      </SelectList>
+      <Box
+        padding={2}
+        dangerouslySetInlineStyle={{
+          __style: {
+            backgroundImage:
+              on === "darkBackground"
+                ? "linear-gradient(0deg, #000, #555 )"
+                : null,
+          },
+        }}
+      >
+        <Tabs accessibilityLabel="My custom tabs" on={on}>
+          <Tabs.Link
+            href="https://cambly-syntax.vercel.app/?path=/docs/components-tabs--docs"
+            text="Tabrell"
+            onClick={() => setSelected("Tabrell")}
+            selected={selected === "Tabrell"}
+            on={on}
+          />
+          <Tabs.Link
+            href="https://cambly-syntax.vercel.app/?path=/docs/components-tabs--docs"
+            text="Tabara"
+            onClick={() => setSelected("Tabara")}
+            selected={selected === "Tabara"}
+            on={on}
+          />
+          <Tabs.Link
+            href="https://cambly-syntax.vercel.app/?path=/docs/components-tabs--docs"
+            text="Tabson"
+            onClick={() => setSelected("Tabson")}
+            selected={selected === "Tabson"}
+            on={on}
+          />
+        </Tabs>
+      </Box>
+    </Box>
   );
 };
 
-export const Default: StoryObj<
-  ComponentProps<typeof Tabs> & { on: "lightBackground" | "darkBackground" }
-> = {
+export const Default: StoryObj<ComponentProps<typeof Tabs>> = {
   args: { accessibilityLabel: "My custom tabs" },
   render: (args) => {
     return (
@@ -141,25 +174,6 @@ export const Default: StoryObj<
   },
 };
 
-export const Link: StoryObj<
-  ComponentProps<typeof Tabs> & { on: "lightBackground" | "darkBackground" }
-> = {
-  args: { accessibilityLabel: "My custom tabs" },
-  render: (args) => {
-    return (
-      <Box
-        padding={2}
-        dangerouslySetInlineStyle={{
-          __style: {
-            backgroundImage:
-              args.on === "darkBackground"
-                ? "linear-gradient(0deg, #000, #555 )"
-                : null,
-          },
-        }}
-      >
-        <TabsLinkInteractive {...args} />
-      </Box>
-    );
-  },
+export const Link: StoryObj<ComponentProps<typeof Tabs>> = {
+  render: () => <TabsLinkInteractive />,
 };


### PR DESCRIPTION
# Background

Noticed the following issue in VSCode:

> Property 'selectedTabDarkBackground' does not exist on type '{ tabContainerlightBackground: string; tabContainerDarkBackground: string; selectedTabOnLightBackground: string; selectedTabOnDarkBackground: string; unselectedTab: string; link: string; }'. Did you mean 'selectedTabOnDarkBackground'?

![Screenshot 2024-06-09 at 8 11 14 AM](https://github.com/Cambly/syntax/assets/127199/e2864ec4-a9ea-4821-9ab5-2dbe71833bab)

Note that this TS issue doesn't fail the build because of this outstanding TS ticket to support plugins during compilation:
* https://www.npmjs.com/package/typescript-plugin-css-modules#about-this-plugin
* https://github.com/microsoft/TypeScript/issues/16607

# Before (incorrect selected state)
![Screenshot 2024-06-09 at 8 16 50 AM](https://github.com/Cambly/syntax/assets/127199/5c6d315b-abdb-436c-879c-1a89bf330d96)

# After
![Screenshot 2024-06-09 at 8 17 05 AM](https://github.com/Cambly/syntax/assets/127199/75e600c8-d1fe-4e9b-acab-9415f5e79b63)

# Notes

Also added a light / dark toggle to the `Tabs.Link` example so we can easily test: 
![Screenshot 2024-06-09 at 8 26 29 AM](https://github.com/Cambly/syntax/assets/127199/4275363e-493d-4b06-a9c9-f39e933f9888)

