### PR TITLE
Fix Modal FocusTrap swallowing focus inside react-aria overlays

### DIFF
--- a/.changeset/modal-focustrap-react-aria-overlays.md
+++ b/.changeset/modal-focustrap-react-aria-overlays.md
@@ -1,0 +1,5 @@
+---
+"@cambly/syntax-core": patch
+---
+
+Modal FocusTrap: allow focus to land in react-aria overlays (Popover, Dialog, Menu, Tooltip, ListBox, AlertDialog) that portal out of the Modal subtree. Previously, the FocusTrap bounced focus back into the Modal whenever it landed on an element outside the Modal's DOM, breaking react-aria's internal FocusScope. The canonical symptom was a `DateRangePicker` inside a `Modal` where picking a single date collapsed the range to a single day, because the bounce triggered RangeCalendar's onBlur-while-anchored path.

--- a/packages/syntax-core/src/Modal/FocusTrap.tsx
+++ b/packages/syntax-core/src/Modal/FocusTrap.tsx
@@ -60,10 +60,25 @@ export default function FocusTrap({
         return;
       }
 
-      // This prevents stack overflow when multiple FocusTraps are rendered
+      // Allow focus to land in:
+      // 1. Other Syntax FocusTraps — prevents stack overflow when two FocusTraps
+      //    are rendered (nested Modals).
+      // 2. react-aria overlays that portal out of the Modal subtree:
+      //    - Popover / DateRangePicker / Select / ComboBox — react-aria marks
+      //      the portal root with `data-trigger`.
+      //    - Dialog / AlertDialog / Menu / Tooltip / ListBox — these carry the
+      //      corresponding ARIA role on their root element.
+      //    These overlays manage their own focus via react-aria's FocusScope.
+      //    Without this escape hatch, every focus event inside the overlay
+      //    would be bounced back into the Modal. The canonical symptom is a
+      //    DateRangePicker inside a Modal where picking one date collapses the
+      //    range to a single day, because the bounce triggers RangeCalendar's
+      //    onBlur-while-anchored path (selectFocusedDate).
       if (
         event.target instanceof Element &&
-        event.target.closest('[data-testid="syntax-focus-trap"]') !== null
+        event.target.closest(
+          '[data-testid="syntax-focus-trap"], [data-trigger], [role="dialog"], [role="alertdialog"], [role="menu"], [role="tooltip"], [role="listbox"]',
+        ) !== null
       ) {
         return;
       }

--- a/packages/syntax-core/src/Modal/Modal.test.tsx
+++ b/packages/syntax-core/src/Modal/Modal.test.tsx
@@ -176,51 +176,60 @@ describe("modal", () => {
     // breaks react-aria's internal FocusScope (e.g. collapses a date range to a
     // single day on first click in a DateRangePicker inside a Modal).
     render(
-      <Modal header="title" onDismiss={() => {}}>
-        <button type="button" data-testid="modal-first-focusable">
-          first focusable
-        </button>
-      </Modal>,
+      <>
+        <Modal
+          header="title"
+          onDismiss={() => {
+            /* empty */
+          }}
+        >
+          <button type="button">first focusable</button>
+        </Modal>
+        {createPortal(
+          <div data-trigger="DateRangePicker">
+            <button type="button" data-testid="overlay-target">
+              overlay
+            </button>
+          </div>,
+          document.body,
+        )}
+      </>,
     );
 
-    const portalHost = document.createElement("div");
-    portalHost.setAttribute("data-trigger", "DateRangePicker");
-    const overlayButton = document.createElement("button");
-    overlayButton.setAttribute("data-testid", "overlay-target");
-    portalHost.appendChild(overlayButton);
-    document.body.appendChild(portalHost);
-
-    try {
-      act(() => {
-        overlayButton.focus();
-      });
-      expect(document.activeElement).toBe(overlayButton);
-    } finally {
-      portalHost.remove();
-    }
+    const overlayButton = screen.getByTestId("overlay-target");
+    act(() => {
+      overlayButton.focus();
+    });
+    expect(overlayButton).toHaveFocus();
   });
 
   it("does not bounce focus out of a portalled element with role=dialog", () => {
     render(
-      <Modal header="title" onDismiss={() => {}}>
-        <button type="button">first focusable</button>
-      </Modal>,
+      <>
+        <Modal
+          header="title"
+          onDismiss={() => {
+            /* empty */
+          }}
+        >
+          <button type="button">first focusable</button>
+        </Modal>
+        {createPortal(
+          <div role="dialog">
+            <button type="button" data-testid="dialog-target">
+              dialog
+            </button>
+          </div>,
+          document.body,
+        )}
+      </>,
     );
 
-    const portalHost = document.createElement("div");
-    portalHost.setAttribute("role", "dialog");
-    const dialogButton = document.createElement("button");
-    portalHost.appendChild(dialogButton);
-    document.body.appendChild(portalHost);
-
-    try {
-      act(() => {
-        dialogButton.focus();
-      });
-      expect(document.activeElement).toBe(dialogButton);
-    } finally {
-      portalHost.remove();
-    }
+    const dialogButton = screen.getByTestId("dialog-target");
+    act(() => {
+      dialogButton.focus();
+    });
+    expect(dialogButton).toHaveFocus();
   });
 
   it("still bounces focus out of unrelated elements outside the modal", () => {
@@ -228,7 +237,9 @@ describe("modal", () => {
       <>
         <Modal
           header="title"
-          onDismiss={() => {}}
+          onDismiss={() => {
+            /* empty */
+          }}
           accessibilityCloseLabel="close-button"
         >
           <button type="button">first focusable</button>
@@ -246,7 +257,7 @@ describe("modal", () => {
     act(() => {
       outside.focus();
     });
-    expect(document.activeElement).not.toBe(outside);
+    expect(outside).not.toHaveFocus();
   });
 
   it("should not tab outside the Modal", async () => {

--- a/packages/syntax-core/src/Modal/Modal.test.tsx
+++ b/packages/syntax-core/src/Modal/Modal.test.tsx
@@ -1,7 +1,9 @@
 import { createPortal } from "react-dom";
 import { screen, render, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { parseDate } from "@internationalized/date";
 import { expect, vi } from "vitest";
+import DateRangePicker from "../DateRangePicker/DateRangePicker";
 import Modal from "./Modal";
 
 describe("modal", () => {
@@ -230,6 +232,47 @@ describe("modal", () => {
       dialogButton.focus();
     });
     expect(dialogButton).toHaveFocus();
+  });
+
+  it("allows DateRangePicker inside a Modal to select a multi-day range", async () => {
+    // Integration regression test for the original bug: the FocusTrap escape
+    // hatch keys off `data-trigger`, which is a react-aria implementation
+    // detail. The simulated test above fabricates that attribute, so it would
+    // keep passing even if react-aria renamed it. This test renders a real
+    // DateRangePicker inside a Modal and exercises the calendar via the same
+    // user interaction that surfaced the bug, so a react-aria upgrade that
+    // breaks the escape hatch will fail here.
+    const now = new Date();
+    const month = now.toLocaleString("en-US", { month: "long" });
+    const year = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+
+    const handleChange = vi.fn();
+    render(
+      <Modal
+        header="title"
+        onDismiss={() => {
+          /* empty */
+        }}
+      >
+        <DateRangePicker label="Date range" onChange={handleChange} />
+      </Modal>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /calendar/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: new RegExp(`${month} 10`) }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: new RegExp(`${month} 15`) }),
+    );
+
+    // If FocusTrap bounces focus out of the popover, the range collapses to a
+    // single day on the first click and this assertion fails.
+    expect(handleChange).toHaveBeenCalledWith({
+      start: parseDate(`${year}-${mm}-10`),
+      end: parseDate(`${year}-${mm}-15`),
+    });
   });
 
   it("still bounces focus out of unrelated elements outside the modal", () => {

--- a/packages/syntax-core/src/Modal/Modal.test.tsx
+++ b/packages/syntax-core/src/Modal/Modal.test.tsx
@@ -1,4 +1,5 @@
-import { screen, render } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import { screen, render, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, vi } from "vitest";
 import Modal from "./Modal";
@@ -165,6 +166,87 @@ describe("modal", () => {
     await userEvent.tab();
     const button = screen.getByTestId("should-focus");
     expect(button).toHaveFocus();
+  });
+
+  it("does not bounce focus out of a react-aria overlay portalled outside the modal", () => {
+    // Simulates the DOM react-aria produces for a Popover (e.g. DateRangePicker's
+    // calendar): a sibling portal under document.body whose root carries
+    // `data-trigger`. Without the FocusTrap escape hatch for `[data-trigger]`,
+    // focusing anything inside the portal is bounced back into the Modal, which
+    // breaks react-aria's internal FocusScope (e.g. collapses a date range to a
+    // single day on first click in a DateRangePicker inside a Modal).
+    render(
+      <Modal header="title" onDismiss={() => {}}>
+        <button type="button" data-testid="modal-first-focusable">
+          first focusable
+        </button>
+      </Modal>,
+    );
+
+    const portalHost = document.createElement("div");
+    portalHost.setAttribute("data-trigger", "DateRangePicker");
+    const overlayButton = document.createElement("button");
+    overlayButton.setAttribute("data-testid", "overlay-target");
+    portalHost.appendChild(overlayButton);
+    document.body.appendChild(portalHost);
+
+    try {
+      act(() => {
+        overlayButton.focus();
+      });
+      expect(document.activeElement).toBe(overlayButton);
+    } finally {
+      portalHost.remove();
+    }
+  });
+
+  it("does not bounce focus out of a portalled element with role=dialog", () => {
+    render(
+      <Modal header="title" onDismiss={() => {}}>
+        <button type="button">first focusable</button>
+      </Modal>,
+    );
+
+    const portalHost = document.createElement("div");
+    portalHost.setAttribute("role", "dialog");
+    const dialogButton = document.createElement("button");
+    portalHost.appendChild(dialogButton);
+    document.body.appendChild(portalHost);
+
+    try {
+      act(() => {
+        dialogButton.focus();
+      });
+      expect(document.activeElement).toBe(dialogButton);
+    } finally {
+      portalHost.remove();
+    }
+  });
+
+  it("still bounces focus out of unrelated elements outside the modal", () => {
+    render(
+      <>
+        <Modal
+          header="title"
+          onDismiss={() => {}}
+          accessibilityCloseLabel="close-button"
+        >
+          <button type="button">first focusable</button>
+        </Modal>
+        {createPortal(
+          <button type="button" data-testid="outside-button">
+            outside
+          </button>,
+          document.body,
+        )}
+      </>,
+    );
+
+    const outside = screen.getByTestId("outside-button");
+    act(() => {
+      outside.focus();
+    });
+    expect(document.activeElement).not.toBe(outside);
   });
 
   it("should not tab outside the Modal", async () => {


### PR DESCRIPTION
## Summary
The Modal's `FocusTrap` listens for `focus` events at the document level and bounces any focus outside the Modal's DOM back inside. react-aria overlays (Popover, Dialog, Menu, Tooltip, ListBox, AlertDialog) portal to `document.body` by design, so they live outside the Modal's subtree. When focus lands on a cell/option inside such an overlay the FocusTrap yanks it back, which breaks react-aria's internal `FocusScope`.

**Canonical symptom:** a `DateRangePicker` inside a `Modal`. On the first date click the FocusTrap bounce triggers `RangeCalendar`'s onBlur-while-anchored path (`selectFocusedDate`), which commits the range as `{start: clicked, end: clicked}` and closes the popover before the user can pick a second date. Outside a Modal (e.g. `DirectoryTable` in Cambly-Frontend) the same `DateRangePicker` works correctly, because there's no FocusTrap to fight react-aria.

https://github.com/user-attachments/assets/964ec8c0-a64e-4905-8077-3234c113f8c4

## Fix
Extend the existing `[data-testid="syntax-focus-trap"]` escape hatch in `FocusTrap` to also match react-aria overlay markers:

- `[data-trigger]` — react-aria sets this on every `Popover` portal root (e.g. `data-trigger="DateRangePicker"`, `data-trigger="Select"`).
- `[role="dialog"]`, `[role="alertdialog"]`, `[role="menu"]`, `[role="tooltip"]`, `[role="listbox"]` — standard ARIA roles used by react-aria overlay primitives.

These overlays manage their own focus via react-aria's `FocusScope` and should never be overridden by the Modal's FocusTrap.

## Tests
Added three cases to `Modal.test.tsx` (all passing; full suite 373/373 green):
1. Focus on a button inside a `[data-trigger="DateRangePicker"]` portal outside the Modal is preserved (reproduces the bug class).
2. Focus on a button inside a `[role="dialog"]` portal outside the Modal is preserved.
3. Focus on an unrelated portalled button (no overlay marker) is still bounced, confirming we haven't weakened the trap for genuine outside-focus cases.

## Downstream
Cambly-Frontend PR https://github.com/Cambly/Cambly-Frontend/pull/15189 currently carries a `MutationObserver` workaround that stamps `data-testid="syntax-focus-trap"` onto the DateRangePicker popover after it mounts. Once this Syntax fix lands and Cambly-Frontend bumps `@cambly/syntax-core`, that workaround can be removed.

## Test plan
- [x] `pnpm test` — all syntax-core tests pass
- [x] Manually verified via `agent-browser` against the Cambly-Frontend dialog that triggered the original report: click one → anchor set, popover stays open; click two → range commits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)