### PR TITLE
Avatar: update icon sizes and offsets for medium and small variants

### DIFF
--- a/.changeset/unlucky-squids-deliver.md
+++ b/.changeset/unlucky-squids-deliver.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Avatar: update icon sizes and offset for medium and small avatars

--- a/packages/syntax-core/src/Avatar/Avatar.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.tsx
@@ -6,8 +6,8 @@ import { useAvatarGroup } from "../AvatarGroup/AvatarGroup";
 
 const sizeToIconStyles = {
   xs: { bottom: 4, marginInlineEnd: 0, height: 8, width: 8 },
-  sm: { bottom: 4, marginInlineEnd: 0, height: 10, width: 10 },
-  md: { bottom: 4, marginInlineEnd: 0, height: 12, width: 12 },
+  sm: { bottom: 4, marginInlineEnd: 0, height: 12, width: 12 },
+  md: { bottom: 4, marginInlineEnd: 0, height: 16, width: 16 },
   lg: { bottom: 4, marginInlineEnd: 0, height: 16, width: 16 },
   xl: { bottom: 4, marginInlineEnd: 4, height: 16, width: 16 },
 } as const;
@@ -15,7 +15,7 @@ const sizeToIconStyles = {
 const sizeToMargin = {
   xs: -10,
   sm: -14,
-  md: -22,
+  md: -24,
   lg: -28,
   xl: -34,
 } as const;


### PR DESCRIPTION
I got the following specs wrong on the first iteration:

medium avatars should have a 16x16 icon with a lower offset 
small avatars should have a 12x12 icon instead of 10x10