### PR TITLE
Button: Update button disabled hover state

### DIFF
--- a/.changeset/brown-turtles-fry.md
+++ b/.changeset/brown-turtles-fry.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Button: Update disabled button hover state

--- a/packages/syntax-core/src/Button/Button.module.css
+++ b/packages/syntax-core/src/Button/Button.module.css
@@ -46,6 +46,13 @@
   cursor: auto;
 }
 
+.disabled:hover {
+  filter: opacity(50%);
+  background-image: none;
+  transform: none;
+  cursor: auto;
+}
+
 .disabledPrimary {
   opacity: 0.5;
 }


### PR DESCRIPTION
The hover state for disabled buttons wasn't working as expected - it still looked like it was active with a pointer for the cursor and an animation on click. This PR updates the styling for disabled buttons to be non-interactive.

These stylings already work for focus and active since disabled buttons cannot have those states

Before:

https://github.com/user-attachments/assets/da8a63d7-008f-41ec-89b4-59201e53a82f


After:

https://github.com/user-attachments/assets/c9374cdf-8f47-40c3-9ac3-677eb9e3289c



