### PR TITLE
Fix selectList darkbackground error on windows

### DIFF
--- a/.changeset/empty-beers-listen.md
+++ b/.changeset/empty-beers-listen.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+SelectList error on windows

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -48,13 +48,13 @@
   color: var(--color-base-gray-800);
 }
 
-.transparent {
-  background: transparent;
+.darkBackground {
+  background: var(--color-cambio-gray-900);
   border: 1px solid var(--color-cambio-white-40);
   color: var(--color-cambio-white-70);
 }
 
-.transparent:focus {
+.darkBackground:focus {
   outline: none;
   box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000;
   color: var(--color-cambio-white-100);

--- a/packages/syntax-core/src/SelectList/SelectList.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.tsx
@@ -150,7 +150,7 @@ export default function SelectList({
             [focusStyles.accessibilityOutlineFocus]:
               isFocused && isFocusVisible, // for focus keyboard
             [styles.selectMouseFocusStyling]: isFocused && !isFocusVisible, // for focus mouse
-            [styles.transparent]: on === "darkBackground",
+            [styles.darkBackground]: on === "darkBackground",
           })}
           onChange={onChange}
           onClick={onClick}


### PR DESCRIPTION
There are some differences between select in Windows and Mac. On dark mode, if the background color is not set, it will cause the options container for select on Windows to have a default white background. Resulting in the inability to display white text. So we need to specify the background color for select
![image](https://github.com/user-attachments/assets/25e4f10a-f8c3-4e03-aa07-1796a887b496)
