### PR TITLE
Badge - silver: tweak padding

### DIFF
--- a/.changeset/warm-cobras-walk.md
+++ b/.changeset/warm-cobras-walk.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+Badge: silver - change padding to account for border

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -59,8 +59,12 @@ export const WithIcon: StoryObj<typeof Badge> = {
 export const Multiple: StoryObj<typeof Box> = {
   render: () => (
     <Box display="flex" gap={1} direction="row">
-      <Badge color="yellow700" text="Every Wednesday" />
-      <Badge color="silver" icon={Stars} text="Premium" />
+      <Box width="fit-content" position="relative">
+        <Badge color="yellow700" text="Every Wednesday" />
+      </Box>
+      <Box width="fit-content" position="relative">
+        <Badge color="silver" icon={Stars} text="Premium" />
+      </Box>
     </Box>
   ),
 };

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -65,6 +65,8 @@ const inlineStylesForColor = (
           "linear-gradient(85deg, #CECECE -8.89%, #EEECEC 38.35%, #FFF 49.64%, #E9E8E8 66.22%) padding-box, \
           linear-gradient(83.45deg, #A9A9A9 2.57%, #E5E2E2 61.77%, #6E6E6E 100.3%) border-box",
         border: "1px solid transparent",
+        paddingTop: "3px",
+        paddingBottom: "3px",
       };
     default:
       return {};


### PR DESCRIPTION
In some spots, the individual badges are wrapped in a box which doesn't make the height the same, so tweak the padding. Original padding is 4px, but since this silver badge has a 1px border, make the paddingTop and paddingBottom be 3px

Before:
<img width="869" alt="Screenshot 2025-03-04 at 12 25 59 PM" src="https://github.com/user-attachments/assets/bbe9ce87-c3bb-4688-a3a9-70b2c89e10ef" />

After:
<img width="1490" alt="Screenshot 2025-03-04 at 1 58 58 PM" src="https://github.com/user-attachments/assets/4b8df213-0cc7-47cc-b7e9-2a4de5d93c5f" />
