### PR TITLE
TextArea/TextField: Fix error styling

### DIFF
--- a/.changeset/sharp-stingrays-sip.md
+++ b/.changeset/sharp-stingrays-sip.md
@@ -1,5 +1,5 @@
 ---
-"@cambly/syntax-core": major
+"@cambly/syntax-core": minor
 ---
 
 make red shade for error text and error border (textfield and textarea) the same

--- a/.changeset/sharp-stingrays-sip.md
+++ b/.changeset/sharp-stingrays-sip.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+make red shade for error text and error border (textfield and textarea) the same

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -136,7 +136,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <Box paddingX={1}>
             <Typography
               size={100}
-              color={errorText ? "destructive-primary" : "gray700"}
+              color={errorText ? "destructive700" : "gray700"}
             >
               {errorText || helperText}
             </Typography>

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -136,7 +136,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <Box paddingX={1}>
             <Typography
               size={100}
-              color={errorText ? "destructive700" : "gray700"}
+              color={errorText ? "destructive-darkBackground" : "gray700"}
             >
               {errorText || helperText}
             </Typography>

--- a/packages/syntax-core/src/TextField/TextField.module.css
+++ b/packages/syntax-core/src/TextField/TextField.module.css
@@ -1,6 +1,6 @@
 .textfield {
   appearance: none;
-  border: 2px solid var(--color-cambio-gray-370);
+  border: 1px solid var(--color-cambio-gray-370);
   border-radius: 8px;
   box-sizing: border-box;
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -33,7 +33,7 @@
 
 .inputError {
   color: var(--color-cambio-destructive-900);
-  border-color: var(--color-cambio-destructive-700);
+  border: 2px solid var(--color-cambio-destructive-700);
 }
 
 .inputError::placeholder {

--- a/packages/syntax-core/src/TextField/TextField.module.css
+++ b/packages/syntax-core/src/TextField/TextField.module.css
@@ -1,6 +1,6 @@
 .textfield {
   appearance: none;
-  border: 1px solid var(--color-cambio-gray-370);
+  border: 2px solid var(--color-cambio-gray-370);
   border-radius: 8px;
   box-sizing: border-box;
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -131,7 +131,7 @@ export default function TextField({
         <Box paddingX={1}>
           <Typography
             size={100}
-            color={errorText ? "destructive700" : "gray700"}
+            color={errorText ? "destructive-darkBackground" : "gray700"}
           >
             {errorText || helperText}
           </Typography>

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -131,7 +131,7 @@ export default function TextField({
         <Box paddingX={1}>
           <Typography
             size={100}
-            color={errorText ? "destructive-primary" : "gray700"}
+            color={errorText ? "destructive700" : "gray700"}
           >
             {errorText || helperText}
           </Typography>

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -42,7 +42,9 @@ const Typography = forwardRef<
       | "success-darkBackground"
       | "white"
       | "white-secondary"
+      | "destructive700"
       | "inherit";
+
     /**
      * Test id for the text
      */

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -42,7 +42,6 @@ const Typography = forwardRef<
       | "success-darkBackground"
       | "white"
       | "white-secondary"
-      | "destructive700"
       | "inherit";
     /**
      * Test id for the text

--- a/packages/syntax-core/src/Typography/Typography.tsx
+++ b/packages/syntax-core/src/Typography/Typography.tsx
@@ -44,7 +44,6 @@ const Typography = forwardRef<
       | "white-secondary"
       | "destructive700"
       | "inherit";
-
     /**
      * Test id for the text
      */

--- a/packages/syntax-core/src/colors/textColors.ts
+++ b/packages/syntax-core/src/colors/textColors.ts
@@ -26,13 +26,11 @@ export default function textColor(
     case "destructive-primary":
       return colorStyles.cambioDestructive900Color;
     case "destructive-darkBackground":
-      return colorStyles.cambioDestructive100Color;
+      return colorStyles.cambioDestructive700Color;
     case "success":
       return colorStyles.cambioSuccess900Color;
     case "success-darkBackground":
       return colorStyles.cambioSuccess100Color;
-    case "destructive700":
-      return colorStyles.cambioDestructive700Color;
     // primary / gray900
     default:
       return colorStyles.cambioBlackColor;

--- a/packages/syntax-core/src/colors/textColors.ts
+++ b/packages/syntax-core/src/colors/textColors.ts
@@ -7,6 +7,7 @@ export default function textColor(
     | "primary"
     | "destructive-primary"
     | "destructive-darkBackground"
+    | "destructive700"
     | "success"
     | "success-darkBackground"
     | "white"
@@ -30,6 +31,8 @@ export default function textColor(
       return colorStyles.cambioSuccess900Color;
     case "success-darkBackground":
       return colorStyles.cambioSuccess100Color;
+    case "destructive700":
+      return colorStyles.cambioDestructive700Color;
     // primary / gray900
     default:
       return colorStyles.cambioBlackColor;

--- a/packages/syntax-core/src/colors/textColors.ts
+++ b/packages/syntax-core/src/colors/textColors.ts
@@ -7,7 +7,6 @@ export default function textColor(
     | "primary"
     | "destructive-primary"
     | "destructive-darkBackground"
-    | "destructive700"
     | "success"
     | "success-darkBackground"
     | "white"


### PR DESCRIPTION
TextArea/TextField error styling has too red of an error text. This pr changes the shade of the error text to `destructive700` from `destructive-primary` and changes the border thickness to 1px from 2px

Before:
<img width="1003" alt="Screenshot 2024-06-10 at 3 26 48 PM" src="https://github.com/Cambly/syntax/assets/24865193/8e792051-3ad8-489e-a172-2bf2979505f1">

After:
<img width="1208" alt="image" src="https://github.com/Cambly/syntax/assets/24865193/f1e36cc3-a29f-4300-9550-b90542463ef6">


Relevant slack link: https://cambly.slack.com/archives/C06QK5KF3K4/p1716313519111459