### PR TITLE
TapArea: add fullHeight prop

### DIFF
--- a/.changeset/dry-berries-joke.md
+++ b/.changeset/dry-berries-joke.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+TapArea: add fullHeight prop

--- a/packages/syntax-core/src/TapArea/TapArea.module.css
+++ b/packages/syntax-core/src/TapArea/TapArea.module.css
@@ -2,6 +2,10 @@
   box-sizing: border-box;
 }
 
+.fullHeight {
+  height: 100%;
+}
+
 .fullWidth {
   width: 100%;
 }

--- a/packages/syntax-core/src/TapArea/TapArea.test.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.test.tsx
@@ -56,6 +56,20 @@ describe("tapArea", () => {
     expect(tapArea).toHaveStyle({ width: "100%" });
   });
 
+  it("correctly applies fullHeight when set", async () => {
+    render(
+      <TapArea
+        data-testid="tap-area-testid"
+        onClick={() => {
+          /* empty */
+        }}
+        fullHeight
+      />,
+    );
+    const tapArea = await screen.findByTestId("tap-area-testid");
+    expect(tapArea).toHaveStyle({ height: "100%" });
+  });
+
   it("sets an accessibility label", async () => {
     render(
       <TapArea

--- a/packages/syntax-core/src/TapArea/TapArea.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.tsx
@@ -29,6 +29,10 @@ type TapAreaProps = AriaAttributes & {
    */
   disabled?: boolean;
   /**
+   * If `true`, the tap area will be full height
+   */
+  fullHeight?: boolean;
+  /**
    * If `true`, the tap area will be full width
    */
   fullWidth?: boolean;
@@ -94,6 +98,7 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
       accessibilityLabel,
       "data-testid": dataTestId,
       disabled: disabledProp = false,
+      fullHeight = false,
       fullWidth = true,
       onClick,
       onMouseEnter,
@@ -158,6 +163,7 @@ const TapArea = forwardRef<HTMLDivElement, TapAreaProps>(
         className={classNames(
           styles.tapArea,
           styles[`${disabled ? "disabled" : "enabled"}`],
+          fullHeight && styles.fullHeight,
           fullWidth && styles.fullWidth,
           isHoveredOrFocussed && styles.hoveredOrFocussed,
           roundingClasses,


### PR DESCRIPTION
Just like we already have a `fullWidth` prop on `TapArea`, we should also have a `fullHeight`. It'll allow us to fix the following issue where we want the `height` of the items to be the same:

![Screenshot 2024-10-04 at 4 51 11 AM](https://github.com/user-attachments/assets/fe2de8c8-3f23-42a5-a0bc-0b43fcd6b75f)
