### PR TITLE
TabLink: make href optional

### DIFF
--- a/.changeset/cuddly-kids-film.md
+++ b/.changeset/cuddly-kids-film.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TabLink: allow href to be optional

--- a/packages/syntax-core/src/Tabs/TabLink.tsx
+++ b/packages/syntax-core/src/Tabs/TabLink.tsx
@@ -17,7 +17,7 @@ type TabLinkProps = ComponentProps<typeof TabInternal> & {
    * The link that the Tab should route to.
    *
    */
-  href: string;
+  href?: string;
   /**
    * The target attribute specifies where to open the linked document.
    *


### PR DESCRIPTION
From [this Cambly-Frontend PR](https://github.com/Cambly/Cambly-Frontend/pull/10554#discussion_r1653333648), a NextTabLink actually shouldn't require an href, because we feed it into next's `Link` component. 

LinkButton's href is also currently optional and I imagine it's for the same reason