### PR TITLE
Button: Update hover, focus, active opacity

### DIFF
--- a/.changeset/cool-buttons-rest.md
+++ b/.changeset/cool-buttons-rest.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Button: Update hover, focus, and active state opacity

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -12,8 +12,8 @@
 .button:hover {
   background-image: linear-gradient(
     to bottom,
-    rgba(0, 0, 0, 0.1) 0%,
-    rgba(0, 0, 0, 0.1) 100%
+    rgba(190, 180, 171, 0.3) 0%,
+    rgba(190, 180, 171, 0.3) 100%
   );
   transition-duration: 0.2s;
   cursor: pointer;
@@ -22,8 +22,8 @@
 .button:focus-visible {
   background-image: linear-gradient(
     to bottom,
-    rgba(0, 0, 0, 0.2) 0%,
-    rgba(0, 0, 0, 0.2) 100%
+    rgba(190, 180, 171, 0.3) 0%,
+    rgba(190, 180, 171, 0.3) 100%
   );
   box-shadow: 0 0 0 4px #000;
   outline: solid 2px #fff;
@@ -32,8 +32,8 @@
 .button:active {
   background-image: linear-gradient(
     to bottom,
-    rgba(0, 0, 0, 0.2) 0%,
-    rgba(0, 0, 0, 0.2) 100%
+    rgba(190, 180, 171, 0.3) 0%,
+    rgba(190, 180, 171, 0.3) 100%
   );
   transform: scale(0.97);
   transition-duration: 0.2s;


### PR DESCRIPTION
As [noted](https://cambly.slack.com/archives/C033ZPY5M46/p1720803458912209) by Joey and AJ, our current hover, focus, and active states are barely noticeable for our primary light background or secondary dark background buttons since they're black and the linear gradient for those states is using black as the base color.

This PR updates the linear gradient for the background color of these states to use gray300 at 30% 

Before:
<img width="189" alt="Screenshot 2024-07-16 at 10 23 43 AM" src="https://github.com/user-attachments/assets/9c71b510-b11e-4163-89f6-c0bde7c460e4">
<img width="185" alt="Screenshot 2024-07-16 at 10 29 59 AM" src="https://github.com/user-attachments/assets/2bb197ab-6d9d-445a-a541-20136a3e6275">
<img width="184" alt="Screenshot 2024-07-16 at 10 23 49 AM" src="https://github.com/user-attachments/assets/c51a3500-7a7f-4d96-9884-990b2b7b6677">
<img width="189" alt="Screenshot 2024-07-16 at 10 29 48 AM" src="https://github.com/user-attachments/assets/0368acea-282c-47d3-b25e-900d1f3daaa1">




After:
<img width="177" alt="Screenshot 2024-07-16 at 10 21 44 AM" src="https://github.com/user-attachments/assets/3e06261f-6561-42e8-8e0b-6bc350ae0dd5">
<img width="179" alt="Screenshot 2024-07-16 at 10 21 55 AM" src="https://github.com/user-attachments/assets/72912648-c722-44d6-a03e-9f9613ac9e4f">
<img width="185" alt="Screenshot 2024-07-16 at 10 22 05 AM" src="https://github.com/user-attachments/assets/a4e0e23f-1f4e-4371-ac1c-eaa4b4881620">
<img width="166" alt="Screenshot 2024-07-16 at 10 22 19 AM" src="https://github.com/user-attachments/assets/5a13c954-1cec-4d5b-a6c6-69094398418d">
