### PR TITLE
[NOJIRA] Add indicatorColor prop to IconButton

### DIFF
--- a/.changeset/spicy-sheep-knock.md
+++ b/.changeset/spicy-sheep-knock.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Added new IconButton indicatorColor prop

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -2,6 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import IconButton from "./IconButton";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import StarFilled from "../../../syntax-icons/src/icons/StarFilled";
+import allColors from "../colors/allColors";
 import Box from "../Box/Box";
 
 import CalendarBooking from "../../../syntax-icons/src/icons/CalendarBooking";
@@ -23,6 +24,7 @@ export default {
     "data-testid": "",
     accessibilityLabel: "",
     tooltip: "",
+    indicatorColor: undefined,
   },
   argTypes: {
     color: {
@@ -52,6 +54,10 @@ export default {
       control: { type: "radio" },
     },
     onClick: { action: "clicked" },
+    indicatorColor: {
+      control: { type: "select" },
+      options: allColors,
+    },
   },
   tags: ["autodocs"],
 } as Meta<typeof IconButton>;
@@ -103,6 +109,19 @@ export const DestructiveTertiary: StoryObj<typeof IconButton> = {
 };
 export const DifferentIcon: StoryObj<typeof IconButton> = {
   args: { ...Default.args, icon: FavoriteBorder },
+};
+
+export const IndicatorColors: StoryObj<typeof IconButton> = {
+  args: { ...Default.args, icon: CalendarBooking },
+  render: (args) => {
+    return (
+      <Box display="flex" gap={4}>
+        {allColors.map((color) => (
+          <IconButton {...args} indicatorColor={color} key={color} />
+        ))}
+      </Box>
+    );
+  },
 };
 
 export const SyntaxIcons: StoryObj<typeof IconButton> = {

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -2,6 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import IconButton from "./IconButton";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import StarFilled from "../../../syntax-icons/src/icons/StarFilled";
+import Message from "../../../syntax-icons/src/icons/Message";
 import allColors from "../colors/allColors";
 import Box from "../Box/Box";
 
@@ -112,7 +113,7 @@ export const DifferentIcon: StoryObj<typeof IconButton> = {
 };
 
 export const IndicatorColors: StoryObj<typeof IconButton> = {
-  args: { ...Default.args, icon: CalendarBooking },
+  args: { ...Default.args, icon: Message },
   render: (args) => {
     return (
       <Box display="flex" gap={4}>

--- a/packages/syntax-core/src/IconButton/IconButton.test.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.test.tsx
@@ -32,6 +32,34 @@ describe("iconButton", () => {
     expect(button).toHaveLength(1);
   });
 
+  it.todo("renders an indicator when the indicator color is specified"),
+    async () => {
+      render(
+        <IconButton
+          onClick={() => {
+            /* empty */
+          }}
+          icon={Star}
+          accessibilityLabel="Star"
+        />,
+      );
+      const indicator = await screen.findAllByTestId("indicator");
+      expect(indicator).toHaveLength(0);
+
+      render(
+        <IconButton
+          onClick={() => {
+            /* empty */
+          }}
+          icon={Star}
+          accessibilityLabel="Star"
+          indicatorColor="black"
+        />,
+      );
+      const indicatorB = await screen.findAllByTestId("indicator");
+      expect(indicatorB).toHaveLength(1);
+    };
+
   it("sets an accessibility label", async () => {
     render(
       <IconButton

--- a/packages/syntax-core/src/IconButton/IconButton.test.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.test.tsx
@@ -74,7 +74,7 @@ describe("iconButton", () => {
     expect(button).toHaveLength(1);
   });
 
-  it("fires the onClick when clicked", async () => {
+  it("fires the onClick when it is clicked", async () => {
     const handleClick = vi.fn();
     render(
       <IconButton

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -11,6 +11,25 @@ import {
   materialIconSize,
   internalIconSize,
 } from "../Button/constants/iconSize";
+import Box from "../Box/Box";
+
+const sizeToIndicatorSize = {
+  sm: "6px",
+  md: "8px",
+  lg: "10px",
+} as const;
+
+type Color =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "destructive-primary"
+  | "destructive-secondary"
+  | "destructive-tertiary"
+  | "branded"
+  | "success-primary"
+  | "success-secondary"
+  | "success-tertiary";
 
 type IconButtonProps = {
   /**
@@ -18,17 +37,7 @@ type IconButtonProps = {
    *
    * @defaultValue "primary"
    */
-  color?:
-    | "primary"
-    | "secondary"
-    | "tertiary"
-    | "destructive-primary"
-    | "destructive-secondary"
-    | "destructive-tertiary"
-    | "branded"
-    | "success-primary"
-    | "success-secondary"
-    | "success-tertiary";
+  color?: Color;
   /**
    * Test id for the button
    */
@@ -69,6 +78,10 @@ type IconButtonProps = {
    */
   on?: "lightBackground" | "darkBackground";
   /**
+   * If specified, will create an indicator (dot) on the top right of the button with the specified color
+   */
+  indicatorColor?: ComponentProps<typeof Box>["backgroundColor"];
+  /**
    * The callback to be called when the button is clicked
    */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -92,6 +105,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       size = "md",
       tooltip,
       on = "lightBackground",
+      indicatorColor,
       onClick,
     }: IconButtonProps,
     ref,
@@ -121,6 +135,35 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
           className={materialIconSize[size]}
           size={internalIconSize[size]}
         />
+        {indicatorColor && (
+          <Box
+            display="flex"
+            position="relative"
+            justifyContent="end"
+            alignItems="end"
+          >
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              position="absolute"
+              backgroundColor={indicatorColor}
+              width={sizeToIndicatorSize[size]}
+              height={sizeToIndicatorSize[size]}
+              // marginBottom="-2px"
+              data-testid="indicator"
+              rounding="full"
+              dangerouslySetInlineStyle={{
+                __style: {
+                  border: "1px solid white",
+                  // top: -sizeToIndicatorSize[size] * 2,
+                  // right: -sizeToIndicatorSize[size] * 2,
+                  top: 0,
+                },
+              }}
+            />
+          </Box>
+        )}
       </button>
     );
   },

--- a/packages/syntax-core/src/IconButton/IconButton.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.tsx
@@ -19,6 +19,12 @@ const sizeToIndicatorSize = {
   lg: "10px",
 } as const;
 
+const sizeToVerticalOffset = {
+  sm: "-1px",
+  md: "-2px",
+  lg: "-3px",
+} as const;
+
 type Color =
   | "primary"
   | "secondary"
@@ -150,15 +156,12 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
               backgroundColor={indicatorColor}
               width={sizeToIndicatorSize[size]}
               height={sizeToIndicatorSize[size]}
-              // marginBottom="-2px"
               data-testid="indicator"
               rounding="full"
               dangerouslySetInlineStyle={{
                 __style: {
                   border: "1px solid white",
-                  // top: -sizeToIndicatorSize[size] * 2,
-                  // right: -sizeToIndicatorSize[size] * 2,
-                  top: 0,
+                  transform: `translateY(${sizeToVerticalOffset[size]})`,
                 },
               }}
             />


### PR DESCRIPTION
Background:
As part of the [Next NavBar project](https://www.figma.com/design/W3Qpau7j62wblnK7xIwJDV/%F0%9F%A7%B0-IA-2024?node-id=607-12586&m=dev) I need to add an indicator to the `MessageButton` (`IconButton`). 

Changes:
- Add `indicatorColor `prop that is typed the same as `Box`'s `backgroundColor` that shows in the top right corner when it's passed in otherwise it doesn't show anything.
- Updated stories and tests

Screenshots:
<img width="1081" alt="Screenshot 2024-08-07 at 7 38 16 PM" src="https://github.com/user-attachments/assets/6aaef5a1-3c3a-48e9-8ef4-2f558fd488b5">

