### PR TITLE
[NOJIRA] Add option popoverZIndex prop to RichSelectList

### DIFF
--- a/.changeset/chatty-snails-reply.md
+++ b/.changeset/chatty-snails-reply.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Add popoverZINdex prop to rich-select-list

--- a/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
@@ -26,6 +26,9 @@ export default {
         options: ["white", "clear"],
       },
     },
+    popoverZIndex: {
+      control: "number",
+    },
   },
   tags: ["autodocs"],
 } as Meta<typeof RichSelectList>;

--- a/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
@@ -26,7 +26,7 @@ export default {
         options: ["white", "clear"],
       },
     },
-    popoverZIndex: {
+    zIndex: {
       control: "number",
     },
   },

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -72,7 +72,7 @@ export type RichSelectListProps = RichSelectBoxProps & {
   /**
    * Z-index of the popover
    */
-  popoverZIndex?: number;
+  zIndex?: number;
 };
 
 /**
@@ -115,7 +115,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
     selectedValues: selectedValuesProp,
     defaultSelectedValues: defaultSelectedValuesProp,
     color = "white",
-    popoverZIndex,
+    zIndex,
     ...richSelectBoxProps
   } = props;
 
@@ -217,7 +217,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
         <Popover
           ref={overlayHandlerRef}
           disabled={disabled}
-          zIndex={popoverZIndex}
+          zIndex={zIndex}
           content={
             // this Box wrapper is to reapply the padding that was stripped from popover's dialog to show the sticky save/close buttons. Ideally this could be avoided
             <Box

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -69,6 +69,10 @@ export type RichSelectListProps = RichSelectBoxProps & {
    * @defaultValue white
    */
   color?: "white" | "clear";
+  /**
+   * Z-index of the popover
+   */
+  popoverZIndex?: number;
 };
 
 /**
@@ -111,6 +115,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
     selectedValues: selectedValuesProp,
     defaultSelectedValues: defaultSelectedValuesProp,
     color = "white",
+    popoverZIndex,
     ...richSelectBoxProps
   } = props;
 
@@ -212,6 +217,7 @@ function RichSelectList(props: RichSelectListProps): ReactElement {
         <Popover
           ref={overlayHandlerRef}
           disabled={disabled}
+          zIndex={popoverZIndex}
           content={
             // this Box wrapper is to reapply the padding that was stripped from popover's dialog to show the sticky save/close buttons. Ideally this could be avoided
             <Box


### PR DESCRIPTION
Black Friday is about to begin and our tutor search page is broken:

<img width="1728" alt="Screenshot 2024-10-29 at 12 33 30 PM" src="https://github.com/user-attachments/assets/d93d8182-cb2d-40ed-b7e8-7bf77ce6dc3a">

Tested to see that it forwarded the z-index to the popover properly:

<img width="1515" alt="Screenshot 2024-10-29 at 3 45 55 PM" src="https://github.com/user-attachments/assets/bde68adb-fb05-4777-9c22-9ec16e6c7c56">

Needed a quick fix because black friday is beginning today. If you have a more robust fix in mind let me know.
