### PR TITLE
[WEB-5 SYNTAX] white40 updates

### DIFF
--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -233,7 +233,14 @@ export const BackgroundColor: StoryObj<typeof Box> = {
           <Box key={color} backgroundColor={color} width={240} padding={2}>
             <Typography
               color={
-                ["gray10", "gray30", "white", "cream"].includes(color) ||
+                [
+                  "gray10",
+                  "gray30",
+                  "white",
+                  "cream",
+                  "white40",
+                  "white70",
+                ].includes(color) ||
                 (number && parseInt(number) < 400)
                   ? "gray900"
                   : "white"

--- a/packages/syntax-core/src/colors/allColors.ts
+++ b/packages/syntax-core/src/colors/allColors.ts
@@ -42,8 +42,6 @@ const colors = [
   "success800",
   "success900",
   "white",
-  "white40",
-  "white70",
   "yellow100",
   "yellow200",
   "yellow300",

--- a/packages/syntax-core/src/colors/colors.module.css
+++ b/packages/syntax-core/src/colors/colors.module.css
@@ -435,11 +435,11 @@
   color: var(--color-cambio-white-100);
 }
 
-.cambioWhite40Color {
+.white40Color {
   color: var(--color-cambio-white-40);
 }
 
-.cambioWhite70Color {
+.white70Color {
   color: var(--color-cambio-white-70);
 }
 
@@ -449,6 +449,10 @@
 
 .cambioGray200Color {
   color: var(--color-cambio-gray-200);
+}
+
+.gray270Color {
+  color: var(--color-cambio-gray-270);
 }
 
 .cambioGray300Color {
@@ -643,11 +647,11 @@
   background-color: var(--color-cambio-white-100);
 }
 
-.cambioWhite40BackgroundColor {
+.white40BackgroundColor {
   background-color: var(--color-cambio-white-40);
 }
 
-.cambioWhite70BackgroundColor {
+.white70BackgroundColor {
   background-color: var(--color-cambio-white-70);
 }
 
@@ -661,6 +665,10 @@
 
 .cambioGray300BackgroundColor {
   background-color: var(--color-cambio-gray-300);
+}
+
+.gray270BackgroundColor {
+  background-color: var(--color-cambio-gray-270);
 }
 
 .gray370BackgroundColor {


### PR DESCRIPTION
[Jira](https://cambly.atlassian.net/browse/WEB-5)
In dark mode, it makes it pretty clear which background colors are broken in syntax -- white40, white70, gray270:
![Screenshot 2024-10-25 at 9 49 55 AM](https://github.com/user-attachments/assets/1411d58a-efe7-400b-9f9c-057e55ed3af0) (white40 and white70) are also duplicated b/c they appeared in the `allColors.ts` file twice.

The reason for this is because the `colors.module.css` file only had cambio class names for these e.g.
`.cambioWhite40`,`.cambioWhite70`, `.cambioGray270`
vs
`.white40`, `.white70`, `.gray270`

Because of this, the background color css lookup wasn't working because "white40" didn't map to any css classes.

After change: 
![Screenshot 2024-10-25 at 9 48 57 AM](https://github.com/user-attachments/assets/83ffb75f-9b6b-4391-9f30-d89083ef69f4)


Question, should we get rid of all classes that start with `.cambio*`? And do we need to distinguish cambio specific colors in our `allColors.ts` file anymore? I don't think any of the cambio classes are being accessed anymore, so the css seems safe to remove? I can do that in a follow up PR
