### PR TITLE
[NOJIRA] Badge: Add silver colour, change text size to 0

### DIFF
--- a/.changeset/new-pumas-relax.md
+++ b/.changeset/new-pumas-relax.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Badge: add silver colour, change text size to 0

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -59,7 +59,7 @@ export const Multiple: StoryObj<typeof Box> = {
   render: () => (
     <Box display="flex" gap={1} direction="row">
       <Badge color="yellow700" text="Every Wednesday" />
-      <Badge color="silver" icon={RepeatIcon} text="Every Wednesday" />
+      <Badge color="silver" icon={RepeatIcon} text="Premium" />
     </Box>
   ),
 };

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -2,6 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react";
 import Badge from "./Badge";
 import RepeatIcon from "@mui/icons-material/Repeat";
 import Refresh from "../../../syntax-icons/src/icons/Refresh";
+import Box from "../Box/Box";
 
 export default {
   title: "Components/Badge",
@@ -30,6 +31,7 @@ export default {
         "pink",
         "cream",
         "yellow700",
+        "silver",
       ],
       control: { type: "radio" },
     },
@@ -51,4 +53,13 @@ export const WithIcon: StoryObj<typeof Badge> = {
     icon: RepeatIcon,
     text: "Every Wednesday",
   },
+};
+
+export const Multiple: StoryObj<typeof Box> = {
+  render: () => (
+    <Box display="flex" gap={1} direction="row">
+      <Badge color="yellow700" text="Every Wednesday" />
+      <Badge color="silver" icon={RepeatIcon} text="Every Wednesday" />
+    </Box>
+  ),
 };

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -1,7 +1,8 @@
 import { type StoryObj, type Meta } from "@storybook/react";
 import Badge from "./Badge";
-import RepeatIcon from "@mui/icons-material/Repeat";
+import Shuffle from "../../../syntax-icons/src/icons/Shuffle";
 import Refresh from "../../../syntax-icons/src/icons/Refresh";
+import Stars from "../../../syntax-icons/src/icons/Stars";
 import Box from "../Box/Box";
 
 export default {
@@ -50,7 +51,7 @@ export const WithSyntaxIcon: StoryObj<typeof Badge> = {
 export const WithIcon: StoryObj<typeof Badge> = {
   args: {
     color: "gray370",
-    icon: RepeatIcon,
+    icon: Shuffle,
     text: "Every Wednesday",
   },
 };
@@ -59,7 +60,7 @@ export const Multiple: StoryObj<typeof Box> = {
   render: () => (
     <Box display="flex" gap={1} direction="row">
       <Badge color="yellow700" text="Every Wednesday" />
-      <Badge color="silver" icon={RepeatIcon} text="Premium" />
+      <Badge color="silver" icon={Stars} text="Premium" />
     </Box>
   ),
 };

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -73,7 +73,7 @@ const Badge = ({
       paddingX={2}
       paddingY={1}
       rounding={"sm"}
-      backgroundColor={color === "silver" ? undefined : color}
+      backgroundColor={color !== "silver" ? color : undefined}
       alignItems="center"
       justifyContent="center"
       minHeight={24}

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -50,21 +50,8 @@ const backgroundColorForColor = (
   switch (color) {
     case "silver":
       return undefined;
-    case "gray370":
-    case "destructive300":
-    case "orange":
-    case "tan":
-    case "success300":
-    case "sky":
-    case "thistle":
-    case "pink":
-    case "lilac":
-    case "cream":
-    case "yellow700":
-    case "gray870":
-      return color;
     default:
-      return undefined;
+      return color;
   }
 };
 
@@ -79,18 +66,6 @@ const inlineStylesForColor = (
           linear-gradient(83.45deg, #A9A9A9 2.57%, #E5E2E2 61.77%, #6E6E6E 100.3%) border-box",
         border: "1px solid transparent",
       };
-    case "gray370":
-    case "destructive300":
-    case "orange":
-    case "tan":
-    case "success300":
-    case "sky":
-    case "thistle":
-    case "pink":
-    case "lilac":
-    case "cream":
-    case "yellow700":
-    case "gray870":
     default:
       return {};
   }

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -17,6 +17,7 @@ const badgeColor = [
   "pink",
   "cream",
   "yellow700",
+  "silver",
 ] as const;
 
 const textColorForBackgroundColor = (
@@ -33,6 +34,7 @@ const textColorForBackgroundColor = (
     case "pink":
     case "lilac":
     case "cream":
+    case "silver":
     case "yellow700":
       return "gray900";
     default:
@@ -71,13 +73,25 @@ const Badge = ({
       paddingX={2}
       paddingY={1}
       rounding={"sm"}
-      backgroundColor={color}
+      backgroundColor={color === "silver" ? undefined : color}
       alignItems="center"
       justifyContent="center"
       minHeight={24}
+      dangerouslySetInlineStyle={
+        color === "silver"
+          ? {
+              __style: {
+                background:
+                  "linear-gradient(85deg, #CECECE -8.89%, #EEECEC 38.35%, #FFF 49.64%, #E9E8E8 66.22%) padding-box, \
+                  linear-gradient(83.45deg, #A9A9A9 2.57%, #E5E2E2 61.77%, #6E6E6E 100.3%) border-box",
+                border: "1px solid transparent",
+              },
+            }
+          : { __style: {} }
+      }
     >
       <Typography
-        size={100}
+        size={0}
         weight="medium"
         color={textColorForBackgroundColor(color)}
       >
@@ -85,7 +99,7 @@ const Badge = ({
           {Icon && <Icon className={styles.icon} size={100} />}
           <Typography
             color={textColorForBackgroundColor(color)}
-            size={100}
+            size={0}
             weight="medium"
             transform="uppercase"
           >

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -20,8 +20,10 @@ const badgeColor = [
   "silver",
 ] as const;
 
+type BadgeColor = (typeof badgeColor)[number];
+
 const textColorForBackgroundColor = (
-  color: (typeof badgeColor)[number],
+  color: BadgeColor,
 ): "gray900" | "white" => {
   switch (color) {
     case "gray370":
@@ -39,6 +41,58 @@ const textColorForBackgroundColor = (
       return "gray900";
     default:
       return "white";
+  }
+};
+
+const backgroundColorForColor = (
+  color: BadgeColor,
+): Exclude<BadgeColor, "silver"> | undefined => {
+  switch (color) {
+    case "silver":
+      return undefined;
+    case "gray370":
+    case "destructive300":
+    case "orange":
+    case "tan":
+    case "success300":
+    case "sky":
+    case "thistle":
+    case "pink":
+    case "lilac":
+    case "cream":
+    case "yellow700":
+    case "gray870":
+      return color;
+    default:
+      return undefined;
+  }
+};
+
+const inlineStylesForColor = (
+  color: BadgeColor,
+): Record<string, string | number | null> => {
+  switch (color) {
+    case "silver":
+      return {
+        background:
+          "linear-gradient(85deg, #CECECE -8.89%, #EEECEC 38.35%, #FFF 49.64%, #E9E8E8 66.22%) padding-box, \
+          linear-gradient(83.45deg, #A9A9A9 2.57%, #E5E2E2 61.77%, #6E6E6E 100.3%) border-box",
+        border: "1px solid transparent",
+      };
+    case "gray370":
+    case "destructive300":
+    case "orange":
+    case "tan":
+    case "success300":
+    case "sky":
+    case "thistle":
+    case "pink":
+    case "lilac":
+    case "cream":
+    case "yellow700":
+    case "gray870":
+    default:
+      return {};
   }
 };
 
@@ -73,22 +127,13 @@ const Badge = ({
       paddingX={2}
       paddingY={1}
       rounding={"sm"}
-      backgroundColor={color !== "silver" ? color : undefined}
+      backgroundColor={backgroundColorForColor(color)}
       alignItems="center"
       justifyContent="center"
       minHeight={24}
-      dangerouslySetInlineStyle={
-        color === "silver"
-          ? {
-              __style: {
-                background:
-                  "linear-gradient(85deg, #CECECE -8.89%, #EEECEC 38.35%, #FFF 49.64%, #E9E8E8 66.22%) padding-box, \
-                  linear-gradient(83.45deg, #A9A9A9 2.57%, #E5E2E2 61.77%, #6E6E6E 100.3%) border-box",
-                border: "1px solid transparent",
-              },
-            }
-          : { __style: {} }
-      }
+      dangerouslySetInlineStyle={{
+        __style: inlineStylesForColor(color),
+      }}
     >
       <Typography
         size={0}


### PR DESCRIPTION
Figma: https://www.figma.com/design/7wAM5Us9AnFrYHyLV1YCEs/Premium-Tier?node-id=2023-6014&m=dev
Badge:
Adds silver colour for premium.
Text size should have been 0 instead of 100 here.

<img width="901" alt="Screenshot 2025-02-25 at 3 18 54 PM" src="https://github.com/user-attachments/assets/0589a6ed-0956-436c-bbf9-31364e6f9cd7" />

<img width="345" alt="Screenshot 2025-02-25 at 3 18 59 PM" src="https://github.com/user-attachments/assets/0b212e6c-fa1a-4c3d-b54e-f733a973ea17" />
