### PR TITLE
Fix typo on identity document icon

### DIFF
--- a/.changeset/healthy-news-enjoy.md
+++ b/.changeset/healthy-news-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@syntax/storybook": minor
+---
+
+fix typo for identity document

--- a/packages/syntax-icons/src/Icons.stories.tsx
+++ b/packages/syntax-icons/src/Icons.stories.tsx
@@ -60,7 +60,7 @@ import HeartFilled from "./icons/HeartFilled";
 import HeartUnfilled from "./icons/HeartUnfilled";
 import Help from "./icons/Help";
 import Home from "./icons/Home";
-import IdentifyDocument from "./icons/IdentityDocument";
+import IdentityDocument from "./icons/IdentityDocument";
 import Information from "./icons/Information";
 import Joystick from "./icons/Joystick";
 import Keyboard from "./icons/Keyboard";
@@ -177,7 +177,7 @@ const cambioIcons = [
   { name: "HeartUnfilled", component: HeartUnfilled },
   { name: "Help", component: Help },
   { name: "Home", component: Home },
-  { name: "IdentifyDocument", component: IdentifyDocument },
+  { name: "IdentityDocument", component: IdentityDocument },
   { name: "Information", component: Information },
   { name: "Joystick", component: Joystick },
   { name: "Keyboard", component: Keyboard },


### PR DESCRIPTION
- before
<img width="207" alt="Screenshot 2024-10-14 at 11 18 02 AM" src="https://github.com/user-attachments/assets/a03d0787-08d6-48f2-9e6c-ff32ebcbbf9b">

- after
<img width="559" alt="image" src="https://github.com/user-attachments/assets/be72ba6e-b27c-4bc2-bbb5-ec8684c19be5">
