### PR TITLE
Reorganize Storybook sidebar into semantic buckets

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -14,6 +14,34 @@ const preview: Preview = {
   ],
 
   tags: ["autodocs"],
+
+  parameters: {
+    options: {
+      storySort: {
+        method: "alphabetical",
+        order: [
+          "Introduction",
+          "Foundations",
+          "Layout",
+          "Actions",
+          [
+            "Buttons",
+            [
+              "ButtonGroup",
+              "Button",
+              "IconButton",
+              "LinkButton",
+              "IconLinkButton",
+            ],
+          ],
+          "Inputs",
+          "Navigation",
+          "Feedback",
+          "Data Display",
+        ],
+      },
+    },
+  },
 };
 
 export default preview;

--- a/apps/storybook/stories/Colors.mdx
+++ b/apps/storybook/stories/Colors.mdx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 import Colors from "./Colors";
 
-<Meta title="Colors" />
+<Meta title="Foundations/Colors" />
 
 # Colors
 

--- a/packages/syntax-core/src/Avatar/Avatar.stories.tsx
+++ b/packages/syntax-core/src/Avatar/Avatar.stories.tsx
@@ -3,7 +3,7 @@ import Avatar from "./Avatar";
 import image from "../../../../apps/storybook/assets/images/jane.webp";
 
 export default {
-  title: "Components/Avatar",
+  title: "Data Display/Avatar",
   component: Avatar,
   parameters: {
     design: {

--- a/packages/syntax-core/src/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/syntax-core/src/AvatarGroup/AvatarGroup.stories.tsx
@@ -7,7 +7,7 @@ import Box from "../Box/Box";
 import { type ComponentProps } from "react";
 
 export default {
-  title: "Components/AvatarGroup",
+  title: "Data Display/AvatarGroup",
   component: AvatarGroup,
   parameters: {
     layout: "fullscreen",

--- a/packages/syntax-core/src/Badge/Badge.stories.tsx
+++ b/packages/syntax-core/src/Badge/Badge.stories.tsx
@@ -6,7 +6,7 @@ import Stars from "../../../syntax-icons/src/icons/Stars";
 import Box from "../Box/Box";
 
 export default {
-  title: "Components/Badge",
+  title: "Data Display/Badge",
   component: Badge,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Box/Box.stories.tsx
+++ b/packages/syntax-core/src/Box/Box.stories.tsx
@@ -7,7 +7,7 @@ import Heading from "../Heading/Heading";
 import Divider from "../Divider/Divider";
 
 export default {
-  title: "Components/Box",
+  title: "Layout/Box",
   component: Box,
   args: {
     as: "div",

--- a/packages/syntax-core/src/Button/Button.stories.tsx
+++ b/packages/syntax-core/src/Button/Button.stories.tsx
@@ -7,7 +7,7 @@ import Play from "../../../syntax-icons/src/icons/Play";
 import Accent from "../../../syntax-icons/src/icons/Accent";
 
 export default {
-  title: "Components/Button",
+  title: "Actions/Buttons/Button",
   component: Button,
   parameters: {
     design: {

--- a/packages/syntax-core/src/ButtonGroup/Buttongroup.stories.tsx
+++ b/packages/syntax-core/src/ButtonGroup/Buttongroup.stories.tsx
@@ -3,7 +3,7 @@ import ButtonGroup from "./ButtonGroup";
 import Button from "../Button/Button";
 
 export default {
-  title: "Components/ButtonGroup",
+  title: "Actions/Buttons/ButtonGroup",
   component: ButtonGroup,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Card/Card.stories.tsx
+++ b/packages/syntax-core/src/Card/Card.stories.tsx
@@ -6,7 +6,7 @@ import Heading from "../Heading/Heading";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/Card",
+  title: "Layout/Card",
   component: Card,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/syntax-core/src/Checkbox/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/Checkbox",
+  title: "Inputs/Checkbox",
   component: Checkbox,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Chip/Chip.stories.tsx
+++ b/packages/syntax-core/src/Chip/Chip.stories.tsx
@@ -7,7 +7,7 @@ import Box from "../Box/Box";
 import HeartFilled from "../../../syntax-icons/src/icons/HeartFilled";
 
 export default {
-  title: "Components/Chip",
+  title: "Inputs/Chip",
   component: Chip,
   parameters: {
     design: {

--- a/packages/syntax-core/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/syntax-core/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -13,7 +13,7 @@ import Typography from "../Typography/Typography";
 import DateRangePicker from "./DateRangePicker";
 
 export default {
-  title: "Components/DateRangePicker",
+  title: "Inputs/DateRangePicker",
   component: DateRangePicker,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Divider/Divider.stories.tsx
+++ b/packages/syntax-core/src/Divider/Divider.stories.tsx
@@ -2,7 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react-vite";
 import Divider from "./Divider";
 
 export default {
-  title: "Components/Divider",
+  title: "Layout/Divider",
   component: Divider,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Heading/Heading.stories.tsx
+++ b/packages/syntax-core/src/Heading/Heading.stories.tsx
@@ -2,7 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react-vite";
 import Heading from "./Heading";
 
 export default {
-  title: "Components/Heading",
+  title: "Foundations/Heading",
   component: Heading,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Icon/Icon.stories.tsx
+++ b/packages/syntax-core/src/Icon/Icon.stories.tsx
@@ -5,7 +5,7 @@ import Icon from "./Icon";
 import allColors from "../colors/allColors";
 
 export default {
-  title: "Components/Icon",
+  title: "Data Display/Icon",
   component: Icon,
   args: {
     size: 200,

--- a/packages/syntax-core/src/IconButton/IconButton.stories.tsx
+++ b/packages/syntax-core/src/IconButton/IconButton.stories.tsx
@@ -10,7 +10,7 @@ import CalendarBooking from "../../../syntax-icons/src/icons/CalendarBooking";
 import Accent from "../../../syntax-icons/src/icons/Accent";
 
 export default {
-  title: "Components/IconButton",
+  title: "Actions/Buttons/IconButton",
   component: IconButton,
   parameters: {
     design: {

--- a/packages/syntax-core/src/IconLinkButton/IconLinkButton.stories.tsx
+++ b/packages/syntax-core/src/IconLinkButton/IconLinkButton.stories.tsx
@@ -8,7 +8,7 @@ import IconLinkButton from "./IconLinkButton";
 import CalendarBooking from "../../../syntax-icons/src/icons/CalendarBooking";
 
 export default {
-  title: "Components/IconLinkButton",
+  title: "Actions/Buttons/IconLinkButton",
   component: IconLinkButton,
   parameters: {},
   args: {

--- a/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
+++ b/packages/syntax-core/src/LinkButton/LinkButton.stories.tsx
@@ -6,7 +6,7 @@ import Box from "../Box/Box";
 import Pause from "../../../syntax-icons/src/icons/Pause";
 
 export default {
-  title: "Components/LinkButton",
+  title: "Actions/Buttons/LinkButton",
   component: LinkButton,
   parameters: {
     design: {

--- a/packages/syntax-core/src/LinkTapArea/LinkTapArea.stories.tsx
+++ b/packages/syntax-core/src/LinkTapArea/LinkTapArea.stories.tsx
@@ -7,7 +7,7 @@ import Avatar from "../Avatar/Avatar";
 import image from "../../../../apps/storybook/assets/images/jane.webp";
 
 export default {
-  title: "Components/LinkTapArea",
+  title: "Actions/LinkTapArea",
   component: LinkTapArea,
   args: {
     href: "https://www.cambly.com",

--- a/packages/syntax-core/src/Modal/Modal.stories.tsx
+++ b/packages/syntax-core/src/Modal/Modal.stories.tsx
@@ -7,7 +7,7 @@ import Modal from "./Modal";
 import Box from "../Box/Box";
 
 export default {
-  title: "Components/Modal",
+  title: "Feedback/Modal",
   component: Modal,
   parameters: {
     layout: "fullscreen",

--- a/packages/syntax-core/src/Popover/Popover.stories.tsx
+++ b/packages/syntax-core/src/Popover/Popover.stories.tsx
@@ -95,7 +95,7 @@ const SuperLongContent = () => (
 );
 
 export default {
-  title: "Components/Popover",
+  title: "Feedback/Popover",
   component: Popover,
   argTypes: {
     accessibilityLabel: {

--- a/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
+++ b/packages/syntax-core/src/RadioButton/RadioButton.stories.tsx
@@ -5,7 +5,7 @@ import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/RadioButton",
+  title: "Inputs/RadioButton",
   component: RadioButton,
   parameters: {
     design: {

--- a/packages/syntax-core/src/RichSelect/RichSelectBox.stories.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectBox.stories.tsx
@@ -7,7 +7,7 @@ import Heading from "../Heading/Heading";
 import { type Key } from "react-aria";
 
 export default {
-  title: "Components/RichSelectBox",
+  title: "Inputs/RichSelectBox",
   component: RichSelectBox,
   parameters: {
     design: {

--- a/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
+++ b/packages/syntax-core/src/RichSelect/RichSelectList.stories.tsx
@@ -6,7 +6,7 @@ import Typography from "../Typography/Typography";
 import { type Key } from "react-aria";
 
 export default {
-  title: "Components/RichSelectList",
+  title: "Inputs/RichSelectList",
   component: RichSelectList,
   parameters: {
     design: {

--- a/packages/syntax-core/src/SelectList/SelectList.stories.tsx
+++ b/packages/syntax-core/src/SelectList/SelectList.stories.tsx
@@ -6,7 +6,7 @@ import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/SelectList",
+  title: "Inputs/SelectList",
   component: SelectList,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Tabs/Tabs.stories.tsx
+++ b/packages/syntax-core/src/Tabs/Tabs.stories.tsx
@@ -8,7 +8,7 @@ import TabLink from "../TabLink/TabLink";
 import TabButton from "../TabButton/TabButton";
 
 export default {
-  title: "Components/Tabs",
+  title: "Navigation/Tabs",
   component: Tabs,
   parameters: {
     design: {

--- a/packages/syntax-core/src/TapArea/TapArea.stories.tsx
+++ b/packages/syntax-core/src/TapArea/TapArea.stories.tsx
@@ -6,7 +6,7 @@ import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/TapArea",
+  title: "Actions/TapArea",
   component: TapArea,
   args: {
     disabled: false,

--- a/packages/syntax-core/src/TextArea/TextArea.stories.tsx
+++ b/packages/syntax-core/src/TextArea/TextArea.stories.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/TextArea",
+  title: "Inputs/TextArea",
   component: TextArea,
   parameters: {
     design: {

--- a/packages/syntax-core/src/TextField/TextField.stories.tsx
+++ b/packages/syntax-core/src/TextField/TextField.stories.tsx
@@ -5,7 +5,7 @@ import Box from "../Box/Box";
 import Typography from "../Typography/Typography";
 
 export default {
-  title: "Components/TextField",
+  title: "Inputs/TextField",
   component: TextField,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Toast/Toast.stories.tsx
+++ b/packages/syntax-core/src/Toast/Toast.stories.tsx
@@ -4,7 +4,7 @@ import Box from "../Box/Box";
 import Alert from "../../../syntax-icons/src/icons/Alert";
 
 export default {
-  title: "Components/Toast",
+  title: "Feedback/Toast",
   component: Toast,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/syntax-core/src/Tooltip/Tooltip.stories.tsx
@@ -15,7 +15,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import RadioButton from "../../../syntax-core/src/RadioButton/RadioButton";
 
 export default {
-  title: "Components/Tooltip",
+  title: "Feedback/Tooltip",
   component: Tooltip,
   parameters: {
     design: {

--- a/packages/syntax-core/src/Typography/Typography.stories.tsx
+++ b/packages/syntax-core/src/Typography/Typography.stories.tsx
@@ -3,7 +3,7 @@ import Typography from "./Typography";
 import Box from "../Box/Box";
 
 export default {
-  title: "Components/Typography",
+  title: "Foundations/Typography",
   component: Typography,
   parameters: {
     design: {

--- a/packages/syntax-core/src/WordConfetti/WordConfetti.stories.tsx
+++ b/packages/syntax-core/src/WordConfetti/WordConfetti.stories.tsx
@@ -2,7 +2,7 @@ import { type StoryObj, type Meta } from "@storybook/react-vite";
 import WordConfetti from "./WordConfetti";
 
 export default {
-  title: "Components/WordConfetti",
+  title: "Data Display/WordConfetti",
   component: WordConfetti,
   parameters: {
     design: {

--- a/packages/syntax-floating-components/src/Popover/Popover.stories.tsx
+++ b/packages/syntax-floating-components/src/Popover/Popover.stories.tsx
@@ -11,7 +11,7 @@ import IconButton from "../../../syntax-core/src/IconButton/IconButton";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 export default {
-  title: "Floating-Components/Popover",
+  title: "Feedback/Popover (Floating UI)",
   component: Popover,
   parameters: {
     design: {

--- a/packages/syntax-floating-components/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/syntax-floating-components/src/Tooltip/Tooltip.stories.tsx
@@ -8,7 +8,7 @@ import Box from "../../../syntax-core/src/Box/Box";
 import RadioButton from "../../../syntax-core/src/RadioButton/RadioButton";
 
 export default {
-  title: "Floating-Components/Tooltip",
+  title: "Feedback/Tooltip (Floating UI)",
   component: Tooltip,
   parameters: {
     design: {

--- a/packages/syntax-icons/src/Icons.stories.tsx
+++ b/packages/syntax-icons/src/Icons.stories.tsx
@@ -259,7 +259,7 @@ const copyTextToClipboard = async (iconName: string) => {
 const sizes = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000] as const;
 
 export default {
-  title: "Icons",
+  title: "Foundations/Icon Library",
   component: Icon,
   parameters: {
     design: {


### PR DESCRIPTION
## Summary

Replaces the flat `Components/*` Storybook structure with semantic buckets so the sidebar scales as the design system grows.

### New structure

- **Foundations** — Colors, Heading, Icon Library, Typography
- **Layout** — Box, Card, Divider
- **Actions**
  - **Buttons/** _(sub-folder, custom order)_ — ButtonGroup, Button, IconButton, LinkButton, IconLinkButton
  - LinkTapArea, TapArea
- **Inputs** — Checkbox, Chip, DateRangePicker, RadioButton, RichSelectBox, RichSelectList, SelectList, TextArea, TextField
- **Navigation** — Tabs
- **Feedback** — Modal, Popover, Popover (Floating UI), Toast, Tooltip, Tooltip (Floating UI)
- **Data Display** — Avatar, AvatarGroup, Badge, Icon, WordConfetti

### Key decisions

- **Floating UI variants co-located in Feedback** with `(Floating UI)` suffix to disambiguate from the `syntax-core` Tooltip/Popover.
- **`method: "alphabetical"` storySort** required so Floating UI variants sort next to their core counterparts (without it, package import order pushes them to the end of the bucket).
- **`Buttons/` sub-folder with explicit order** in `storySort.order`. TapArea/LinkTapArea kept flat — different abstraction.
- **Renamed `Icons` → `Icon Library`** in Foundations to disambiguate from the `Icon` component in Data Display.
- **DateRangePicker** placed in Inputs (was unspecified in original brief; recent POC).

### ⚠️ Breaking change: story URLs

Every story URL changes — e.g. `?path=/story/components-button--primary` → `?path=/story/actions-buttons-button--primary`. Bookmarks, Slack/Notion links, and any external Chromatic baselines will need updating.

No published package code changed (stories are dev-only) — no changeset required.

## Test plan

- [ ] Storybook builds cleanly (`pnpm --filter storybook build`)
- [ ] Sidebar renders all 7 buckets in the spec order: Foundations → Layout → Actions → Inputs → Navigation → Feedback → Data Display
- [ ] Both Tooltip variants and both Popover variants appear together inside Feedback
- [ ] `Actions/Buttons/` shows ButtonGroup, Button, IconButton, LinkButton, IconLinkButton in that order
- [ ] No console errors in dev or built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)