### PR TITLE
Icons: bump version to update color prop type

### DIFF
--- a/.changeset/quick-tomatoes-peel.md
+++ b/.changeset/quick-tomatoes-peel.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-icons": minor
+---
+
+Bump version to update Icon color's expected props


### PR DESCRIPTION
Updating Syntax runs into a type incompatibility -- this stems from changing Icon's `color` type [here](https://github.com/Cambly/syntax/pull/493). Each Icon in `syntax-icon` takes a `color` prop based on Icon's `color` prop. If we don't update the version there, each icon keeps the stale value of Icon's `color` prop 

https://app.circleci.com/pipelines/github/Cambly/Cambly-Frontend/63360/workflows/f0a49b47-78d5-46ed-bfa4-c70149bcb609/jobs/531312
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/7e1def14-0bda-4f84-9859-541e7c14aa66">
