### PR TITLE
SelectList: call onClick when user presses enter or space key

### DIFF
--- a/.changeset/few-phones-wash.md
+++ b/.changeset/few-phones-wash.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+SelectList: call onClick when using certain keyboard inputs

--- a/packages/syntax-core/src/SelectList/SelectList.test.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.test.tsx
@@ -12,7 +12,7 @@ const SelectDropdown = ({
 }: {
   selectedValue?: string;
   numberOfOptions: number;
-  onClick?: React.MouseEventHandler<HTMLSelectElement>;
+  onClick?: (event: React.SyntheticEvent<HTMLSelectElement>) => void;
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
 }) => {
   const options = Array.from({ length: numberOfOptions }, (item, idx) => ({
@@ -47,7 +47,7 @@ const InteractiveSelectDropdown = ({
 }: {
   numberOfOptions: number;
   handleChange: (value: string) => void;
-  onClick?: React.MouseEventHandler<HTMLSelectElement>;
+  onClick?: (event: React.SyntheticEvent<HTMLSelectElement>) => void;
 }) => {
   const [selectedValue, setSelectedValue] = useState("");
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -103,6 +103,12 @@ describe("select", () => {
     );
     await userEvent.click(screen.getByTestId("syntax-select"));
     expect(handleClick).toHaveBeenCalledTimes(1);
+    await userEvent.keyboard("{Enter}");
+    expect(handleClick).toHaveBeenCalledTimes(2);
+    await userEvent.keyboard("{Space}");
+    expect(handleClick).toHaveBeenCalledTimes(3);
+    await userEvent.keyboard(" ");
+    expect(handleClick).toHaveBeenCalledTimes(4);
   });
   it("calls onchange on selecting option", async () => {
     const handleChange = vi.fn();

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -49,7 +49,7 @@ export default function SelectList({
   /**
    * Callback to be called when select is clicked
    */
-  onClick?: React.MouseEventHandler<HTMLSelectElement>;
+  onClick?: (event: React.SyntheticEvent<HTMLSelectElement>) => void;
   /**
    * Text shown below select box if there is an input error.
    */
@@ -87,6 +87,15 @@ export default function SelectList({
   const { isFocusVisible } = useFocusVisible();
   const [isFocused, setIsFocused] = useState(false);
 
+  const handleKeyDown: React.KeyboardEventHandler<HTMLSelectElement> = (
+    event,
+  ) => {
+    if (disabled || onClick == null) return;
+    if (event.key === "Enter" || event.key === " " || event.key === "Space") {
+      onClick(event);
+    }
+  };
+
   return (
     <div
       className={classNames(styles.selectContainer, {
@@ -117,6 +126,7 @@ export default function SelectList({
           })}
           onChange={onChange}
           onClick={onClick}
+          onKeyDown={handleKeyDown}
           value={
             placeholderText && !selectedValue ? placeholderText : selectedValue
           }


### PR DESCRIPTION
We have an accessibility issue when using SelectList for opening a more complicated popover (example below). While clicking triggers the `onClick` function, we also need to trigger it if the user presses the "enter" or "space" key.

<img width="838" alt="image" src="https://github.com/Cambly/syntax/assets/36240753/6b1df41b-cf78-4e41-b62e-1965d93a8a7e">
