### PR TITLE
Update icon sizes docstring and size types

### DIFF
--- a/.changeset/strange-eagles-relate.md
+++ b/.changeset/strange-eagles-relate.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Update docstring and size types

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -14,20 +14,20 @@ type IconProps = {
   color?: ComponentProps<typeof Typography>["color"];
   /**
    * The size of the Icon.
-   * * 0: 16px x 16px
-   * * 100: 20px x 20px
-   * * 200: 24px x 24px
-   * * 300: 28px x 28px
-   * * 400: 48px x 48px
-   * * 500: 72px x 72px
-   * * 600: 100px x 100px
-   * * 700: 140px x 140px
-   * * 800: 200px x 200px
-   * * 9000: 280px x 280px
+   * * 100: 16px x 16px
+   * * 200: 20px x 20px
+   * * 300: 24px x 24px
+   * * 400: 28px x 28px
+   * * 500: 48px x 48px
+   * * 600: 72px x 72px
+   * * 700: 100px x 100px
+   * * 800: 140px x 140px
+   * * 900: 200px x 200px
+   * * 1000: 280px x 280px
    *
    * @defaultValue 200
    */
-  size?: 0 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+  size?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
   /**
    * The svg path of the icon. You should not use this prop directly, instead use the specific icon components.
    */


### PR DESCRIPTION
- I noticed the sizes on the docstring didn't match with the actual styling: https://github.com/Cambly/syntax/blob/main/packages/syntax-core/src/Icon/Icon.module.css