### PR TITLE
WordConfetti: Fix WordConfetto key

### DIFF
--- a/.changeset/red-turtles-look.md
+++ b/.changeset/red-turtles-look.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+WordConfetti: Fix error with key

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -30,7 +30,6 @@ const gaps = {
 
 const WordConfetto = ({
   backgroundColor,
-  key,
   rotation,
   size,
   text,
@@ -45,14 +44,12 @@ const WordConfetto = ({
     | "red"
     | "tan"
     | "orange";
-  key: string;
   rotation: number;
   size: 300 | 400 | 700 | 800 | 900 | 1100;
   text: string;
 }): ReactElement => {
   return (
     <Box
-      key={key}
       backgroundColor={backgroundColor}
       dangerouslySetInlineStyle={{
         __style: {
@@ -131,8 +128,8 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
           ({ text, backgroundColor, rotation }, index): ReactNode => {
             return (
               <WordConfetto
-                backgroundColor={backgroundColor}
                 key={`${text}+${index}`}
+                backgroundColor={backgroundColor}
                 rotation={rotation}
                 size={size}
                 text={text}


### PR DESCRIPTION
Noticed an error in the console when developing in Cambly-FE about the key in WordConfetto. Removed it as an actual prop and fixed the issue. Tested by looking at the console in the local storybook

<img width="627" alt="Screenshot 2024-08-06 at 5 16 04 PM" src="https://github.com/user-attachments/assets/caab0758-9794-4230-9bf6-a1da76846fb5">
