### PR TITLE
Update colors on storybook

### DIFF
--- a/apps/storybook/stories/Colors.tsx
+++ b/apps/storybook/stories/Colors.tsx
@@ -51,6 +51,8 @@ export default function Colors() {
                     color:
                       [
                         "color-cambio-white",
+                        "color-cambio-white-40",
+                        "color-cambio-white-70",
                         "color-cambio-cream",
                         "color-cambio-pink",
                         "color-cambio-sky",


### PR DESCRIPTION
Currently, you can't see white-40 and white-70 in storybook, and it's because the font color is white instead of black

Before:
<img width="1164" alt="image" src="https://github.com/user-attachments/assets/0152ea68-9538-45e9-8048-135b11369e04">


After:
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/b6653aed-6bd5-40e9-8a4f-1c6d742cbcfc">
