### PR TITLE
IconButton: add flex none to prevent icon button from shrinking

### DIFF
--- a/.changeset/yellow-lamps-leave.md
+++ b/.changeset/yellow-lamps-leave.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+IconButton: add flex none to prevent button from ever shrinking

--- a/packages/syntax-core/src/IconButton/IconButton.module.css
+++ b/packages/syntax-core/src/IconButton/IconButton.module.css
@@ -3,6 +3,7 @@
   justify-content: center;
   display: flex;
   border-radius: 50%;
+  flex: none;
 }
 
 .iconButton:hover {


### PR DESCRIPTION
these icon buttons should never shrink

![image](https://github.com/Cambly/syntax/assets/15243713/e1a36256-f2d7-487a-a26b-fea8f83d0a4b)
