### PR TITLE
Lock eslint config syntax packages

### DIFF
--- a/packages/eslint-config-syntax/package.json
+++ b/packages/eslint-config-syntax/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "eslint-config-next": "^14.2.15",
+    "eslint-config-next": "14.2.15",
     "eslint-config-prettier": "8.8.0",
-    "eslint-config-turbo": "latest",
+    "eslint-config-turbo": "2.4.1",
     "eslint-plugin-react": "7.32.2"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,14 +157,14 @@ importers:
   packages/eslint-config-syntax:
     dependencies:
       eslint-config-next:
-        specifier: ^14.2.15
+        specifier: 14.2.15
         version: 14.2.15(eslint@8.39.0)(typescript@5.3.3)
       eslint-config-prettier:
         specifier: 8.8.0
         version: 8.8.0(eslint@8.39.0)
       eslint-config-turbo:
-        specifier: latest
-        version: 2.4.4(eslint@8.39.0)(turbo@1.9.0)
+        specifier: 2.4.1
+        version: 2.4.1(eslint@8.39.0)(turbo@1.9.0)
       eslint-plugin-react:
         specifier: 7.32.2
         version: 7.32.2(eslint@8.39.0)
@@ -4440,8 +4440,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-turbo@2.4.4:
-    resolution: {integrity: sha512-4w/heWywWkFw09a5MY5lCvb9suJlhBSkzNtGTwM5+zRif4rksubaMYy1pD0++5rqoDVcQax25jCrtii9ptsNDw==}
+  eslint-config-turbo@2.4.1:
+    resolution: {integrity: sha512-IFlqpBrWgVG1VJO34H2X2IgxU363CB67Bzsd/MekcD7gPAcRtNIyn8cQXibZL/+jZxdbacp1JLm26iHPg8XqgQ==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -4517,8 +4517,8 @@ packages:
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
 
-  eslint-plugin-turbo@2.4.4:
-    resolution: {integrity: sha512-myEnQTjr3FkI0j1Fu0Mqnv1z8n0JW5iFTOUNzHaEevjzl+1uzMSsFwks/x8i3rGmI3EYtC1BY8K2B2pS0Vfx6w==}
+  eslint-plugin-turbo@2.4.1:
+    resolution: {integrity: sha512-sTJZrgn7G1rF7RHZcj367g2cT0+E5v0lt9LD+nBpTnCyDA/yB0PwSm/QM+aXQ39vxuK9sqlUL2LyPXyGFvUXsg==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -14575,10 +14575,10 @@ snapshots:
     dependencies:
       eslint: 8.39.0
 
-  eslint-config-turbo@2.4.4(eslint@8.39.0)(turbo@1.9.0):
+  eslint-config-turbo@2.4.1(eslint@8.39.0)(turbo@1.9.0):
     dependencies:
       eslint: 8.39.0
-      eslint-plugin-turbo: 2.4.4(eslint@8.39.0)(turbo@1.9.0)
+      eslint-plugin-turbo: 2.4.1(eslint@8.39.0)(turbo@1.9.0)
       turbo: 1.9.0
 
   eslint-import-resolver-node@0.3.9:
@@ -14720,7 +14720,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-turbo@2.4.4(eslint@8.39.0)(turbo@1.9.0):
+  eslint-plugin-turbo@2.4.1(eslint@8.39.0)(turbo@1.9.0):
     dependencies:
       dotenv: 16.0.3
       eslint: 8.39.0


### PR DESCRIPTION
These packages weren't lock which was leading to lint failing within main. This goes in and locks eslint-config-next and eslint-config-turbo to the version we were on prior to it starting to fail.
