### PR TITLE
ButtonGroup: Make orientation responsive

### DIFF
--- a/.changeset/clever-balloons-change.md
+++ b/.changeset/clever-balloons-change.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+ButtonGroup: Make responsive

--- a/packages/syntax-core/src/ButtonGroup/ButtonGroup.module.css
+++ b/packages/syntax-core/src/ButtonGroup/ButtonGroup.module.css
@@ -21,3 +21,25 @@
 .largeGap {
   gap: 12px;
 }
+
+/* Flex direction (small and up) */
+@media (min-width: 480px) {
+  .orientationhorizontalSmall {
+    flex-direction: row;
+  }
+
+  .orientationverticalSmall {
+    flex-direction: column;
+  }
+}
+
+/* Align items (large and up) */
+@media (min-width: 960px) {
+  .orientationhorizontalLarge {
+    flex-direction: row;
+  }
+
+  .orientationverticalLarge {
+    flex-direction: column;
+  }
+}

--- a/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
@@ -16,11 +16,17 @@ const ButtonGroup = ({
   orientation = "horizontal",
   size = "md",
   children,
+  smOrientation,
+  lgOrientation,
 }: {
   /**
    * The orientation of the button group
    *
    * @defaultValue "horizontal"
+   *
+   * Responsive props:
+   * `smOrientation`
+   * `lgOrientation`
    */
   orientation?: "horizontal" | "vertical";
   /**
@@ -37,11 +43,30 @@ const ButtonGroup = ({
    * Buttons to be rendered inside the button group
    */
   children?: ReactNode;
+  /**
+   * Bottom margin on sm (480px) or larger viewports.
+   */
+  smOrientation?: typeof orientation;
+  /**
+   * Bottom margin on lg (960px) or larger viewports.
+   */
+  lgOrientation?: typeof orientation;
 }): ReactElement => {
-  const classnames = classNames(styles.buttonGroup, gap[size], {
-    [styles.horizontal]: orientation === "horizontal",
-    [styles.vertical]: orientation === "vertical",
-  });
+  console.log(
+    smOrientation != null,
+    smOrientation && `orientation${smOrientation}Small`,
+    smOrientation && styles[`orientation${smOrientation}Small`],
+  );
+  const classnames = classNames(
+    styles.buttonGroup,
+    gap[size],
+    smOrientation != null && styles[`orientation${smOrientation}Small`],
+    lgOrientation != null && styles[`orientation${lgOrientation}Large`],
+    {
+      [styles.horizontal]: orientation === "horizontal",
+      [styles.vertical]: orientation === "vertical",
+    },
+  );
 
   return <div className={classnames}>{children}</div>;
 };

--- a/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/syntax-core/src/ButtonGroup/ButtonGroup.tsx
@@ -52,11 +52,6 @@ const ButtonGroup = ({
    */
   lgOrientation?: typeof orientation;
 }): ReactElement => {
-  console.log(
-    smOrientation != null,
-    smOrientation && `orientation${smOrientation}Small`,
-    smOrientation && styles[`orientation${smOrientation}Small`],
-  );
   const classnames = classNames(
     styles.buttonGroup,
     gap[size],

--- a/packages/syntax-core/src/ButtonGroup/Buttongroup.stories.tsx
+++ b/packages/syntax-core/src/ButtonGroup/Buttongroup.stories.tsx
@@ -101,3 +101,12 @@ export const Vertical: StoryObj<typeof ButtonGroup> = {
     </ButtonGroup>
   ),
 };
+
+export const Responsive: StoryObj<typeof ButtonGroup> = {
+  render: (args) => (
+    <ButtonGroup {...args} orientation="vertical" smOrientation="horizontal">
+      <Button color="secondary" text="Secondary" onClick={handleClick} />
+      <Button color="primary" text="Primary" onClick={handleClick} />
+    </ButtonGroup>
+  ),
+};


### PR DESCRIPTION
Currently there are a few usages of ButtonGroup where the CTAs could be more responsive. Things will look normal on a desktop but then the mWeb view looks squished because CTAs are still side-by-side. Allowing ButtonGroup's orientation to be responsive should help alleviate most of those issues.

New props:
`smOrientation`
`lgOrientation`