### PR TITLE
[NO-JIRA] Fix Icon Colors

### DIFF
--- a/.changeset/fluffy-spies-grin.md
+++ b/.changeset/fluffy-spies-grin.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Icon: made default color "inherit"

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -8,7 +8,7 @@ type IconProps = {
   /**
    * The color of the Icon.
    *
-   * @defaultValue "gray900"
+   * @defaultValue "inherit"
    */
   color?: (typeof allColors)[number];
   /**
@@ -42,7 +42,7 @@ type IconProps = {
  * You can click on the icon to copy the import statement!
  */
 const Icon = forwardRef<SVGSVGElement, IconProps>(
-  ({ color = "gray900", path, size = 200 }: IconProps, ref) => (
+  ({ color = "inherit", path, size = 200 }: IconProps, ref) => (
     <svg
       className={classnames(
         styles.icon,

--- a/packages/syntax-core/src/colors/allColors.ts
+++ b/packages/syntax-core/src/colors/allColors.ts
@@ -1,4 +1,5 @@
 const colors = [
+  "inherit",
   "black",
   "destructive100",
   "destructive200",


### PR DESCRIPTION
Issue after [this PR](https://github.com/Cambly/syntax/pull/493) where IconButton color was appearing dark gray and the darkBackground field stopped working. 

Fixed by making the default color `inherit` for Icon