### PR TITLE
Allow RichSelectItem to be accessed from RichSelectList

### DIFF
--- a/.changeset/spicy-baboons-brake.md
+++ b/.changeset/spicy-baboons-brake.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": minor
+---
+
+RichSelectList: Allow RichSelectItem to be accessed

--- a/packages/syntax-core/src/RichSelect/RichSelectList.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.tsx
@@ -33,6 +33,7 @@ import Box from "../Box/Box";
 import RichSelectSection from "./RichSelectSection";
 import RichSelectChip from "./RichSelectChip";
 import RichSelectRadioButton from "./RichSelectRadioButton";
+import RichSelectItem from "./RichSelectItem";
 import { useField } from "react-aria";
 
 const NOOP = () => undefined;
@@ -304,4 +305,5 @@ export default Object.assign(RichSelectList, {
   Section: RichSelectSection,
   Chip: RichSelectChip,
   RadioButton: RichSelectRadioButton,
+  Item: RichSelectItem,
 });


### PR DESCRIPTION
Allow people to access the RIchSelectItem if necessary when utilizing the rich select list component. 