### PR TITLE
WordConfetti: add simple hashing function

### DIFF
--- a/.changeset/spicy-ladybugs-try.md
+++ b/.changeset/spicy-ladybugs-try.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+WordConfetti: add hashing function

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
@@ -26,4 +26,22 @@ describe("wordConfetti", () => {
     expect(screen.getByText("test")).toBeInTheDocument();
     expect(screen.getByText("word")).toBeInTheDocument();
   });
+
+  it("returns a consistent color and tilt for words", () => {
+    render(
+      <WordConfetti
+        size={300}
+        theme="neutral"
+        words={["test", "word", "confetti"]}
+      />,
+    );
+
+    const confetti = screen.getByTestId("confetti");
+    expect(confetti.getAttribute("style")).toMatchInlineSnapshot(
+      `"padding: 16px 20px 16px 20px; transform: rotate(3deg);"`,
+    );
+    expect(confetti.className).toMatchInlineSnapshot(
+      `"_box_b2ac18 _thistleBackgroundColor_0d99d4"`,
+    );
+  });
 });

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, forwardRef, useMemo, type ReactElement } from "react";
+import {
+  type ReactNode,
+  forwardRef,
+  useMemo,
+  type ReactElement,
+  useCallback,
+} from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
@@ -8,7 +14,7 @@ const themeBackgroundColors = {
   warm: ["red", "tan", "orange"],
 } as const;
 
-const degreeOfTiltOptions = [-6, -6, -3, -3, 0, 3, 3, 6, 6];
+const degreeOfTiltOptions = [-6, -3, 0, 3, 6];
 
 const paddings = {
   300: "16px 20px 16px 20px",
@@ -104,15 +110,25 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
+    const hashCode = useCallback((string: string) => {
+      let hash = 0;
+      if (string.length === 0) return hash;
+      for (let i = 0; i < string.length; i++) {
+        const char = string.charCodeAt(i);
+        hash = (hash << 5) - hash + char;
+        hash |= 0; // Convert to 32bit integer
+      }
+      return Math.abs(hash);
+    }, []);
+
     const styledWords = useMemo(
       () =>
         words.map((word) => ({
           text: word,
-          backgroundColor:
-            themeBackgroundColors[theme][Math.floor(Math.random() * 3)],
-          rotation: degreeOfTiltOptions[Math.floor(Math.random() * 9)],
+          backgroundColor: themeBackgroundColors[theme][hashCode(word) % 3],
+          rotation: degreeOfTiltOptions[hashCode(word) % 5],
         })),
-      [theme, words],
+      [hashCode, theme, words],
     );
 
     return (

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,10 +1,4 @@
-import {
-  type ReactNode,
-  forwardRef,
-  useMemo,
-  type ReactElement,
-  useCallback,
-} from "react";
+import { type ReactNode, forwardRef, useMemo, type ReactElement } from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
@@ -56,6 +50,7 @@ const WordConfetto = ({
 }): ReactElement => {
   return (
     <Box
+      data-testid={text}
       backgroundColor={backgroundColor}
       dangerouslySetInlineStyle={{
         __style: {
@@ -97,6 +92,17 @@ type WordConfettiProps = {
   words: string[];
 };
 
+const hashCode = (string: string): number => {
+  let hash = 0;
+  if (string.length === 0) return hash;
+  for (let i = 0; i < string.length; i++) {
+    const char = string.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+};
+
 /**
  * [WordConfetti](https://cambly-syntax.vercel.app/?path=/docs/components-wordconfetti--docs) is a container for displaying words in different color themes and fun offset angles.
  */
@@ -110,17 +116,6 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
-    const hashCode = useCallback((string: string) => {
-      let hash = 0;
-      if (string.length === 0) return hash;
-      for (let i = 0; i < string.length; i++) {
-        const char = string.charCodeAt(i);
-        hash = (hash << 5) - hash + char;
-        hash |= 0; // Convert to 32bit integer
-      }
-      return Math.abs(hash);
-    }, []);
-
     const styledWords = useMemo(
       () =>
         words.map((word) => ({
@@ -128,7 +123,7 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
           backgroundColor: themeBackgroundColors[theme][hashCode(word) % 3],
           rotation: degreeOfTiltOptions[hashCode(word) % 5],
         })),
-      [hashCode, theme, words],
+      [theme, words],
     );
 
     return (


### PR DESCRIPTION
With word confetti, we were still getting an issue of the word color and tilt changing on rerender (the useMemo originally implemented wasn't working).

This PR adds a simple hashing function so the same word will always have the same color and tilt


https://github.com/user-attachments/assets/2fd15dd7-3670-421c-8837-cd593a1330f4

