### PR TITLE
Tabs: update hover state padding

### DIFF
--- a/.changeset/wise-drinks-cheat.md
+++ b/.changeset/wise-drinks-cheat.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Tabs: Update padding on hover state

--- a/packages/syntax-core/src/Tabs/TabInternal.tsx
+++ b/packages/syntax-core/src/Tabs/TabInternal.tsx
@@ -99,7 +99,7 @@ export default function TabInternal({
       alignItems="center"
       justifyContent="start"
       gap={2}
-      paddingY={2}
+      padding={2}
     >
       <Typography
         size={0}


### PR DESCRIPTION
We have a UI issue with Tabs -- the hover state horizontal-padding is 0 which makes it look a bit ugly. This will fix that, but introduces another aesthetic issue, where the underline extends past the text. We've decided that this was fine, and is the better of two options
https://cambly.slack.com/archives/C033ZPY5M46/p1725925324938419

Before:
<img width="222" alt="image" src="https://github.com/user-attachments/assets/56681abc-6e94-48a6-82af-e5ef7f94eb9e">

After:
<img width="247" alt="image" src="https://github.com/user-attachments/assets/eea9c753-abd6-45bf-b0ce-a831e2f20455">

