### PR TITLE
ZIndex: base implementation + story

### DIFF
--- a/.changeset/fast-poets-wash.md
+++ b/.changeset/fast-poets-wash.md
@@ -1,0 +1,6 @@
+---
+"@cambly/syntax-core": minor
+"@syntax/storybook": minor
+---
+
+ZIndex: basic implementation + story

--- a/apps/storybook/stories/ZIndex.stories.mdx
+++ b/apps/storybook/stories/ZIndex.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta } from "@storybook/addon-docs";
+import ZIndex from "./ZIndex";
+
+<Meta title="z-Index" />
+
+# z-Index
+
+[getZIndex](https://cambly-syntax.vercel.app/?path=/docs/z-index--docs) is a utility function that returns a z-index value based on the layer and local layer.
+
+## Parameters
+
+- `layer`: The layer to get the z-index for.
+
+  - Default: `base`
+  - Options:
+    - `base`: 0 // base layer
+    - `menu`: 10 // example: dropdown menus
+    - `sticky`: 20 // example: sticky headers
+    - `fixed`: 30 // example: fixed position elements
+    - `modal`: 40 // example: modals
+    - `popup`: 50 // example: tooltips or popovers
+
+- `localLayer`: An optional parameter to manually tweak the z-index within each layer.
+  - Usage:
+    - getZIndex recognizes that there are occasional needs to have multiple things stacked in the same layer.
+    - For example, two modals existing in the same layer. In these occasions, you can pass a localLayer to the function to manually tweak the z-index within each layer.
+  - Default: `0`
+  - Options: `-3` | `-2` | `-1` | `0` | `1` | `2` | `3`
+
+<ZIndex />

--- a/apps/storybook/stories/ZIndex.tsx
+++ b/apps/storybook/stories/ZIndex.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from "react";
+import Box from "../../../packages/syntax-core/src/Box/Box";
+import Button from "../../../packages/syntax-core/src/Button/Button";
+import Typography from "../../../packages/syntax-core/src/Typography/Typography";
+import Modal from "../../../packages/syntax-core/src/Modal/Modal";
+import getZIndex from "../../../packages/syntax-core/src/getZIndex";
+
+export default function ZIndex() {
+  const [currentZIndex, setCurrentZIndex] = useState(-10);
+  const [openModal, setOpenModal] = useState(false);
+
+  return (
+    <Box display="flex" direction="column" gap={4}>
+      <Box>
+        <Typography size={400} weight="medium">
+          Current Z-Index: {currentZIndex}
+        </Typography>
+        <Box display="flex" gap={4}>
+          <Button
+            text="Increase Z-Index Layer"
+            onClick={() => setCurrentZIndex(currentZIndex + 10)}
+          />
+          <Button
+            text="Decrease Z-Index Layer"
+            onClick={() => setCurrentZIndex(currentZIndex - 10)}
+          />
+          <Button text="Open Modal" onClick={() => setOpenModal(true)} />
+        </Box>
+      </Box>
+      <Box
+        height={1000}
+        width="100%"
+        backgroundColor="gray100"
+        display="flex"
+        direction="column"
+        gap={4}
+        dangerouslySetInlineStyle={{
+          __style: {
+            border: "1px solid black",
+          },
+        }}
+      >
+        <Box position="relative">
+          <Box
+            position="absolute"
+            width="100%"
+            height={1000}
+            dangerouslySetInlineStyle={{
+              __style: {
+                backgroundColor: "darkgray",
+                zIndex: currentZIndex,
+              },
+            }}
+          />
+        </Box>
+        <Box
+          width="100%"
+          height={64}
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          dangerouslySetInlineStyle={{
+            __style: {
+              backgroundColor: "lightblue",
+              zIndex: getZIndex("sticky"),
+            },
+          }}
+        >
+          Theoretical sticky navbar (sticky layer)
+        </Box>
+
+        <Box display="flex" direction="column">
+          <Box
+            width="100%"
+            height={200}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            dangerouslySetInlineStyle={{
+              __style: {
+                backgroundColor: "lightgreen",
+                zIndex: getZIndex("base"),
+              },
+            }}
+          >
+            Theoretical main content (base layer)
+          </Box>
+
+          <Box
+            width="100%"
+            height={200}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            dangerouslySetInlineStyle={{
+              __style: {
+                backgroundColor: "#E6E6FA",
+                zIndex: getZIndex("menu"),
+              },
+            }}
+          >
+            Theoretical menu content (menu layer)
+          </Box>
+
+          <Box
+            width="100%"
+            height={200}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            dangerouslySetInlineStyle={{
+              __style: {
+                backgroundColor: "#FFB6C1",
+                zIndex: getZIndex("fixed"),
+              },
+            }}
+          >
+            Theoretical fixed content (fixed layer)
+          </Box>
+        </Box>
+      </Box>
+
+      {openModal && (
+        <Modal
+          header="Theoretical Modal"
+          onDismiss={() => setOpenModal(false)}
+          zIndex={getZIndex("modal")}
+        >
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                backgroundColor: "#FFCC99",
+              },
+            }}
+          >
+            <Typography>Theoretical modal content (modal layer)</Typography>
+            <Typography>
+              tiny bug on this page, backdrop doesnt show because of no color
+              tokens but this is just used to demonstrate the layers!
+            </Typography>
+          </Box>
+        </Modal>
+      )}
+    </Box>
+  );
+}

--- a/packages/syntax-core/src/getZIndex.ts
+++ b/packages/syntax-core/src/getZIndex.ts
@@ -1,0 +1,36 @@
+/**
+ * [getZIndex](https://cambly-syntax.vercel.app/?path=/docs/ZIndex--docs) is a utility function that returns a z-index value based on the layer and local layer.
+ */
+export default function getZIndex(
+  /**
+   * The layer to get the z-index for.
+   *
+   * * `base`: 0 // base layer
+   * * `menu`: 10 // example: dropdown menus
+   * * `sticky`: 20 // example: sticky headers
+   * * `fixed`: 30 // example: fixed position elements
+   * * `modal`: 40 // example: modals
+   * * `popup`: 50 // example: tooltips or popovers
+   *
+   * @defaultValue `base`
+   */
+  layer: "base" | "menu" | "sticky" | "fixed" | "modal" | "popup" = "base",
+  /**
+   * getZIndex recognizes that there are occasional needs to have multiple things stacked in the same layer.
+   * For example, two modals existing in the same layer. In these occasions, you can pass a localLayer to the function to manually tweak the z-index within each layer.
+   *
+   * @defaultValue `0`
+   */
+  localLayer: -3 | -2 | -1 | 0 | 1 | 2 | 3 = 0,
+): number {
+  const layerIndex = {
+    base: 0,
+    menu: 10,
+    sticky: 20,
+    fixed: 30,
+    modal: 40,
+    popup: 50,
+  };
+
+  return layerIndex[layer] + localLayer;
+}


### PR DESCRIPTION
Z-Index implementation based off of [Outlayers UI Layer System](https://medium.com/@bernardocardoso/outsystems-ui-layer-system-managing-z-index-at-scale-68dca9e543de)

Basically has 6 "groups" of layers. and a `localLayer` prop to adjust between the layers if necessary

![image](https://github.com/user-attachments/assets/e6bbf0df-28e2-4d80-a0a9-bfabc6396c32)
