### PR TITLE
Icon: Add document direction support to Icon

### DIFF
--- a/.changeset/tidy-dodos-explode.md
+++ b/.changeset/tidy-dodos-explode.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+SelectList: Add document direction support to SelectList

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -136,6 +136,17 @@ export const WithRtlDirection: StoryObj<typeof Button> = {
     );
   },
 };
+
+export const WithRtlDirectionNoFlip: StoryObj<typeof Button> = {
+  args: { ...Default.args, endIcon: Play },
+  render: (args) => {
+    return (
+      <div dir="rtl">
+        <Button {...args} />
+      </div>
+    );
+  },
+};
 export const WithSyntaxIcons: StoryObj<typeof Button> = {
   render: (args) => (
     <Box display="flex" gap={2}>

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -137,7 +137,7 @@ export const WithRtlDirection: StoryObj<typeof Button> = {
   },
 };
 
-export const WithRtlDirectionNoFlip: StoryObj<typeof Button> = {
+export const WithRtlDirectionNoMirror: StoryObj<typeof Button> = {
   args: { ...Default.args, endIcon: Play },
   render: (args) => {
     return (

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -4,6 +4,7 @@ import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import Box from "../Box/Box";
 
 import Play from "../../../syntax-icons/src/icons/Play";
+import Accent from "../../../syntax-icons/src/icons/Accent";
 
 export default {
   title: "Components/Button",
@@ -123,9 +124,18 @@ export const WithStartIcon: StoryObj<typeof Button> = {
   args: { ...Default.args, startIcon: FavoriteBorder },
 };
 export const WithEndIcon: StoryObj<typeof Button> = {
-  args: { ...Default.args, endIcon: FavoriteBorder },
+  args: { ...Default.args, endIcon: Accent },
 };
-
+export const WithRtlDirection: StoryObj<typeof Button> = {
+  args: { ...Default.args, endIcon: Accent },
+  render: (args) => {
+    return (
+      <div dir="rtl">
+        <Button {...args} />
+      </div>
+    );
+  },
+};
 export const WithSyntaxIcons: StoryObj<typeof Button> = {
   render: (args) => (
     <Box display="flex" gap={2}>

--- a/packages/syntax-core/src/Icon/Icon.module.css
+++ b/packages/syntax-core/src/Icon/Icon.module.css
@@ -6,7 +6,7 @@
 }
 
 /* for rtl */
-:global([dir="rtl"]) .icon {
+:global([dir="rtl"]) .icon:not(.noRtlFlip) {
   transform: scaleX(-1);
 }
 

--- a/packages/syntax-core/src/Icon/Icon.module.css
+++ b/packages/syntax-core/src/Icon/Icon.module.css
@@ -5,8 +5,8 @@
   user-select: none;
 }
 
-/* for rtl */
-:global([dir="rtl"]) .icon:not(.noRtlMirror) {
+/* stylelint-disable-next-line selector-max-class, selector-max-specificity, selector-max-compound-selectors -- need to flip icon in rtl */
+:global([dir="rtl"]) .icon.iconRtlMirror {
   transform: scaleX(-1);
 }
 

--- a/packages/syntax-core/src/Icon/Icon.module.css
+++ b/packages/syntax-core/src/Icon/Icon.module.css
@@ -6,7 +6,7 @@
 }
 
 /* for rtl */
-:global([dir="rtl"]) .icon:not(.noRtlFlip) {
+:global([dir="rtl"]) .icon:not(.noRtlMirror) {
   transform: scaleX(-1);
 }
 

--- a/packages/syntax-core/src/Icon/Icon.module.css
+++ b/packages/syntax-core/src/Icon/Icon.module.css
@@ -5,6 +5,11 @@
   user-select: none;
 }
 
+/* for rtl */
+:global([dir="rtl"]) .icon {
+  transform: scaleX(-1);
+}
+
 .icon100 {
   width: 16px;
   height: 16px;

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -41,13 +41,14 @@ const IconWithLtrDirection = (): ReactElement => {
   );
 };
 
-const IconWithRtlDirection = (): ReactElement => {
+const IconWithRtlDirectionMirror = (): ReactElement => {
   return (
     <div dir="rtl">
       <Icon
         size={200}
         // Accent
         path="M22 9.368h-6.316V7.263H22zM19.895 2l-5.263 2.105 1.052 2.106 5.263-2.106zm1.052 10.526-5.263-2.105-1.052 2.105 5.263 2.106zM2 22h15.79l-2.106-5.263-5.263-3.158-2.632 4.21-2.631-4.21L2 15.684zM12.526 7.79a4.737 4.737 0 1 1-9.473 0 4.737 4.737 0 0 1 9.473 0"
+        rtlMirror
       />
     </div>
   );
@@ -60,7 +61,6 @@ const IconWithRtlDirectionNoMirror = (): ReactElement => {
         size={200}
         // play
         path="M6.8 3v18l14.4-9z"
-        noRtlMirror
       />
     </div>
   );
@@ -71,7 +71,7 @@ export const WithLtrDirection: StoryObj<typeof Icon> = {
 };
 
 export const WithRtlDirection: StoryObj<typeof Icon> = {
-  render: () => <IconWithRtlDirection />,
+  render: () => <IconWithRtlDirectionMirror />,
 };
 
 export const WithRtlDirectionNoMirror: StoryObj<typeof Icon> = {

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -53,14 +53,14 @@ const IconWithRtlDirection = (): ReactElement => {
   );
 };
 
-const IconWithRtlDirectionNoFlip = (): ReactElement => {
+const IconWithRtlDirectionNoMirror = (): ReactElement => {
   return (
     <div dir="rtl">
       <Icon
         size={200}
         // play
         path="M6.8 3v18l14.4-9z"
-        noRtlFlip
+        noRtlMirror
       />
     </div>
   );
@@ -74,6 +74,6 @@ export const WithRtlDirection: StoryObj<typeof Icon> = {
   render: () => <IconWithRtlDirection />,
 };
 
-export const WithRtlDirectionNoFlip: StoryObj<typeof Icon> = {
-  render: () => <IconWithRtlDirectionNoFlip />,
+export const WithRtlDirectionNoMirror: StoryObj<typeof Icon> = {
+  render: () => <IconWithRtlDirectionNoMirror />,
 };

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from "react";
 import { type StoryObj, type Meta } from "@storybook/react";
 import Icon from "./Icon";
 import allColors from "../colors/allColors";
@@ -26,4 +27,36 @@ export const Default: StoryObj<typeof Icon> = {
     size: 200,
     path: "m22 11-.5-3.5h-6l-2-5.5h-3l-2 5.5h-6L2 11l4.5 3L4 20.5 7 22l5-4 5 4 3-1.5-2.5-6.5z",
   },
+};
+
+const IconWithLtrDirection = (): ReactElement => {
+  return (
+    <div dir="ltr">
+      <Icon
+        size={200}
+        // Accent
+        path="M22 9.368h-6.316V7.263H22zM19.895 2l-5.263 2.105 1.052 2.106 5.263-2.106zm1.052 10.526-5.263-2.105-1.052 2.105 5.263 2.106zM2 22h15.79l-2.106-5.263-5.263-3.158-2.632 4.21-2.631-4.21L2 15.684zM12.526 7.79a4.737 4.737 0 1 1-9.473 0 4.737 4.737 0 0 1 9.473 0"
+      />
+    </div>
+  );
+};
+
+const IconWithRtlDirection = (): ReactElement => {
+  return (
+    <div dir="rtl">
+      <Icon
+        size={200}
+        // Accent
+        path="M22 9.368h-6.316V7.263H22zM19.895 2l-5.263 2.105 1.052 2.106 5.263-2.106zm1.052 10.526-5.263-2.105-1.052 2.105 5.263 2.106zM2 22h15.79l-2.106-5.263-5.263-3.158-2.632 4.21-2.631-4.21L2 15.684zM12.526 7.79a4.737 4.737 0 1 1-9.473 0 4.737 4.737 0 0 1 9.473 0"
+      />
+    </div>
+  );
+};
+
+export const WithLtrDirection: StoryObj<typeof Icon> = {
+  render: () => <IconWithLtrDirection />,
+};
+
+export const WithRtlDirection: StoryObj<typeof Icon> = {
+  render: () => <IconWithRtlDirection />,
 };

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -53,10 +53,27 @@ const IconWithRtlDirection = (): ReactElement => {
   );
 };
 
+const IconWithRtlDirectionNoFlip = (): ReactElement => {
+  return (
+    <div dir="rtl">
+      <Icon
+        size={200}
+        // play
+        path="M6.8 3v18l14.4-9z"
+        noRtlFlip
+      />
+    </div>
+  );
+};
+
 export const WithLtrDirection: StoryObj<typeof Icon> = {
   render: () => <IconWithLtrDirection />,
 };
 
 export const WithRtlDirection: StoryObj<typeof Icon> = {
   render: () => <IconWithRtlDirection />,
+};
+
+export const WithRtlDirectionNoFlip: StoryObj<typeof Icon> = {
+  render: () => <IconWithRtlDirectionNoFlip />,
 };

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -36,7 +36,7 @@ type IconProps = {
    *
    * @defaultValue false
    */
-  noRtlFlip?: boolean;
+  noRtlMirror?: boolean;
 };
 
 /**
@@ -49,7 +49,7 @@ type IconProps = {
  */
 const Icon = forwardRef<SVGSVGElement, IconProps>(
   (
-    { color = "inherit", path, size = 200, noRtlFlip = false }: IconProps,
+    { color = "inherit", path, size = 200, noRtlMirror = false }: IconProps,
     ref,
   ) => (
     <svg
@@ -58,7 +58,7 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(
         colorStyles[`${color}Color`],
         styles[`icon${size}`],
         {
-          [styles.noRtlFlip]: noRtlFlip,
+          [styles.noRtlMirror]: noRtlMirror,
         },
       )}
       ref={ref}

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -32,11 +32,10 @@ type IconProps = {
    */
   path?: string;
   /**
-   * Whether to prevent the icon from being flipped in RTL mode.
-   *
+   * Whether to mirror the icon in RTL mode.
    * @defaultValue false
    */
-  noRtlMirror?: boolean;
+  rtlMirror?: boolean;
 };
 
 /**
@@ -49,7 +48,7 @@ type IconProps = {
  */
 const Icon = forwardRef<SVGSVGElement, IconProps>(
   (
-    { color = "inherit", path, size = 200, noRtlMirror = false }: IconProps,
+    { color = "inherit", path, size = 200, rtlMirror = false }: IconProps,
     ref,
   ) => (
     <svg
@@ -58,7 +57,7 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(
         colorStyles[`${color}Color`],
         styles[`icon${size}`],
         {
-          [styles.noRtlMirror]: noRtlMirror,
+          [styles.iconRtlMirror]: rtlMirror,
         },
       )}
       ref={ref}

--- a/packages/syntax-core/src/Icon/Icon.tsx
+++ b/packages/syntax-core/src/Icon/Icon.tsx
@@ -31,6 +31,12 @@ type IconProps = {
    * The svg path of the icon. You should not use this prop directly, instead use the specific icon components.
    */
   path?: string;
+  /**
+   * Whether to prevent the icon from being flipped in RTL mode.
+   *
+   * @defaultValue false
+   */
+  noRtlFlip?: boolean;
 };
 
 /**
@@ -42,12 +48,18 @@ type IconProps = {
  * You can click on the icon to copy the import statement!
  */
 const Icon = forwardRef<SVGSVGElement, IconProps>(
-  ({ color = "inherit", path, size = 200 }: IconProps, ref) => (
+  (
+    { color = "inherit", path, size = 200, noRtlFlip = false }: IconProps,
+    ref,
+  ) => (
     <svg
       className={classnames(
         styles.icon,
         colorStyles[`${color}Color`],
         styles[`icon${size}`],
+        {
+          [styles.noRtlFlip]: noRtlFlip,
+        },
       )}
       ref={ref}
       viewBox="0 0 24 24"

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -7,6 +7,7 @@ import allColors from "../colors/allColors";
 import Box from "../Box/Box";
 
 import CalendarBooking from "../../../syntax-icons/src/icons/CalendarBooking";
+import Accent from "../../../syntax-icons/src/icons/Accent";
 
 export default {
   title: "Components/IconButton",
@@ -110,6 +111,19 @@ export const DestructiveTertiary: StoryObj<typeof IconButton> = {
 };
 export const DifferentIcon: StoryObj<typeof IconButton> = {
   args: { ...Default.args, icon: FavoriteBorder },
+};
+
+export const WithRtlDirection: StoryObj<typeof IconButton> = {
+  args: { ...Default.args, icon: Accent },
+  render: (args) => {
+    return (
+      <div dir="rtl">
+        <Box display="flex" gap={4}>
+          <IconButton {...args} />
+        </Box>
+      </div>
+    );
+  },
 };
 
 export const IndicatorColors: StoryObj<typeof IconButton> = {

--- a/packages/syntax-icons/src/icons/Accent.tsx
+++ b/packages/syntax-icons/src/icons/Accent.tsx
@@ -6,7 +6,7 @@ const Accent = forwardRef<
 >(({ color, size }, ref) => {
   const path =
     "M22 9.368h-6.316V7.263H22zM19.895 2l-5.263 2.105 1.052 2.106 5.263-2.106zm1.052 10.526-5.263-2.105-1.052 2.105 5.263 2.106zM2 22h15.79l-2.106-5.263-5.263-3.158-2.632 4.21-2.631-4.21L2 15.684zM12.526 7.79a4.737 4.737 0 1 1-9.473 0 4.737 4.737 0 0 1 9.473 0";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 Accent.displayName = "Accent";
 export default Accent;

--- a/packages/syntax-icons/src/icons/ArrowLeft.tsx
+++ b/packages/syntax-icons/src/icons/ArrowLeft.tsx
@@ -5,7 +5,7 @@ const ArrowLeft = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M10.5 3.5 12 5l-6 6h16v2H6l6 6-1.5 1.5L2 12z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 ArrowLeft.displayName = "ArrowLeft";
 export default ArrowLeft;

--- a/packages/syntax-icons/src/icons/ArrowRight.tsx
+++ b/packages/syntax-icons/src/icons/ArrowRight.tsx
@@ -5,7 +5,7 @@ const ArrowRight = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M13.5 3.5 12 5l6 6H2v2h16l-6 6 1.5 1.5L22 12z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 ArrowRight.displayName = "ArrowRight";
 export default ArrowRight;

--- a/packages/syntax-icons/src/icons/ChevronLeft.tsx
+++ b/packages/syntax-icons/src/icons/ChevronLeft.tsx
@@ -5,7 +5,7 @@ const ChevronLeft = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "m14.525 3 1.35 1.35L8.225 12l7.65 7.65-1.35 1.35-9-9z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 ChevronLeft.displayName = "ChevronLeft";
 export default ChevronLeft;

--- a/packages/syntax-icons/src/icons/ChevronRight.tsx
+++ b/packages/syntax-icons/src/icons/ChevronRight.tsx
@@ -5,7 +5,7 @@ const ChevronRight = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "m9.475 21-1.35-1.35 7.65-7.65-7.65-7.65L9.475 3l9 9z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 ChevronRight.displayName = "ChevronRight";
 export default ChevronRight;

--- a/packages/syntax-icons/src/icons/Exit.tsx
+++ b/packages/syntax-icons/src/icons/Exit.tsx
@@ -6,7 +6,7 @@ const Exit = forwardRef<
 >(({ color, size }, ref) => {
   const path =
     "M4 4v16h7v2H2V2h9v2zm11 1-1.5 1.5L18 11H7v2h11l-4.5 4.5L15 19l7-7z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 Exit.displayName = "Exit";
 export default Exit;

--- a/packages/syntax-icons/src/icons/Help.tsx
+++ b/packages/syntax-icons/src/icons/Help.tsx
@@ -6,7 +6,7 @@ const Help = forwardRef<
 >(({ color, size }, ref) => {
   const path =
     "M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2m1 16h-2v-2h2zm.94-5.506c-.6.594-.94.958-.94 1.506h-2c0-1.41.85-2.252 1.534-2.928.617-.61.966-.984.966-1.572 0-.378-.134-.764-.359-1.031C12.881 8.158 12.496 8 12 8c-.556 0-.968.15-1.227.448A1.15 1.15 0 0 0 10.5 9h-2c0-.423.18-1.14.684-1.77C9.635 6.67 10.49 6 12 6c1.388 0 2.22.643 2.673 1.182.525.626.827 1.471.827 2.318 0 1.452-.865 2.307-1.56 2.994";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 Help.displayName = "Help";
 export default Help;

--- a/packages/syntax-icons/src/icons/Play.tsx
+++ b/packages/syntax-icons/src/icons/Play.tsx
@@ -5,7 +5,7 @@ const Play = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M6.8 3v18l14.4-9z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} noRtlFlip />;
 });
 Play.displayName = "Play";
 export default Play;

--- a/packages/syntax-icons/src/icons/Play.tsx
+++ b/packages/syntax-icons/src/icons/Play.tsx
@@ -5,7 +5,7 @@ const Play = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M6.8 3v18l14.4-9z";
-  return <Icon ref={ref} path={path} color={color} size={size} noRtlFlip />;
+  return <Icon ref={ref} path={path} color={color} size={size} noRtlMirror />;
 });
 Play.displayName = "Play";
 export default Play;

--- a/packages/syntax-icons/src/icons/Play.tsx
+++ b/packages/syntax-icons/src/icons/Play.tsx
@@ -5,7 +5,7 @@ const Play = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M6.8 3v18l14.4-9z";
-  return <Icon ref={ref} path={path} color={color} size={size} noRtlMirror />;
+  return <Icon ref={ref} path={path} color={color} size={size} />;
 });
 Play.displayName = "Play";
 export default Play;

--- a/packages/syntax-icons/src/icons/Progress.tsx
+++ b/packages/syntax-icons/src/icons/Progress.tsx
@@ -5,7 +5,7 @@ const Progress = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M20 22h-4V2h4zM14 7h-4v15h4zm-6 5H4v10h4z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 Progress.displayName = "Progress";
 export default Progress;

--- a/packages/syntax-icons/src/icons/Send.tsx
+++ b/packages/syntax-icons/src/icons/Send.tsx
@@ -5,7 +5,7 @@ const Send = forwardRef<
   Omit<ComponentProps<typeof Icon>, "path">
 >(({ color, size }, ref) => {
   const path = "M20 2 2 9v3l6 2.5L13.5 9l1.5 1.5L9.5 16l2.5 6h3l7-18z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 Send.displayName = "Send";
 export default Send;

--- a/packages/syntax-icons/src/icons/UserRemove.tsx
+++ b/packages/syntax-icons/src/icons/UserRemove.tsx
@@ -6,7 +6,7 @@ const UserRemove = forwardRef<
 >(({ color, size }, ref) => {
   const path =
     "m2 15 3-2 2.5 4 2.5-4 5 3 2 5H2zM7.5 3a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9M22 10h-8v2h8z";
-  return <Icon ref={ref} path={path} color={color} size={size} />;
+  return <Icon ref={ref} path={path} color={color} size={size} rtlMirror />;
 });
 UserRemove.displayName = "UserRemove";
 export default UserRemove;


### PR DESCRIPTION
Background
[As shown in the picture, the direction of the icon is reversed](https://docs.google.com/spreadsheets/d/1B_4adZJ4OMmywSMVuw5ry9deLe54_tW_BnbCQNh5QcQ/edit?gid=875673687#gid=875673687&range=7:7). This problem exists in many places.
![image](https://github.com/user-attachments/assets/d68d662a-1ade-4907-9dcf-cbd5e06831b9)

At present, our project loads different icons by manually judging the document direction, which is not very convenient. I hope we don’t need to worry about this problem when using icons.
https://github.com/Cambly/Cambly-Frontend/blob/af479fc7a73c6c9fd26cbe5fed7e1c9121a2f72f/src/components/CamblychatTextMessages.jsx#L393

https://github.com/Cambly/Cambly-Frontend/blob/6f3a8dac657da5d730d5300865e0f48125278e74/src/components/GroupsSubscriptionPage/GroupsSubscriptionPageV2/GroupsSubscriptionPageV2.tsx#L50

My idea is to automatically mirror the icon if it is rtl. But there are some exceptions, such as the search and play icons, which should not be mirrored. According to Google's Material UI RTL design guidelines: https://m2.material.io/design/usability/bidirectionality.html#mirroring-elements.  Also on youtube.
![image](https://github.com/user-attachments/assets/234dbf3e-f802-4a93-9002-0a3b50cc63f4)

So i want to let icon be mirrored by default on rtl, and have the initial prop on some specific icons to prevent the icon from being mirrored in RTL mode.
![image](https://github.com/user-attachments/assets/de4e3ed7-c878-494f-b4e5-b04946ca4344)
![image](https://github.com/user-attachments/assets/547d34fc-76e9-43ab-8e26-a20f196a8b74)

Since we use RTL judgment, after completing the syntax modification and before merging, we also need to consider how to migrate the existing code so as not to affect the prodction environment.