### PR TITLE
WordConfetti: add simple hashing function (follow up)

### DIFF
--- a/.changeset/spicy-ladybugs-try.md
+++ b/.changeset/spicy-ladybugs-try.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+WordConfetti: add hashing function

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
@@ -28,20 +28,62 @@ describe("wordConfetti", () => {
   });
 
   it("returns a consistent color and tilt for words", () => {
+    const wordsWithRotation = [
+      {
+        word: "a",
+        rotation: "0deg",
+        backgroundColor: "lilac",
+      },
+      {
+        word: "b",
+        rotation: "3deg",
+        backgroundColor: "thistle",
+      },
+      {
+        word: "c",
+        rotation: "6deg",
+        backgroundColor: "pink",
+      },
+      {
+        word: "d",
+        rotation: "-6deg",
+        backgroundColor: "lilac",
+      },
+      {
+        word: "e",
+        rotation: "-3deg",
+        backgroundColor: "thistle",
+      },
+      {
+        word: "f",
+        rotation: "0deg",
+        backgroundColor: "pink",
+      },
+      {
+        word: "g",
+        rotation: "3deg",
+        backgroundColor: "lilac",
+      },
+      {
+        word: "h",
+        rotation: "6deg",
+        backgroundColor: "thistle",
+      },
+    ] as const;
+
     render(
       <WordConfetti
+        data-testid="confetti"
         size={300}
         theme="neutral"
-        words={["test", "word", "confetti"]}
+        words={wordsWithRotation.map((word) => word.word)}
       />,
     );
 
-    const confetti = screen.getByTestId("confetti");
-    expect(confetti.getAttribute("style")).toMatchInlineSnapshot(
-      `"padding: 16px 20px 16px 20px; transform: rotate(3deg);"`,
-    );
-    expect(confetti.className).toMatchInlineSnapshot(
-      `"_box_b2ac18 _thistleBackgroundColor_0d99d4"`,
-    );
+    Object.entries(wordsWithRotation).forEach(([index, word]) => {
+      const confetto = screen.getByTestId(`confetti-${index}`);
+      expect(confetto.getAttribute("style")).toContain(word.rotation);
+      expect(confetto.className).toContain(word.backgroundColor);
+    });
   });
 });

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.test.tsx
@@ -26,4 +26,22 @@ describe("wordConfetti", () => {
     expect(screen.getByText("test")).toBeInTheDocument();
     expect(screen.getByText("word")).toBeInTheDocument();
   });
+
+  it("returns a consistent color and tilt for words", () => {
+    render(
+      <WordConfetti
+        size={300}
+        theme="neutral"
+        words={["test", "word", "confetti"]}
+      />,
+    );
+
+    const confetti = screen.getByTestId("confetti");
+    expect(confetti.getAttribute("style")).toMatchInlineSnapshot(
+      `"padding: 16px 20px 16px 20px; transform: rotate(3deg);"`,
+    );
+    expect(confetti.className).toMatchInlineSnapshot(
+      `"_box_b2ac18 _thistleBackgroundColor_0d99d4"`,
+    );
+  });
 });

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, forwardRef, useMemo, type ReactElement } from "react";
+import {
+  type ReactNode,
+  forwardRef,
+  useMemo,
+  type ReactElement,
+  useCallback,
+} from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
@@ -8,7 +14,7 @@ const themeBackgroundColors = {
   warm: ["red", "tan", "orange"],
 } as const;
 
-const degreeOfTiltOptions = [-6, -6, -3, -3, 0, 3, 3, 6, 6];
+const degreeOfTiltOptions = [-6, -3, 0, 3, 6];
 
 const paddings = {
   300: "16px 20px 16px 20px",
@@ -104,15 +110,25 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
+    const hashCode = useCallback((string: string) => {
+      let hash = 0;
+      if (string.length === 0) return hash;
+      for (let i = 0; i < string.length; i++) {
+        const char = string.charCodeAt(i);
+        hash = (hash << 5) - hash + char;
+        hash |= 0; // Convert to 32bit integer
+      }
+      return Math.abs(hash);
+    }, []);
+
     const styledWords = useMemo(
       () =>
         words.map((word) => ({
           text: word,
-          backgroundColor:
-            themeBackgroundColors[theme][Math.floor(Math.random() * 3)],
-          rotation: degreeOfTiltOptions[Math.floor(Math.random() * 9)],
+          backgroundColor: themeBackgroundColors[theme][hashCode(word) % 3],
+          rotation: degreeOfTiltOptions[hashCode(word) % 5],
         })),
-      [theme, words],
+      [hashCode, theme, words],
     );
 
     return (

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, forwardRef, useMemo, type ReactElement } from "react";
+import { type ReactNode, forwardRef, type ReactElement } from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
@@ -8,7 +8,7 @@ const themeBackgroundColors = {
   warm: ["red", "tan", "orange"],
 } as const;
 
-const degreeOfTiltOptions = [-6, -3, 0, 3, 6];
+const degreeOfTiltOptions = [-6, -3, 0, 3, 6] as const;
 
 const paddings = {
   300: "16px 20px 16px 20px",
@@ -28,29 +28,38 @@ const gaps = {
   1100: 10,
 } as const;
 
+const hashWord = (string: string): number => {
+  let hash = 0;
+  if (string.length === 0) return hash;
+  for (let i = 0; i < string.length; i++) {
+    const char = string.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+};
+
 const WordConfetto = ({
-  backgroundColor,
-  rotation,
+  "data-testid": dataTestId,
   size,
   text,
+  theme,
 }: {
-  backgroundColor:
-    | "pink"
-    | "lilac"
-    | "thistle"
-    | "sky"
-    | "slate"
-    | "teal"
-    | "red"
-    | "tan"
-    | "orange";
-  rotation: number;
+  "data-testid"?: string;
   size: 300 | 400 | 700 | 800 | 900 | 1100;
   text: string;
+  theme: "neutral" | "cool" | "warm";
 }): ReactElement => {
+  const hash = hashWord(text);
+  const backgroundColor =
+    themeBackgroundColors[theme][
+      hash % Object.values(themeBackgroundColors[theme]).length
+    ];
+  const rotation = degreeOfTiltOptions[hash % degreeOfTiltOptions.length];
+
   return (
     <Box
-      data-testid={text}
+      data-testid={dataTestId}
       backgroundColor={backgroundColor}
       dangerouslySetInlineStyle={{
         __style: {
@@ -92,17 +101,6 @@ type WordConfettiProps = {
   words: string[];
 };
 
-const hashCode = (string: string): number => {
-  let hash = 0;
-  if (string.length === 0) return hash;
-  for (let i = 0; i < string.length; i++) {
-    const char = string.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash |= 0; // Convert to 32bit integer
-  }
-  return Math.abs(hash);
-};
-
 /**
  * [WordConfetti](https://cambly-syntax.vercel.app/?path=/docs/components-wordconfetti--docs) is a container for displaying words in different color themes and fun offset angles.
  */
@@ -116,16 +114,6 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
-    const styledWords = useMemo(
-      () =>
-        words.map((word) => ({
-          text: word,
-          backgroundColor: themeBackgroundColors[theme][hashCode(word) % 3],
-          rotation: degreeOfTiltOptions[hashCode(word) % 5],
-        })),
-      [theme, words],
-    );
-
     return (
       <Box
         display="flex"
@@ -135,19 +123,17 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
         ref={ref}
         gap={gaps[size]}
       >
-        {styledWords.map(
-          ({ text, backgroundColor, rotation }, index): ReactNode => {
-            return (
-              <WordConfetto
-                key={`${text}+${index}`}
-                backgroundColor={backgroundColor}
-                rotation={rotation}
-                size={size}
-                text={text}
-              />
-            );
-          },
-        )}
+        {words.map((word, index): ReactNode => {
+          return (
+            <WordConfetto
+              data-testid={dataTestId ? `${dataTestId}-${index}` : undefined}
+              key={`${word}${index}`}
+              size={size}
+              text={word}
+              theme={theme}
+            />
+          );
+        })}
       </Box>
     );
   },

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.tsx
@@ -1,10 +1,4 @@
-import {
-  type ReactNode,
-  forwardRef,
-  useMemo,
-  type ReactElement,
-  useCallback,
-} from "react";
+import { type ReactNode, forwardRef, useMemo, type ReactElement } from "react";
 import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
@@ -56,6 +50,7 @@ const WordConfetto = ({
 }): ReactElement => {
   return (
     <Box
+      data-testid={text}
       backgroundColor={backgroundColor}
       dangerouslySetInlineStyle={{
         __style: {
@@ -97,6 +92,17 @@ type WordConfettiProps = {
   words: string[];
 };
 
+const hashCode = (string: string): number => {
+  let hash = 0;
+  if (string.length === 0) return hash;
+  for (let i = 0; i < string.length; i++) {
+    const char = string.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+};
+
 /**
  * [WordConfetti](https://cambly-syntax.vercel.app/?path=/docs/components-wordconfetti--docs) is a container for displaying words in different color themes and fun offset angles.
  */
@@ -110,17 +116,6 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
       words,
     } = props;
 
-    const hashCode = useCallback((string: string) => {
-      let hash = 0;
-      if (string.length === 0) return hash;
-      for (let i = 0; i < string.length; i++) {
-        const char = string.charCodeAt(i);
-        hash = (hash << 5) - hash + char;
-        hash |= 0; // Convert to 32bit integer
-      }
-      return Math.abs(hash);
-    }, []);
-
     const styledWords = useMemo(
       () =>
         words.map((word) => ({
@@ -128,7 +123,7 @@ const WordConfetti = forwardRef<HTMLDivElement, WordConfettiProps>(
           backgroundColor: themeBackgroundColors[theme][hashCode(word) % 3],
           rotation: degreeOfTiltOptions[hashCode(word) % 5],
         })),
-      [hashCode, theme, words],
+      [theme, words],
     );
 
     return (


### PR DESCRIPTION
Follow up to https://github.com/Cambly/syntax/pull/556 with the following changes

1. Update tests so we deterministically determine the rotation & background color
2. Remove `useMemo` usage since we no longer perform 2 maps over the words array
3. Use `.length` instead of specific `3` or `5` number when getting the rotation & background color