### PR TITLE
Avatar: update icon sizes and layouts

### DIFF
--- a/.changeset/weak-grapes-jam.md
+++ b/.changeset/weak-grapes-jam.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Avatar: update icon sizes and layouts

--- a/packages/syntax-core/src/Avatar/Avatar.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.tsx
@@ -5,11 +5,11 @@ import Box from "../Box/Box";
 import { useAvatarGroup } from "../AvatarGroup/AvatarGroup";
 
 const sizeToIconStyles = {
-  xs: { bottom: 6, marginInlineEnd: 2, height: 4, width: 4 },
-  sm: { bottom: 6, marginInlineEnd: 2, height: 4, width: 4 },
-  md: { bottom: 6, marginInlineEnd: 2, height: 8, width: 8 },
-  lg: { bottom: 6, marginInlineEnd: 6, height: 12, width: 12 },
-  xl: { bottom: 8, marginInlineEnd: 6, height: 12, width: 12 },
+  xs: { bottom: 4, marginInlineEnd: 0, height: 8, width: 8 },
+  sm: { bottom: 4, marginInlineEnd: 0, height: 10, width: 10 },
+  md: { bottom: 4, marginInlineEnd: 0, height: 12, width: 12 },
+  lg: { bottom: 4, marginInlineEnd: 0, height: 16, width: 16 },
+  xl: { bottom: 4, marginInlineEnd: 4, height: 16, width: 16 },
 } as const;
 
 const sizeToMargin = {
@@ -33,6 +33,17 @@ function AvatarInternal({
   size?: "xs" | "sm" | "md" | "lg" | "xl";
   src: string;
 }): ReactElement {
+  function getBorderSize() {
+    switch (size) {
+      case "xs":
+      case "sm":
+        return 0.5;
+      case "md":
+      case "lg":
+      case "xl":
+        return 1;
+    }
+  }
   return (
     <div className={classNames(styles.avatar, styles[size])}>
       <img
@@ -54,7 +65,7 @@ function AvatarInternal({
             backgroundColor="white"
             dangerouslySetInlineStyle={{
               __style: {
-                border: "1px solid white",
+                border: `${getBorderSize()}px solid white`,
                 ...sizeToIconStyles[size],
               },
             }}


### PR DESCRIPTION
[Figma](https://www.figma.com/design/G3UM2urgAYO2iiNU7nlulI/Cambio-Syntax?node-id=6742-11605&t=gOMEsrWOzMgS3YzJ-0)
Per [this convo](https://cambly.slack.com/archives/C033ZPY5M46/p1721335898547979), icon sizes are too small currently on avatars -- this will at least fix the issue of the "online" icon being too small in our web app