### PR TITLE
[WEB-10] Chip: Add medium size

### DIFF
--- a/.changeset/twelve-llamas-call.md
+++ b/.changeset/twelve-llamas-call.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Chip: Add medium size

--- a/packages/syntax-core/src/Chip/Chip.module.css
+++ b/packages/syntax-core/src/Chip/Chip.module.css
@@ -35,7 +35,6 @@
   height: 24px !important;
   /* stylelint-disable-next-line declaration-no-important --  Need to use !important to override MUI icon sizes  */
   width: 24px !important;
-  color: var(--color-base-grey-900);
 }
 
 .selectedIcon {
@@ -46,6 +45,12 @@
   height: 32px;
   min-width: 40px;
   padding: 8px 12px;
+}
+
+.md {
+  height: 48px;
+  min-width: 56px;
+  padding: 8px 16px;
 }
 
 .chip:focus-visible,

--- a/packages/syntax-core/src/Chip/Chip.stories.tsx
+++ b/packages/syntax-core/src/Chip/Chip.stories.tsx
@@ -17,6 +17,7 @@ export default {
   },
   args: {
     selected: false,
+    size: "sm",
     text: "text on chip",
     on: "lightBackground",
     disabled: false,
@@ -30,6 +31,10 @@ export default {
     },
     selected: {
       control: "boolean",
+    },
+    size: {
+      options: ["sm", "md"],
+      control: { type: "radio" },
     },
     text: {
       control: "text",

--- a/packages/syntax-core/src/Chip/Chip.tsx
+++ b/packages/syntax-core/src/Chip/Chip.tsx
@@ -5,6 +5,12 @@ import Box from "../Box/Box";
 import styles from "./Chip.module.css";
 import useIsHydrated from "../useIsHydrated";
 import type InternalIcon from "../Icon/Icon";
+import { type Size } from "../constants";
+import textVariant from "../Button/constants/textVariant";
+import {
+  internalIconSize,
+  materialIconSize,
+} from "../Button/constants/iconSize";
 
 function typographyColor({
   selected,
@@ -46,6 +52,15 @@ type ChipProps = {
    */
   "data-testid"?: string;
   /**
+   * The size of the chip
+   *
+   * * `sm`: 32px height
+   * * `md`: 48px height
+   *
+   * @defaultValue "sm"
+   */
+  size?: (typeof Size)[number];
+  /**
    * The text to be displayed on the chip
    */
   text: string;
@@ -76,6 +91,7 @@ const Chip = forwardRef<HTMLButtonElement, ChipProps>(
     {
       disabled: disabledProp = false,
       selected = false,
+      size = "sm",
       "data-testid": dataTestId,
       text,
       on = "lightBackground",
@@ -115,7 +131,7 @@ const Chip = forwardRef<HTMLButtonElement, ChipProps>(
 
     return (
       <button
-        className={chipStyles}
+        className={classnames(chipStyles, styles[size])}
         disabled={disabled}
         data-testid={dataTestId}
         ref={ref}
@@ -123,9 +139,15 @@ const Chip = forwardRef<HTMLButtonElement, ChipProps>(
         aria-pressed={selected}
         onClick={onChange}
       >
-        {Icon && <Icon className={iconStyles} size={100} />}
+        {Icon && (
+          <Icon
+            className={classnames(iconStyles, materialIconSize[size])}
+            color={color}
+            size={internalIconSize[size]}
+          />
+        )}
         <Box paddingX={Icon ? 1 : 0}>
-          <Typography size={100} color={color} weight="medium">
+          <Typography size={textVariant[size]} color={color} weight="medium">
             {text}
           </Typography>
         </Box>


### PR DESCRIPTION
[Figma](https://www.figma.com/design/G3UM2urgAYO2iiNU7nlulI/Cambio-Syntax?node-id=676-10881&node-type=canvas&m=dev)

This PR adds a medium size to the Chip component. Previously we only had a small size which is now the default for this component. 

<img width="458" alt="Screenshot 2024-11-19 at 2 31 43 PM" src="https://github.com/user-attachments/assets/5410b1f6-09fe-447d-b855-56e0b70aacc1">
<img width="175" alt="Screenshot 2024-11-19 at 2 31 59 PM" src="https://github.com/user-attachments/assets/98a53651-5434-400c-b9dc-e100e9fe81a9">
<img width="214" alt="Screenshot 2024-11-19 at 2 34 18 PM" src="https://github.com/user-attachments/assets/6008fada-1908-4f7d-ac30-60a4d41b803a">
