### PR TITLE
Add light/dark toggle for Storybook UI chrome

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -19,6 +19,7 @@ const config: StorybookConfig = {
     getAbsolutePath("storybook-addon-rtl"),
     getAbsolutePath("@storybook/addon-docs"),
     getAbsolutePath("@storybook/addon-mcp"),
+    getAbsolutePath("@vueless/storybook-dark-mode"),
   ],
 
   staticDirs: ["../public"],

--- a/apps/storybook/.storybook/manager.ts
+++ b/apps/storybook/.storybook/manager.ts
@@ -1,11 +1,4 @@
-import { addons } from "storybook/manager-api";
-import syntaxTheme from "./syntaxTheme";
-
 const link = document.createElement("link");
 link.setAttribute("rel", "shortcut icon");
 link.setAttribute("href", "favicon.ico");
 document.head.appendChild(link);
-
-addons.setConfig({
-  theme: syntaxTheme,
-});

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Preview } from "@storybook/react-vite";
 import ThemeProvider from "../../../packages/syntax-core/src/ThemeProvider/ThemeProvider";
+import { darkTheme, lightTheme } from "./syntaxTheme";
 
 const preview: Preview = {
   decorators: [
@@ -12,6 +13,15 @@ const preview: Preview = {
       );
     },
   ],
+
+  parameters: {
+    darkMode: {
+      dark: darkTheme,
+      light: lightTheme,
+      // stylePreview omitted → only the Storybook UI chrome toggles,
+      // the story canvas / components are left untouched.
+    },
+  },
 
   tags: ["autodocs"],
 };

--- a/apps/storybook/.storybook/syntaxTheme.ts
+++ b/apps/storybook/.storybook/syntaxTheme.ts
@@ -1,8 +1,19 @@
 import { create } from "storybook/theming";
 
-export default create({
-  base: "dark",
+const shared = {
   brandTitle: "Syntax - Cambly's design system",
   brandUrl: "https://syntax-cambly.vercel.app/",
-  brandTarget: "_self",
+  brandTarget: "_self" as const,
+};
+
+export const darkTheme = create({
+  base: "dark",
+  ...shared,
 });
+
+export const lightTheme = create({
+  base: "light",
+  ...shared,
+});
+
+export default darkTheme;

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -28,6 +28,7 @@
     "@storybook/addon-mcp": "^0.6.0",
     "@storybook/react-vite": "10.3.5",
     "@vitejs/plugin-react": "4.7.0",
+    "@vueless/storybook-dark-mode": "^10.0.7",
     "eslint-plugin-storybook": "10.3.5",
     "serve": "14.2.0",
     "storybook": "10.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.7.0
         version: 4.7.0(vite@5.4.3(@types/node@18.16.3)(less@4.1.3)(sass@1.62.1)(stylus@0.59.0))
+      '@vueless/storybook-dark-mode':
+        specifier: ^10.0.7
+        version: 10.0.7(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       eslint-plugin-storybook:
         specifier: 10.3.5
         version: 10.3.5(eslint@8.39.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.0.4)
@@ -2816,6 +2819,12 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@vueless/storybook-dark-mode@10.0.7':
+    resolution: {integrity: sha512-mI+tqHykUMlhdwu7PlZ6/wvq1aZqn4DWoUbO4GMhJxLnrDSJn4zKaeEtGXp4KTO5Myv/T6k2iteIe7MSTAZVDQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      storybook: ^10.0.0
+
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
@@ -4596,6 +4605,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -9526,6 +9538,12 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@vueless/storybook-dark-mode@10.0.7(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      lodash-es: 4.18.1
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+
   '@webcontainer/env@1.1.1': {}
 
   '@zeit/schemas@2.29.0': {}
@@ -11652,6 +11670,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 


### PR DESCRIPTION
## Summary
- Adds `@vueless/storybook-dark-mode` to the Storybook app so users can toggle the Storybook manager UI between light and dark from the toolbar.
- The toggle only affects **Storybook's chrome** (sidebar, toolbar, docs panels). The story canvas and the components being previewed are deliberately untouched — `stylePreview` is omitted.
- Splits `syntaxTheme.ts` into a `darkTheme` / `lightTheme` pair (shared brand metadata) and moves theme selection out of `manager.ts` and into `preview.tsx`'s `darkMode` parameter, so the addon controls both themes.

## Why
- We picked `@vueless/storybook-dark-mode` over:
  - `@storybook/addon-themes` — it's the official addon but only themes the canvas, not the Storybook UI, which is what we actually wanted here.
  - `hipstersmoothie/storybook-dark-mode` — the original community addon; compatibility with Storybook 10 has lagged.
  - `@vueless/storybook-dark-mode` is a maintained fork with the same API, explicitly tracking Storybook 9/10. We're on 10.3.5.

## Scope — intentionally narrow
- No component styling changes.
- `ThemeProvider` continues to own the Syntax runtime theme for the stories themselves.
- Our `ThemeProvider` / design-token side is unaffected.

## Future extensions
The addon already exposes the primitives we'd need if we later want to theme the canvas too:
- Flip `stylePreview: true` in `preview.tsx` to have the addon apply `dark` / `light` classes to the preview iframe. We could pair that with `classTarget` to land the class where Syntax's token CSS expects it.
- Use the exported `useDarkMode()` hook (or the `DARK_MODE_EVENT_NAME` channel event) inside a preview decorator to drive `ThemeProvider`'s theme prop from the same toggle — so the Storybook chrome and Syntax components switch together.
- Wire a matching light-mode token set into `syntax-design-tokens` once that's in scope, then the two above stop being "future work" and become a one-line config change.

## Test plan
- [ ] `pnpm start` — Storybook boots without errors.
- [ ] Toolbar shows the sun/moon toggle; clicking it swaps Storybook's chrome between the `lightTheme` and `darkTheme`.
- [ ] Preference persists across reloads (localStorage) and respects OS \`prefers-color-scheme\` on first load.
- [ ] Story canvas / rendered components stay visually identical in both modes.
- [ ] Docs pages render correctly in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)