### PR TITLE
[NOJIRA] Fix broken colors

### DIFF
--- a/.changeset/soft-oranges-admire.md
+++ b/.changeset/soft-oranges-admire.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Fix typography color-styling

--- a/packages/syntax-core/src/Tabs/TabInternal.tsx
+++ b/packages/syntax-core/src/Tabs/TabInternal.tsx
@@ -18,7 +18,7 @@ const ItemCountIcon = ({
       className={classnames({
         [colorStyles.cambioWhiteBackgroundColor]:
           on === "darkBackground" && selected,
-        [colorStyles.cambioWhite70BackgroundColor]:
+        [colorStyles.white70BackgroundColor]:
           on === "darkBackground" && !selected,
         [colorStyles.cambioBlackBackgroundColor]:
           on === "lightBackground" && selected,

--- a/packages/syntax-core/src/colors/textColors.ts
+++ b/packages/syntax-core/src/colors/textColors.ts
@@ -20,7 +20,7 @@ export default function textColor(
     case "white":
       return colorStyles.cambioWhiteColor;
     case "white-secondary":
-      return colorStyles.cambioWhite70Color;
+      return colorStyles.white70Color;
     case "inherit":
       return colorStyles.inheritColor;
     case "destructive-primary":


### PR DESCRIPTION
This change: https://github.com/Cambly/syntax/pull/584/files broke colors in a couple of places where components were referencing classes that no longer existed. I first noticed it when I saw the navbar on dark background (this is the tabs issue specificallly):

<img width="1728" alt="Screenshot 2024-10-29 at 3 21 36 PM" src="https://github.com/user-attachments/assets/2917058a-a1bd-4ee4-94e3-37aa6556b69b">

Repro'd  tabs in vercel preview:
<img width="1312" alt="Screenshot 2024-10-29 at 3 24 38 PM" src="https://github.com/user-attachments/assets/0e0f5786-8674-4676-a60a-b8bcb5584d9c">

After fix tabs:
<img width="1194" alt="Screenshot 2024-10-29 at 3 26 58 PM" src="https://github.com/user-attachments/assets/162bce48-37e8-4757-81f1-990fd0a52d08">

Typography before with color "white-secondary":
<img width="1223" alt="Screenshot 2024-10-29 at 3 30 16 PM" src="https://github.com/user-attachments/assets/43920c84-fe5b-4860-87e8-b6476dc3e665">

Typography after with "white-secondary" fix:
<img width="1348" alt="Screenshot 2024-10-29 at 3 30 05 PM" src="https://github.com/user-attachments/assets/fc61d9c3-9834-45d0-b9b4-9225cbd4d850">




