### PR TITLE
Change onClick => onMouseDown

### DIFF
--- a/.changeset/silly-kings-kiss.md
+++ b/.changeset/silly-kings-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Update modal backdrop onClick to onMouseDown

--- a/packages/syntax-core/src/Modal/Modal.tsx
+++ b/packages/syntax-core/src/Modal/Modal.tsx
@@ -133,7 +133,7 @@ export default function Modal({
           <div
             className={styles.backdrop}
             role="presentation"
-            onClick={(e) => e.target === e.currentTarget && onDismiss()}
+            onMouseDown={(e) => e.target === e.currentTarget && onDismiss()}
             onKeyDown={(e) => e.key === "Escape" && onDismiss()}
           >
             <Box


### PR DESCRIPTION
Right now, if we hold click inside the modal and then drag and release click outside of the modal, we trigger the `onClick` on the backdrop div, which dismisses the modal. This update will only fire if the mouse down occurs on the backdrop and NOT when we release click on the backdrop.