### PR TITLE
Tabs: update underline css

### DIFF
--- a/.changeset/hot-grapes-grow.md
+++ b/.changeset/hot-grapes-grow.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Tabs: Update underline styling

--- a/packages/syntax-core/src/Tabs/TabButton.tsx
+++ b/packages/syntax-core/src/Tabs/TabButton.tsx
@@ -31,7 +31,7 @@ export default function TabButton({
   return (
     <div
       role="tab"
-      className={classnames({
+      className={classnames(styles.tab, {
         [styles.unselectedTab]: !selected,
         [styles.selectedTabOnLightBackground]:
           selected && on === "lightBackground",

--- a/packages/syntax-core/src/Tabs/TabLink.tsx
+++ b/packages/syntax-core/src/Tabs/TabLink.tsx
@@ -53,7 +53,7 @@ const TabLink = forwardRef<HTMLAnchorElement, TabLinkProps>(
     return (
       <div
         role="tab"
-        className={classnames({
+        className={classnames(styles.tab, {
           [styles.unselectedTab]: !selected,
           [styles.selectedTabOnLightBackground]:
             selected && on === "lightBackground",

--- a/packages/syntax-core/src/Tabs/Tabs.module.css
+++ b/packages/syntax-core/src/Tabs/Tabs.module.css
@@ -6,6 +6,10 @@
   border-bottom: 1px solid var(--color-cambio-white-40);
 }
 
+.tab {
+  margin-bottom: 1px;
+}
+
 .selectedTabOnLightBackground {
   border-bottom: 3px solid var(--color-cambio-black);
 }


### PR DESCRIPTION
Context: https://cambly.slack.com/archives/C033ZPY5M46/p1720808650914279

The underline on the selected tab's margin is slightly off from design

Current:
![image](https://github.com/user-attachments/assets/b023ddcb-6a80-4f52-9a45-0f7c0369a631)

Ideal:
![image](https://github.com/user-attachments/assets/09664b72-93fa-4db4-bb15-25a22f7b227d)
