### PR TITLE
SelectList: Add document direction support to SelectList

### DIFF
--- a/.changeset/tidy-dodos-explode.md
+++ b/.changeset/tidy-dodos-explode.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+SelectList: Add document direction support to SelectList

--- a/packages/syntax-core/src/SelectList/SelectList.module.css
+++ b/packages/syntax-core/src/SelectList/SelectList.module.css
@@ -32,7 +32,10 @@
   box-sizing: border-box;
   font-size: 16px;
   height: 48px;
-  padding: 12px 36px 12px 12px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-inline-start: 12px;
+  padding-inline-end: 36px;
 }
 
 .selectMouseFocusStyling {
@@ -63,7 +66,7 @@
 .arrowIcon {
   display: flex;
   position: absolute;
-  right: 0;
+  inset-inline-end: 0;
   top: 0;
   bottom: 0;
   padding-inline-end: 8px;


### PR DESCRIPTION
The SelectList component previously did not account for the dir attribute on the document. This change updates SelectList to automatically adapt its layout and styling based on the document's dir attribute, ensuring correct alignment and spacing for both LTR and RTL contexts.
Before:
![image](https://github.com/user-attachments/assets/10b379ab-a027-4719-9c2d-14b724be8fe4)
After:
![image](https://github.com/user-attachments/assets/247da457-6d95-4e12-a7fd-1186b6ab463b)

