### PR TITLE
New badge color, used by Pro badge

### DIFF
--- a/.changeset/rich-days-turn.md
+++ b/.changeset/rich-days-turn.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Added blackandwhite badge color

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -33,6 +33,7 @@ export default {
         "cream",
         "yellow700",
         "silver",
+        "blackandwhite",
       ],
       control: { type: "radio" },
     },
@@ -63,7 +64,7 @@ export const Multiple: StoryObj<typeof Box> = {
         <Badge color="yellow700" text="Every Wednesday" />
       </Box>
       <Box width="fit-content" position="relative">
-        <Badge color="silver" icon={Stars} text="Premium" />
+        <Badge color="blackandwhite" icon={Stars} text="Pro" />
       </Box>
     </Box>
   ),

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -18,6 +18,7 @@ const badgeColor = [
   "cream",
   "yellow700",
   "silver",
+  "blackandwhite",
 ] as const;
 
 type BadgeColor = (typeof badgeColor)[number];
@@ -50,6 +51,8 @@ const backgroundColorForColor = (
   switch (color) {
     case "silver":
       return undefined;
+    case "blackandwhite":
+      return undefined;
     default:
       return color;
   }
@@ -64,6 +67,14 @@ const inlineStylesForColor = (
         background:
           "linear-gradient(85deg, #CECECE -8.89%, #EEECEC 38.35%, #FFF 49.64%, #E9E8E8 66.22%) padding-box, \
           linear-gradient(83.45deg, #A9A9A9 2.57%, #E5E2E2 61.77%, #6E6E6E 100.3%) border-box",
+        border: "1px solid transparent",
+        paddingTop: "3px",
+        paddingBottom: "3px",
+      };
+    case "blackandwhite":
+      return {
+        background:
+          "linear-gradient(65deg, #000 12.53%, #949494 45.45%, #000 81.69%)",
         border: "1px solid transparent",
         paddingTop: "3px",
         paddingBottom: "3px",

--- a/packages/syntax-core/src/Badge/Badge.tsx
+++ b/packages/syntax-core/src/Badge/Badge.tsx
@@ -47,7 +47,7 @@ const textColorForBackgroundColor = (
 
 const backgroundColorForColor = (
   color: BadgeColor,
-): Exclude<BadgeColor, "silver"> | undefined => {
+): Exclude<BadgeColor, "silver" | "blackandwhite"> | undefined => {
   switch (color) {
     case "silver":
       return undefined;


### PR DESCRIPTION
blackandwhite - a black and white gradient

Example (ignore the yellow line; that was just a bad screenshot cut):
<img width="81" alt="Screenshot 2025-06-23 at 6 18 10 PM" src="https://github.com/user-attachments/assets/e92d3e2d-bda4-44d0-b969-eb08c274fd8b" />


<img width="206" alt="Screenshot 2025-06-23 at 6 18 17 PM" src="https://github.com/user-attachments/assets/d5b34bc8-f8ed-4afa-a7fa-381cadb3f04d" />
