### PR TITLE
Dialog: Remove outline

### DIFF
--- a/.changeset/shaggy-jars-hope.md
+++ b/.changeset/shaggy-jars-hope.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Dialog: remove outline

--- a/packages/syntax-core/src/Dialog/Dialog.module.css
+++ b/packages/syntax-core/src/Dialog/Dialog.module.css
@@ -1,3 +1,4 @@
 .dialog {
+  outline: none;
   min-width: var(--trigger-width);
 }

--- a/packages/syntax-core/src/Dialog/Dialog.module.css
+++ b/packages/syntax-core/src/Dialog/Dialog.module.css
@@ -1,8 +1,3 @@
 .dialog {
   min-width: var(--trigger-width);
 }
-
-.dialog:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000, var(--elevation-400);
-}


### PR DESCRIPTION
[SYN-78](https://cambly.atlassian.net/browse/SYN-78)

Remove the outline from Dialog when it is launched (video is from Popover that uses Dialog):


https://github.com/user-attachments/assets/bb8ef56b-8fb9-4ff3-887b-8f69e2691dcc



[SYN-78]: https://cambly.atlassian.net/browse/SYN-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ