### PR TITLE
Bump syntax icons version

### DIFF
--- a/.changeset/clever-stingrays-boil.md
+++ b/.changeset/clever-stingrays-boil.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-core": major
+"@cambly/syntax-icons": major
+---
+
+Update the types for Icon sizing. Remove 0


### PR DESCRIPTION
After [this PR](https://github.com/Cambly/syntax/pull/456), we don't accept 0 as an icon size