### PR TITLE
TextArea, SelectList: Add on prop and update lightBackground/darkBackground colors

### DIFF
--- a/.changeset/small-apes-explode.md
+++ b/.changeset/small-apes-explode.md
@@ -2,4 +2,4 @@
 "@cambly/syntax-core": major
 ---
 
-TextArea, SelectList: Add on prop and update lightBackground/darkBackgroudn colors
+TextArea, SelectList: Add on prop and update lightBackground/darkBackground colors

--- a/.changeset/small-apes-explode.md
+++ b/.changeset/small-apes-explode.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": major
+---
+
+TextArea, SelectList: Add on prop and update lightBackground/darkBackgroudn colors

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -48,6 +48,18 @@
   color: var(--color-base-gray-800);
 }
 
+.transparent {
+  background: transparent;
+  border: 1px solid var(--color-cambio-white-40);
+  color: var(--color-cambio-white-70);
+}
+
+.transparent:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
+  color: var(--color-cambio-white-100);
+}
+
 .arrowIcon {
   display: flex;
   position: absolute;
@@ -74,8 +86,11 @@
   color: var(--color-base-gray-700);
 }
 
-.selectColorclear {
-  background-color: transparent;
-  border: none;
-  color: var(--color-cambio-white-100);
+.transparentInputError {
+  color: var(--color-cambio-destructive-370);
+  border: 1px solid var(--color-cambio-destructive-300);
+}
+
+.transparenInputError::placeholder {
+  color: var(--color-cambio-destructive-370);
 }

--- a/packages/syntax-core/src/SelectList/SelectList.stories.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.stories.tsx
@@ -17,6 +17,7 @@ export default {
   args: {
     "data-testid": "",
     label: "Label",
+    on: "lightBackground",
     placeholderText: "Placeholder",
     errorText: "",
     helperText: "Helper text",
@@ -28,6 +29,10 @@ export default {
   argTypes: {
     disabled: {
       control: "boolean",
+    },
+    on: {
+      options: ["lightBackground", "darkBackground"],
+      control: { type: "radio" },
     },
     onChange: { action: "clicked" },
     color: {
@@ -54,10 +59,42 @@ const Options = () => (
   </>
 );
 
+function SelectListDefault({
+  label = "Label",
+  placeholderText = "Placeholder",
+  selectedValue: initialValue = "",
+  ...rest
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <Box
+      padding={2}
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundImage:
+            rest.on === "darkBackground"
+              ? "linear-gradient(0deg, #000, #555 )"
+              : null,
+        },
+      }}
+    >
+      <SelectList
+        label={label}
+        placeholderText={placeholderText}
+        onChange={(event) => {
+          setValue(event.target.value);
+        }}
+        selectedValue={initialValue || value}
+        {...rest}
+      >
+        <Options />
+      </SelectList>
+    </Box>
+  );
+}
+
 export const Default: StoryObj<typeof SelectList> = {
-  args: {
-    children: <Options />,
-  },
+  render: (args) => <SelectListDefault {...args} />,
 };
 
 export const Error: StoryObj<typeof SelectList> = {
@@ -68,6 +105,7 @@ export const Error: StoryObj<typeof SelectList> = {
     label: "Label",
     placeholderText: "Placeholder",
   },
+  render: (args) => <SelectListDefault {...args} />,
 };
 
 const SelectListInteractive = ({
@@ -105,11 +143,11 @@ const SelectListInteractiveDark = ({
     <Box backgroundColor="black" padding={4}>
       <SelectList
         label="Label"
-        color="clear"
         helperText="Helper text"
         selectedValue={selectionValue}
         placeholderText={placeholderText}
         onChange={onChange}
+        on="darkBackground"
       >
         <Options />
       </SelectList>

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -34,7 +34,6 @@ export default function SelectList({
   onClick,
   placeholderText,
   selectedValue = "",
-  color = "white",
 }: {
   /**
    * One or more SelectList.Option components.
@@ -88,11 +87,6 @@ export default function SelectList({
    * Value of the currently selected option
    */
   selectedValue?: string;
-  /**
-   * Color of the select box
-   * @defaultValue white
-   */
-  color?: "white" | "clear";
 }): ReactElement {
   const reactId = useId();
   const isHydrated = useIsHydrated();
@@ -100,6 +94,11 @@ export default function SelectList({
   const selectId = id ?? reactId;
   const { isFocusVisible } = useFocusVisible();
   const [isFocused, setIsFocused] = useState(false);
+  const textColor = on === "darkBackground" ? "white" : "gray900";
+  const errorTextColor =
+    on !== "darkBackground"
+      ? "destructive-lightBackground"
+      : "destructive-darkBackground";
 
   const handleKeyDown: React.KeyboardEventHandler<HTMLSelectElement> = (
     event,
@@ -110,16 +109,11 @@ export default function SelectList({
     }
   };
 
-  const textColor = {
-    white: "gray700",
-    clear: "white",
-  } as const;
-
   const getArrowIconColor = () => {
     if (errorText) {
       return ColorBaseDestructive700;
     } else {
-      if (color === "clear") {
+      if (on === "darkBackground") {
         return ColorCambioWhite100;
       } else {
         return ColorBaseGray700;
@@ -136,7 +130,7 @@ export default function SelectList({
       {label && (
         <label htmlFor={selectId}>
           <Box paddingX={1}>
-            <Typography size={100} color={textColor[color]}>
+            <Typography size={100} color={textColor}>
               {label}
             </Typography>
           </Box>
@@ -154,7 +148,7 @@ export default function SelectList({
             [focusStyles.accessibilityOutlineFocus]:
               isFocused && isFocusVisible, // for focus keyboard
             [styles.selectMouseFocusStyling]: isFocused && !isFocusVisible, // for focus mouse
-            [styles[`selectColor${color}`]]: color,
+            [styles.transparent]: on === "darkBackground",
           })}
           onChange={onChange}
           onClick={onClick}
@@ -188,10 +182,7 @@ export default function SelectList({
       </div>
       {(helperText || errorText) && (
         <Box paddingX={1}>
-          <Typography
-            size={100}
-            color={errorText ? "destructive-primary" : textColor[color]}
-          >
+          <Typography size={100} color={errorText ? errorTextColor : textColor}>
             {errorText ? errorText : helperText}
           </Typography>
         </Box>

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -29,6 +29,7 @@ export default function SelectList({
   helperText,
   id,
   label,
+  on,
   onChange,
   onClick,
   placeholderText,
@@ -48,6 +49,12 @@ export default function SelectList({
    * @defaultValue false
    */
   disabled?: boolean;
+  /**
+   * Indicate whether the component renders on a light or dark background. Changes the color of the text
+   *
+   * @defaulValue `lightBackground`
+   */
+  on?: "lightBackground" | "darkBackground";
   /**
    * Callback to be called when select is clicked
    */

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -144,7 +144,9 @@ export default function SelectList({
           className={classNames(styles.selectBox, styles.selectBoxCambio, {
             [styles.unselected]: !selectedValue && !errorText,
             [styles.selected]: selectedValue && !errorText,
-            [styles.selectErrorCambio]: errorText,
+            [styles.selectErrorCambio]: errorText && on === "lightBackground",
+            [styles.transparentInputError]:
+              errorText && on === "darkBackground",
             [focusStyles.accessibilityOutlineFocus]:
               isFocused && isFocusVisible, // for focus keyboard
             [styles.selectMouseFocusStyling]: isFocused && !isFocusVisible, // for focus mouse

--- a/packages/syntax-core/src/TextArea/TextArea.stories.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.stories.tsx
@@ -1,4 +1,5 @@
 import { type StoryObj, type Meta } from "@storybook/react";
+import Box from "../Box/Box";
 import TextArea from "./TextArea";
 import React, { useState } from "react";
 
@@ -18,6 +19,7 @@ export default {
     errorText: "",
     helperText: "",
     maxLength: 1024,
+    on: "lightBackground",
     resize: "none",
     rows: 3,
     value: "",
@@ -27,6 +29,10 @@ export default {
   argTypes: {
     disabled: {
       control: "boolean",
+    },
+    on: {
+      options: ["lightBackground", "darkBackground"],
+      control: { type: "radio" },
     },
     placeholder: {
       control: "text",
@@ -47,15 +53,27 @@ function TextAreaDefault({
 }) {
   const [value, setValue] = useState("");
   return (
-    <TextArea
-      label={label}
-      placeholder={placeholder}
-      onChange={(event) => {
-        setValue(event.target.value);
+    <Box
+      padding={2}
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundImage:
+            args.on === "darkBackground"
+              ? "linear-gradient(0deg, #000, #555 )"
+              : null,
+        },
       }}
-      value={initialValue || value}
-      {...args}
-    />
+    >
+      <TextArea
+        label={label}
+        placeholder={placeholder}
+        onChange={(event) => {
+          setValue(event.target.value);
+        }}
+        value={initialValue || value}
+        {...args}
+      />
+    </Box>
   );
 }
 

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -36,6 +36,12 @@ type TextAreaProps = {
    */
   maxLength?: number;
   /**
+   * Indicate whether the button renders on a light or dark background. Changes the color of the input field and text
+   *
+   * @defaulValue `lightBackground`
+   */
+  on?: "lightBackground" | "darkBackground";
+  /**
    * Callback fired when the value is changed.
    */
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -79,6 +85,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       placeholder = "",
       rows = 3,
       value = "",
+      on,
       onChange,
       resize = "none",
     }: TextAreaProps,
@@ -88,6 +95,11 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const disabled = !isHydrated || disabledProp;
     const reactId = useId();
     const inputId = id ?? reactId;
+    const textColor = on === "darkBackground" ? "white" : "gray900";
+    const errorTextColor =
+      on !== "darkBackground"
+        ? "destructive-lightBackground"
+        : "destructive-darkBackground";
 
     return (
       <Box
@@ -105,7 +117,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {label && (
           <label className={textFieldStyles.label} htmlFor={inputId}>
             <Box paddingX={1}>
-              <Typography size={100} color="gray700">
+              <Typography size={100} color={textColor}>
                 {label}
               </Typography>
             </Box>
@@ -119,8 +131,12 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               textFieldStyles.textfield,
               styles.textarea,
               styles[`resize${resize}`],
+              errorText &&
+                (on === "darkBackground"
+                  ? textFieldStyles.transparentInputError
+                  : textFieldStyles.inputError),
               {
-                [textFieldStyles.inputError]: errorText,
+                [textFieldStyles.transparent]: on === "darkBackground",
               },
             )}
             id={inputId}
@@ -136,7 +152,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <Box paddingX={1}>
             <Typography
               size={100}
-              color={errorText ? "destructive-darkBackground" : "gray700"}
+              color={errorText ? errorTextColor : textColor}
             >
               {errorText || helperText}
             </Typography>

--- a/packages/syntax-core/src/TextArea/TextArea.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.tsx
@@ -36,7 +36,7 @@ type TextAreaProps = {
    */
   maxLength?: number;
   /**
-   * Indicate whether the button renders on a light or dark background. Changes the color of the input field and text
+   * Indicate whether the component renders on a light or dark background. Changes the color of the input field and text
    *
    * @defaulValue `lightBackground`
    */

--- a/packages/syntax-core/src/TextField/TextField.module.css
+++ b/packages/syntax-core/src/TextField/TextField.module.css
@@ -8,17 +8,25 @@
   margin: 0;
   width: 100%;
   font-size: 16px;
-}
-
-.transparent {
-  background: transparent;
-  border: 1px solid var(--color-cambio-white-100);
-  color: var(--color-cambio-white-100);
+  color: var(--color-cambio-gray-700);
 }
 
 .textfield:focus {
   outline: none;
   box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
+  color: var(--color-cambio-black);
+}
+
+.transparent {
+  background: transparent;
+  border: 1px solid var(--color-cambio-white-40);
+  color: var(--color-cambio-white-70);
+}
+
+.transparent:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
+  color: var(--color-cambio-white-100);
 }
 
 .textfield:disabled {

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -47,7 +47,7 @@ export default function TextField({
    */
   disabled?: boolean;
   /**
-   * Indicate whether the button renders on a light or dark background. Changes the color of the button
+   * Indicate whether the button renders on a light or dark background. Changes the color of the input field, text and badge
    *
    * @defaulValue `lightBackground`
    */

--- a/packages/syntax-core/src/TextField/TextField.tsx
+++ b/packages/syntax-core/src/TextField/TextField.tsx
@@ -47,7 +47,7 @@ export default function TextField({
    */
   disabled?: boolean;
   /**
-   * Indicate whether the button renders on a light or dark background. Changes the color of the input field, text and badge
+   * Indicate whether the component renders on a light or dark background. Changes the color of the input field, text and badge
    *
    * @defaulValue `lightBackground`
    */


### PR DESCRIPTION
[SYN-79](https://cambly.atlassian.net/browse/SYN-79)

This PR accomplishes the following:
- updates text, border colors for lightBackground/darkBackground and selected states for `TextField`
- adds `on` prop to `TextArea` and `SelectList`
- updates stories for all three components

TextField lightBackground:

https://github.com/user-attachments/assets/e0b84d29-b767-49a9-a6ef-54b7ee6fbee8

TextField lightBackground error state:

https://github.com/user-attachments/assets/b32ca24b-fff6-4131-9a7b-1775fd9351da


 TextField darkBackground and error state:

https://github.com/user-attachments/assets/0d7ac821-402f-41c9-890d-6e1043a4deb8



TextArea lightBackground and error state:

https://github.com/user-attachments/assets/1100ab15-81f6-4a13-af98-0255e797a7c8




TextArea darkBackground and error state:


https://github.com/user-attachments/assets/cf2d7760-ae52-48a5-ad5f-9066427a21db



SelectList lightBackground and error state:

https://github.com/user-attachments/assets/19990103-f763-4d0f-aa03-6fdf31199154




SelectList darkBackground and error state:

https://github.com/user-attachments/assets/c53b7b57-d27d-4c1b-85dd-5a9855771047









[SYN-79]: https://cambly.atlassian.net/browse/SYN-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ