### PR TITLE
TextField: Add endBadge prop

### DIFF
--- a/.changeset/soft-garlics-allow.md
+++ b/.changeset/soft-garlics-allow.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TextField: Add endBadge prop

--- a/packages/syntax-core/src/TextField/TextField.stories.tsx
+++ b/packages/syntax-core/src/TextField/TextField.stories.tsx
@@ -17,6 +17,7 @@ export default {
     placeholder: "Placeholder",
     disabled: false,
     on: "lightBackground",
+    endBadge: "",
     errorText: "",
     helperText: "",
     type: "text",
@@ -33,6 +34,7 @@ export default {
     disabled: {
       control: "boolean",
     },
+    endBadge: { control: "text" },
     on: {
       options: ["lightBackground", "darkBackground"],
       control: { type: "radio" },
@@ -109,6 +111,11 @@ export const Default: StoryObj<typeof TextField> = {
 
 export const helperText: StoryObj<typeof TextField> = {
   args: { helperText: "Helper text" },
+  render: (args) => <TextFieldDefault {...args} />,
+};
+
+export const EndBadge: StoryObj<typeof TextField> = {
+  args: { endBadge: "Minutes" },
   render: (args) => <TextFieldDefault {...args} />,
 };
 

--- a/packages/syntax-core/src/TextField/TextField.test.tsx
+++ b/packages/syntax-core/src/TextField/TextField.test.tsx
@@ -42,6 +42,18 @@ describe("textField", () => {
     expect(screen.getByDisplayValue("Value")).toBeInTheDocument();
   });
 
+  it("displays the endBadge", () => {
+    render(
+      <TextField
+        label="TextField label"
+        value=""
+        onChange={() => undefined}
+        endBadge="Minutes"
+      />,
+    );
+    expect(screen.getByText("Minutes")).toBeInTheDocument();
+  });
+
   it("displays the error", () => {
     render(
       <TextField

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -8,6 +8,7 @@ import styles from "./TextField.module.css";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 import useIsHydrated from "../useIsHydrated";
+import Badge from "../Badge/Badge";
 
 /**
  * [TextField](https://cambly-syntax.vercel.app/?path=/docs/components-textfield--docs) is a component that allows users to enter text.
@@ -17,6 +18,7 @@ export default function TextField({
   "data-testid": dataTestId,
   disabled: disabledProp = false,
   on = "lightBackground",
+  endBadge,
   errorText = "",
   helperText = "",
   id,
@@ -50,6 +52,10 @@ export default function TextField({
    * @defaulValue `lightBackground`
    */
   on?: "lightBackground" | "darkBackground";
+  /**
+   * Text for endBadge shown at the end of the input field.
+   */
+  endBadge?: string;
   /**
    * Text shown below TextField if there is an input error.
    */
@@ -123,30 +129,48 @@ export default function TextField({
           </Box>
         </label>
       )}
-      <input
-        autoComplete={autoComplete}
-        className={classNames(
-          styles.textfield,
-          styles.md,
-          styles.height,
-          errorText &&
-            (on === "darkBackground"
-              ? styles.transparentInputError
-              : styles.inputError),
-          {
-            [styles.transparent]: on === "darkBackground",
-          },
+      <Box
+        display="flex"
+        position="relative"
+        justifyContent={endBadge ? "end" : "start"}
+      >
+        <input
+          autoComplete={autoComplete}
+          className={classNames(
+            styles.textfield,
+            styles.md,
+            styles.height,
+            errorText &&
+              (on === "darkBackground"
+                ? styles.transparentInputError
+                : styles.inputError),
+            {
+              [styles.transparent]: on === "darkBackground",
+            },
+          )}
+          data-testid={dataTestId}
+          disabled={disabled}
+          id={inputId}
+          maxLength={maxLength}
+          type={type}
+          onChange={onChange}
+          placeholder={placeholder}
+          value={value}
+          step={step}
+        />
+        {endBadge && (
+          <Box
+            position="absolute"
+            dangerouslySetInlineStyle={{ __style: { top: "25%" } }}
+            marginEnd={4}
+          >
+            <Badge
+              text={endBadge}
+              color={on === "lightBackground" ? "gray370" : "gray870"}
+            />
+          </Box>
         )}
-        data-testid={dataTestId}
-        disabled={disabled}
-        id={inputId}
-        maxLength={maxLength}
-        type={type}
-        onChange={onChange}
-        placeholder={placeholder}
-        value={value}
-        step={step}
-      />
+      </Box>
       {(helperText || errorText) && (
         <Box paddingX={1}>
           <Typography size={100} color={errorText ? errorTextColor : textColor}>


### PR DESCRIPTION
This idea/suggestion to add a [suffix](https://www.figma.com/design/G3UM2urgAYO2iiNU7nlulI/Cambio-Syntax?node-id=3290-9971&m=dev) to `TextField` came up in the syntax meeting today. It's easy for us to add this so submitting this now. Will play around with a startBadge prop in another PR.

lightBackground:
<img width="525" alt="Screenshot 2024-08-27 at 3 30 57 PM" src="https://github.com/user-attachments/assets/852d73e0-6ee5-4a68-b842-768bc7a08ba4">

darkBackground:
<img width="517" alt="Screenshot 2024-08-27 at 3 31 05 PM" src="https://github.com/user-attachments/assets/9136366e-705f-46ed-9bf2-5db3472ca864">

rtl:
<img width="522" alt="Screenshot 2024-08-27 at 3 32 52 PM" src="https://github.com/user-attachments/assets/f5cd81d6-5b87-4758-9e8c-dddbaba41649">

