### PR TITLE
Add yellow700 badge color

### DIFF
--- a/.changeset/giant-actors-develop.md
+++ b/.changeset/giant-actors-develop.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add yellow badge color

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -29,6 +29,7 @@ export default {
         "thistle",
         "pink",
         "cream",
+        "yellow700",
       ],
       control: { type: "radio" },
     },

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -16,6 +16,7 @@ const badgeColor = [
   "thistle",
   "pink",
   "cream",
+  "yellow700",
 ] as const;
 
 const textColorForBackgroundColor = (
@@ -32,6 +33,7 @@ const textColorForBackgroundColor = (
     case "pink":
     case "lilac":
     case "cream":
+    case "yellow700":
       return "gray900";
     default:
       return "white";


### PR DESCRIPTION
Need yellow badge for [this design](https://www.figma.com/design/0X1OjuIrbLVso9L5Zzizyb/Cambio-Subscription-%2B-Checkout-Page?node-id=309-3880&t=5snBRTiQhTfEydvD-4)


<img width="821" alt="Screenshot 2024-08-30 at 3 41 26 PM" src="https://github.com/user-attachments/assets/703f0d04-4b76-4f9c-97b8-77a3d9da6436">
