### PR TITLE
Badge: always capitalize text

### DIFF
--- a/.changeset/polite-crabs-shout.md
+++ b/.changeset/polite-crabs-shout.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Badge: Always capitalize text

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -87,6 +87,7 @@ const Badge = ({
             color={textColorForBackgroundColor(color)}
             size={100}
             weight="medium"
+            transform="uppercase"
           >
             {text}
           </Typography>


### PR DESCRIPTION
Always capitalize text in badges 
https://cambly.slack.com/archives/C033ZPY5M46/p1727309871629329

Before:
<img width="164" alt="Screenshot 2024-10-10 at 4 35 22 PM" src="https://github.com/user-attachments/assets/94ab7afd-0e7d-4726-bfd0-9d5388372a9e">

After:
<img width="164" alt="Screenshot 2024-10-10 at 4 34 59 PM" src="https://github.com/user-attachments/assets/5e3a36ef-15c2-4ca6-99d3-ca2250d8a42f">
