### PR TITLE
WordConfetti: Implement new component

### DIFF
--- a/.changeset/tiny-bugs-deliver.md
+++ b/.changeset/tiny-bugs-deliver.md
@@ -1,5 +1,5 @@
 ---
-"@cambly/syntax-core": major
+"@cambly/syntax-core": minor
 ---
 
 WordConfetti: Implement component

--- a/.changeset/tiny-bugs-deliver.md
+++ b/.changeset/tiny-bugs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+WordConfetti: Implement component

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.stories.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.stories.tsx
@@ -39,9 +39,6 @@ export default {
       options: ["neutral", "cool", "warm"],
       control: { type: "select" },
     },
-    width: {
-      control: "text",
-    },
     words: {
       control: "array",
     },

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.stories.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.stories.tsx
@@ -1,0 +1,54 @@
+import { type StoryObj, type Meta } from "@storybook/react";
+import WordConfetti from "./WordConfetti";
+
+export default {
+  title: "Components/WordConfetti",
+  component: WordConfetti,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/G3UM2urgAYO2iiNU7nlulI/Cambio-Syntax?node-id=6803-23390&t=f4WOjInBkq4pw2kN-0",
+    },
+  },
+  args: {
+    "data-testid": "",
+    direction: "row",
+    size: 300,
+    theme: "neutral",
+    words: [
+      "hello",
+      "world",
+      "meteor",
+      "react",
+      "storybook",
+      "cambly",
+      "expeditiously",
+      "indubitably",
+    ],
+  },
+  argTypes: {
+    direction: {
+      control: { type: "select" },
+      options: ["row", "column"],
+    },
+    size: {
+      options: [300, 400, 700, 800, 900, 1100],
+      control: { type: "select" },
+    },
+    theme: {
+      options: ["neutral", "cool", "warm"],
+      control: { type: "select" },
+    },
+    width: {
+      control: "text",
+    },
+    words: {
+      control: "array",
+    },
+  },
+  tags: ["autodocs"],
+} as Meta<typeof WordConfetti>;
+
+export const Default: StoryObj<typeof WordConfetti> = {
+  render: ({ ...args }) => <WordConfetti {...args} />,
+};

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
@@ -15,14 +15,13 @@ describe("wordConfetti", () => {
   });
 
   it("renders all words successfully", () => {
-    const { baseElement } = render(
+    render(
       <WordConfetti
         size={300}
         theme="neutral"
         words={["test", "word", "confetti"]}
       />,
     );
-    expect(baseElement).toBeTruthy();
     expect(screen.getByText("confetti")).toBeInTheDocument();
     expect(screen.getByText("test")).toBeInTheDocument();
     expect(screen.getByText("word")).toBeInTheDocument();

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
@@ -1,0 +1,30 @@
+import { screen, render } from "@testing-library/react";
+import WordConfetti from "./WordConfetti";
+
+describe("wordConfetti", () => {
+  it("renders successfully", () => {
+    const { baseElement } = render(
+      <WordConfetti
+        size={300}
+        theme="neutral"
+        words={["test", "word", "confetti"]}
+      />,
+    );
+    expect(baseElement).toBeTruthy();
+    expect(screen.getByText("confetti")).toBeInTheDocument();
+  });
+
+  it("renders all words successfully", () => {
+    const { baseElement } = render(
+      <WordConfetti
+        size={300}
+        theme="neutral"
+        words={["test", "word", "confetti"]}
+      />,
+    );
+    expect(baseElement).toBeTruthy();
+    expect(screen.getByText("confetti")).toBeInTheDocument();
+    expect(screen.getByText("test")).toBeInTheDocument();
+    expect(screen.getByText("word")).toBeInTheDocument();
+  });
+});

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -2,7 +2,6 @@ import { type ReactNode, forwardRef } from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
-type Dimension = number | string;
 type Direction = "row" | "column";
 type WordConfettiProps = {
   /**
@@ -22,10 +21,6 @@ type WordConfettiProps = {
    * The theme for the background colors of the confetti.
    */
   theme: "neutral" | "cool" | "warm";
-  /**
-   * The width of the box.
-   */
-  width?: Dimension;
   /**
    * The words to display as confetti.
    */
@@ -68,7 +63,6 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       direction = "row",
       size,
       theme,
-      width = "100%",
       words,
     } = props;
 
@@ -77,7 +71,6 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
         display="flex"
         direction={direction}
         flexWrap="wrap"
-        width={width}
         data-testid={dataTestId}
         ref={ref}
         gap={gaps[size]}

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,0 +1,114 @@
+import { type ReactNode, forwardRef } from "react";
+import Box from "../Box/Box";
+import Typography from "../Typography/Typography";
+
+type Dimension = number | string;
+type Direction = "row" | "column";
+type WordConfettiProps = {
+  /**
+   * Test id for the confetti
+   */
+  "data-testid"?: string;
+  /**
+   * The direction to display the words.
+   * @defaultValue row
+   */
+  direction?: Direction;
+  /**
+   * The size of the font in the confetti.
+   */
+  size: 300 | 400 | 700 | 800 | 900 | 1100;
+  /**
+   * The theme for the background colors of the confetti.
+   */
+  theme: "neutral" | "cool" | "warm";
+  /**
+   * The width of the box.
+   */
+  width?: Dimension;
+  /**
+   * The words to display as confetti.
+   */
+  words: string[];
+};
+
+const themeBackgroundColors = {
+  neutral: ["pink", "lilac", "thistle"],
+  cool: ["sky", "slate", "teal"],
+  warm: ["red", "tan", "orange"],
+} as const;
+
+const degreeOfTiltOptions = [-6, -6, -3, -3, 0, 3, 3, 6, 6];
+
+const paddings = {
+  300: "16px 20px 16px 20px",
+  400: "20px 24px 20px 24px",
+  700: "24px 28px 24px 28px",
+  800: "28px 40px 28px 40px",
+  900: "32px 48px 32px 48px",
+  1100: "36px 56px 36px 56px",
+};
+
+const gaps = {
+  300: 3,
+  400: 4,
+  700: 6,
+  800: 6,
+  900: 9,
+  1100: 10,
+} as const;
+
+/**
+ * [WordConfetti](https://cambly-syntax.vercel.app/?path=/docs/components-wordconfetti--docs) is a container for displaying words in different color themes and fun offset angles.
+ */
+const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
+  function WordConfetti(props: WordConfettiProps, ref): JSX.Element {
+    const {
+      "data-testid": dataTestId,
+      direction = "row",
+      size,
+      theme,
+      width = "100%",
+      words,
+    } = props;
+
+    return (
+      <Box
+        display="flex"
+        direction={direction}
+        flexWrap="wrap"
+        width={width}
+        data-testid={dataTestId}
+        ref={ref}
+        gap={gaps[size]}
+      >
+        {words.map((word, index): ReactNode => {
+          const randomBackgroundColorIndex = Math.floor(Math.random() * 3);
+          const randomDegreeOfTiltIndex = Math.floor(Math.random() * 9);
+
+          return (
+            <Box
+              key={`${word}+${index}`}
+              backgroundColor={
+                themeBackgroundColors[theme][randomBackgroundColorIndex]
+              }
+              dangerouslySetInlineStyle={{
+                __style: {
+                  padding: paddings[size],
+                  transform: `rotate(${degreeOfTiltOptions[randomDegreeOfTiltIndex]}deg)`,
+                },
+              }}
+              width="fit-content"
+            >
+              <Typography size={size} weight="bold" fontStyle="serif">
+                {word}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  },
+);
+
+export default WordConfetti;

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, forwardRef } from "react";
+import { type ReactNode, forwardRef, useMemo } from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
@@ -66,6 +66,16 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
+    const colorOrder: number[] = useMemo(
+      () => words.map(() => Math.floor(Math.random() * 3)),
+      [words],
+    );
+
+    const tiltOrder: number[] = useMemo(
+      () => words.map(() => Math.floor(Math.random() * 9)),
+      [words],
+    );
+
     return (
       <Box
         display="flex"
@@ -76,19 +86,16 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
         gap={gaps[size]}
       >
         {words.map((word, index): ReactNode => {
-          const randomBackgroundColorIndex = Math.floor(Math.random() * 3);
-          const randomDegreeOfTiltIndex = Math.floor(Math.random() * 9);
-
           return (
             <Box
               key={`${word}+${index}`}
-              backgroundColor={
-                themeBackgroundColors[theme][randomBackgroundColorIndex]
-              }
+              backgroundColor={themeBackgroundColors[theme][colorOrder[index]]}
               dangerouslySetInlineStyle={{
                 __style: {
                   padding: paddings[size],
-                  transform: `rotate(${degreeOfTiltOptions[randomDegreeOfTiltIndex]}deg)`,
+                  transform: `rotate(${
+                    degreeOfTiltOptions[tiltOrder[index]]
+                  }deg)`,
                 },
               }}
               width="fit-content"

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,31 +1,6 @@
-import { type ReactNode, forwardRef, useMemo } from "react";
+import { type ReactNode, forwardRef, useMemo, type ReactElement } from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
-
-type Direction = "row" | "column";
-type WordConfettiProps = {
-  /**
-   * Test id for the confetti
-   */
-  "data-testid"?: string;
-  /**
-   * The direction to display the words.
-   * @defaultValue row
-   */
-  direction?: Direction;
-  /**
-   * The size of the font in the confetti.
-   */
-  size: 300 | 400 | 700 | 800 | 900 | 1100;
-  /**
-   * The theme for the background colors of the confetti.
-   */
-  theme: "neutral" | "cool" | "warm";
-  /**
-   * The words to display as confetti.
-   */
-  words: string[];
-};
 
 const themeBackgroundColors = {
   neutral: ["pink", "lilac", "thistle"],
@@ -53,6 +28,72 @@ const gaps = {
   1100: 10,
 } as const;
 
+const WordConfetto = ({
+  backgroundColor,
+  key,
+  rotation,
+  size,
+  text,
+}: {
+  backgroundColor:
+    | "pink"
+    | "lilac"
+    | "thistle"
+    | "sky"
+    | "slate"
+    | "teal"
+    | "red"
+    | "tan"
+    | "orange";
+  key: string;
+  rotation: number;
+  size: 300 | 400 | 700 | 800 | 900 | 1100;
+  text: string;
+}): ReactElement => {
+  return (
+    <Box
+      key={key}
+      backgroundColor={backgroundColor}
+      dangerouslySetInlineStyle={{
+        __style: {
+          padding: paddings[size],
+          transform: `rotate(${rotation}deg)`,
+        },
+      }}
+      width="fit-content"
+    >
+      <Typography size={size} weight="bold" fontStyle="serif">
+        {text}
+      </Typography>
+    </Box>
+  );
+};
+
+type Direction = "row" | "column";
+type WordConfettiProps = {
+  /**
+   * Test id for the confetti
+   */
+  "data-testid"?: string;
+  /**
+   * The direction to display the words.
+   * @defaultValue row
+   */
+  direction?: Direction;
+  /**
+   * The size of the font in the confetti.
+   */
+  size: 300 | 400 | 700 | 800 | 900 | 1100;
+  /**
+   * The theme for the background colors of the confetti.
+   */
+  theme: "neutral" | "cool" | "warm";
+  /**
+   * The words to display as confetti.
+   */
+  words: string[];
+};
+
 /**
  * [WordConfetti](https://cambly-syntax.vercel.app/?path=/docs/components-wordconfetti--docs) is a container for displaying words in different color themes and fun offset angles.
  */
@@ -66,14 +107,15 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
-    const colorOrder: number[] = useMemo(
-      () => words.map(() => Math.floor(Math.random() * 3)),
-      [words],
-    );
-
-    const tiltOrder: number[] = useMemo(
-      () => words.map(() => Math.floor(Math.random() * 9)),
-      [words],
+    const styledWords = useMemo(
+      () =>
+        words.map((word) => ({
+          text: word,
+          backgroundColor:
+            themeBackgroundColors[theme][Math.floor(Math.random() * 3)],
+          rotation: degreeOfTiltOptions[Math.floor(Math.random() * 9)],
+        })),
+      [theme, words],
     );
 
     return (
@@ -85,27 +127,19 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
         ref={ref}
         gap={gaps[size]}
       >
-        {words.map((word, index): ReactNode => {
-          return (
-            <Box
-              key={`${word}+${index}`}
-              backgroundColor={themeBackgroundColors[theme][colorOrder[index]]}
-              dangerouslySetInlineStyle={{
-                __style: {
-                  padding: paddings[size],
-                  transform: `rotate(${
-                    degreeOfTiltOptions[tiltOrder[index]]
-                  }deg)`,
-                },
-              }}
-              width="fit-content"
-            >
-              <Typography size={size} weight="bold" fontStyle="serif">
-                {word}
-              </Typography>
-            </Box>
-          );
-        })}
+        {styledWords.map(
+          ({ text, backgroundColor, rotation }, index): ReactNode => {
+            return (
+              <WordConfetto
+                backgroundColor={backgroundColor}
+                key={`${text}+${index}`}
+                rotation={rotation}
+                size={size}
+                text={text}
+              />
+            );
+          },
+        )}
       </Box>
     );
   },

--- a/packages/syntax-core/src/index.tsx
+++ b/packages/syntax-core/src/index.tsx
@@ -25,6 +25,7 @@ import TextField from "./TextField/TextField";
 import ThemeProvider from "./ThemeProvider/ThemeProvider";
 import Tooltip from "./Tooltip/Tooltip";
 import Typography from "./Typography/Typography";
+import WordConfetti from "./WordConfetti/WordConfetti";
 
 export {
   Avatar,
@@ -54,4 +55,5 @@ export {
   ThemeProvider,
   Tooltip,
   Typography,
+  WordConfetti,
 };


### PR DESCRIPTION
This PR implements a new component: [WordConfetti](https://www.figma.com/design/G3UM2urgAYO2iiNU7nlulI/Cambio-Syntax?node-id=6797-14375&t=IumHj4TBoZL5jIyc-0)

Default: direction row with flex wrap
<img width="397" alt="Screenshot 2024-08-05 at 3 33 07 PM" src="https://github.com/user-attachments/assets/c9abe141-49a5-4957-9c26-8cbe4cb391dd">

Default: column view
<img width="202" alt="Screenshot 2024-08-05 at 3 45 18 PM" src="https://github.com/user-attachments/assets/1e9fdde8-4a3d-40e1-8691-5a1a7ecb5863">

Extra long word: Confirmed with AJ and Casey that this is alright and okay for some cards to overlap slightly when tilted
<img width="356" alt="Screenshot 2024-08-05 at 3 46 23 PM" src="https://github.com/user-attachments/assets/68fe6fb9-ba75-4ee9-8007-9f48f38ce2af">

<img width="361" alt="Screenshot 2024-08-05 at 3 46 51 PM" src="https://github.com/user-attachments/assets/4b32d56a-311d-4214-ad51-7967700cb06c">

Cool theme:
<img width="390" alt="Screenshot 2024-08-05 at 3 47 18 PM" src="https://github.com/user-attachments/assets/905e8704-d17c-4200-b643-427581137175">

Warm theme:
<img width="385" alt="Screenshot 2024-08-05 at 3 47 41 PM" src="https://github.com/user-attachments/assets/09180fd4-2a84-4701-8220-280c2f3bfb05">
